### PR TITLE
Configuration Profiles (005): snapshot, preview, diff, import/export, and full CRUD

### DIFF
--- a/design/005_Configuration_Profiles.md
+++ b/design/005_Configuration_Profiles.md
@@ -97,5 +97,6 @@ Note: If write/apply is split into its own design (006), this section becomes �
 1. Persistence + CRUD APIs (profiles, versions, entries, assignments) — database layer [done]; web/API endpoints [done]; API tests (CRUD, versions, assignments) [done].
 2. Preview/diff endpoint using discovered settings (004) — [done].
 3. Import/export JSON — [done].
-4. Snapshot creation from a BMC (004) — [pending].
-5. Apply planning (optional here; may move to 006 apply design).
+4. Snapshot creation from a BMC (004) — [done].
+5. Diff endpoint to compare two profile versions — [done].
+6. Apply planning (optional here; may move to 006 apply design).

--- a/design/005_Configuration_Profiles.md
+++ b/design/005_Configuration_Profiles.md
@@ -94,7 +94,7 @@ Note: If write/apply is split into its own design (006), this section becomes �
 - Cross-firmware compatibility policy: warn, block, or attempt apply with guardrails?
 
 ## Milestones
-1. Persistence + CRUD APIs (profiles, versions, entries, assignments).
-2. Preview/diff endpoint using discovered settings (004).
-3. Import/export JSON.
+1. Persistence + CRUD APIs (profiles, versions, entries, assignments) — database layer [done]; web/API endpoints [done]; API tests (CRUD, versions, assignments) [done].
+2. Preview/diff endpoint using discovered settings (004) — [pending].
+3. Import/export JSON — [pending].
 4. Apply planning (optional here; may move to 006 apply design).

--- a/design/005_Configuration_Profiles.md
+++ b/design/005_Configuration_Profiles.md
@@ -1,34 +1,47 @@
 # 005: Configuration Profiles
 
 ## Summary
-Capture, store, compare, and apply collections of BMC Redfish settings as versioned profiles. Enable snapshotting current state and reapplying to the same or similar hardware.
+Capture, store, compare, and apply collections of BMC Redfish settings as versioned profiles. Profiles are portable JSON documents that reference discovered settings (004) and are future-enriched by registry metadata (008). Enable snapshotting current state and reapplying to the same or similar hardware.
 
 ## Goals
 - Snapshot current settings into a portable profile.
 - Diff two profiles and show setting deltas.
 - Validate applicability before apply (hardware/model/firmware guards).
 - Support apply-time semantics (immediate vs. on-reset) and batched changes.
+- CRUD for profiles, versions, entries, and assignments to targets.
+- Import/export JSON for portability.
 
 ## Non-Goals
 - Cross-vendor semantic translation beyond attribute-level mapping.
+- Attribute Registry enrichment beyond what is already available from discovery (see 008).
 
-## Profile Model
+## Data Model
 - `Profile`:
-  - `id`, `name`, `created_at`, `created_by`
+  - `id`, `name`, `description`, `created_at`, `updated_at`, `created_by`
   - `hardware_selector` (make/model/family/sku; optional regex)
   - `firmware_ranges` (min/max or allowed set)
-  - `notes`
+- `ProfileVersion`:
+  - `id`, `profile_id`, `version`, `created_at`, `notes`
+  - `entries`: array of `ProfileEntry`
 - `ProfileEntry`:
   - `resource_path` (`@odata.id`)
   - `attribute`
-  - `desired_value`
-  - `apply_time` (when supported)
+  - `desired_value` (JSON value)
+  - `apply_time_preference` (optional: `Immediate`, `OnReset`, etc.)
   - `oem_vendor` (optional)
+- `Assignment`:
+  - `id`, `profile_id`, `version`, `target`: `bmc:<name>` or `group:<group_name>`
+
+Database tables (SQLite):
+- `profiles (id TEXT PK, name TEXT UNIQUE, description TEXT, created_at, updated_at, created_by TEXT, hardware_selector TEXT, firmware_ranges_json TEXT)`
+- `profile_versions (id TEXT PK, profile_id TEXT, version INTEGER, created_at, notes TEXT)`
+- `profile_entries (id TEXT PK, profile_version_id TEXT, resource_path TEXT, attribute TEXT, desired_value_json TEXT, apply_time_preference TEXT, oem_vendor TEXT)`
+- `profile_assignments (id TEXT PK, profile_id TEXT, version INTEGER, target_type TEXT, target_value TEXT)`
 
 ## Snapshot Flow
-1. Run Discovery for target BMC to fetch descriptors and current values.
+1. Use 004 API to fetch descriptors and current values for a BMC in the selected resource scope.
 2. Filter to writable attributes by default; allow include read-only for documentation.
-3. Emit `Profile` with `ProfileEntry[]` using descriptor keys.
+3. Emit `Profile` with `ProfileEntry[]` keyed by `(resource_path, attribute)`; values copied from `current_value`.
 
 ## Diffing
 - Compare two profiles entry-by-entry using `(resource_path, attribute)` tuple.
@@ -41,28 +54,37 @@ Capture, store, compare, and apply collections of BMC Redfish settings as versio
 4. Respect `SupportedApplyTimes`; if `OnReset`, schedule a reminder.
 5. Collect per-request results and aggregate status.
 
+Note: If write/apply is split into its own design (006), this section becomes “apply planning” returning a plan without executing changes.
+
 ## Safety & Rollback
 - Pre-apply: capture an automatic baseline snapshot profile.
 - If failures occur, surface partial apply details and provide revert-to-baseline capability.
 
 ## Persistence
-- Store profiles and their entries in DB; track provenance (BMC, time, user).
+- Store profiles, versions, entries, and assignments; track provenance.
 
 ## API
-- `POST /api/profiles` create from BMC snapshot or JSON upload.
-- `GET /api/profiles` list; `GET /api/profiles/{id}` detail.
-- `POST /api/profiles/{id}/apply?bmc={name}` apply to a BMC.
-- `POST /api/profiles/diff` accept two IDs (or payloads) and return diff.
+- `GET /api/profiles` → list profiles with latest version summary
+- `POST /api/profiles` → create profile `{name, description, scope}` or from snapshot
+- `GET /api/profiles/{id}` → detail with versions
+- `POST /api/profiles/{id}/versions` → create new version with entries
+- `GET /api/profiles/{id}/versions/{version}` → get specific version
+- `POST /api/profiles/{id}/assignments` → assign profile/version to targets
+- `GET /api/profiles/{id}/preview?bmc={name}` → compute diff vs current BMC settings
+- `POST /api/profiles/{id}/export` → export profile+version as JSON
+- `POST /api/profiles/import` → import a profile JSON (create or update)
 
 ## UX Considerations
 - Snapshot wizard from a BMC detail page.
 - Diff viewer with filters (changed only, OEM).
 - Apply preview: grouped requests, apply-time notes, estimated reboot needs.
 
-## Test Plan
+## Testing Strategy
+- DB tests for CRUD of profiles, versions, entries, and assignments.
+- API tests for create/list/detail/version/assign/import/export.
+- Preview tests using httptest BMC with known current values to verify diffs.
 - Unit tests for snapshot serialization/deserialization.
-- Apply simulator against Mock BMC; assert minimal PATCH payloads.
-- Diff correctness with edge cases (missing attrs, type changes).
+- Apply simulator against Mock BMC; assert minimal PATCH payloads (if included).
 
 ## Open Questions
 - Minimum metadata for `hardware_selector` to ensure safe applicability (exact match vs. regex)?
@@ -70,3 +92,9 @@ Capture, store, compare, and apply collections of BMC Redfish settings as versio
   A: Warn for reboot settings, attempt to batch them together.
 - Should profiles support variables/templating for environment-specific values (e.g., NTP/DNS)?
 - Cross-firmware compatibility policy: warn, block, or attempt apply with guardrails?
+
+## Milestones
+1. Persistence + CRUD APIs (profiles, versions, entries, assignments).
+2. Preview/diff endpoint using discovered settings (004).
+3. Import/export JSON.
+4. Apply planning (optional here; may move to 006 apply design).

--- a/design/005_Configuration_Profiles.md
+++ b/design/005_Configuration_Profiles.md
@@ -95,6 +95,7 @@ Note: If write/apply is split into its own design (006), this section becomes �
 
 ## Milestones
 1. Persistence + CRUD APIs (profiles, versions, entries, assignments) — database layer [done]; web/API endpoints [done]; API tests (CRUD, versions, assignments) [done].
-2. Preview/diff endpoint using discovered settings (004) — [pending].
-3. Import/export JSON — [pending].
-4. Apply planning (optional here; may move to 006 apply design).
+2. Preview/diff endpoint using discovered settings (004) — [done].
+3. Import/export JSON — [done].
+4. Snapshot creation from a BMC (004) — [pending].
+5. Apply planning (optional here; may move to 006 apply design).

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -159,6 +159,47 @@ func (db *DB) Migrate(ctx context.Context) error {
 		)`,
 		`CREATE INDEX IF NOT EXISTS idx_settings_by_bmc_resource ON settings_descriptors(bmc_id, resource_path)`,
 		`CREATE INDEX IF NOT EXISTS idx_settings_by_bmc ON settings_descriptors(bmc_id)`,
+		// Profiles (005)
+		`CREATE TABLE IF NOT EXISTS profiles (
+			id TEXT PRIMARY KEY,
+			name TEXT NOT NULL UNIQUE,
+			description TEXT,
+			created_by TEXT,
+			hardware_selector TEXT,
+			firmware_ranges_json TEXT,
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+		)`,
+		`CREATE TABLE IF NOT EXISTS profile_versions (
+			id TEXT PRIMARY KEY,
+			profile_id TEXT NOT NULL,
+			version INTEGER NOT NULL,
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			notes TEXT,
+			FOREIGN KEY (profile_id) REFERENCES profiles(id) ON DELETE CASCADE,
+			UNIQUE(profile_id, version)
+		)`,
+		`CREATE TABLE IF NOT EXISTS profile_entries (
+			id TEXT PRIMARY KEY,
+			profile_version_id TEXT NOT NULL,
+			resource_path TEXT NOT NULL,
+			attribute TEXT NOT NULL,
+			desired_value_json TEXT,
+			apply_time_preference TEXT,
+			oem_vendor TEXT,
+			FOREIGN KEY (profile_version_id) REFERENCES profile_versions(id) ON DELETE CASCADE
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_profile_entries_by_version ON profile_entries(profile_version_id)`,
+		`CREATE TABLE IF NOT EXISTS profile_assignments (
+			id TEXT PRIMARY KEY,
+			profile_id TEXT NOT NULL,
+			version INTEGER NOT NULL,
+			target_type TEXT NOT NULL,
+			target_value TEXT NOT NULL,
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			FOREIGN KEY (profile_id) REFERENCES profiles(id) ON DELETE CASCADE
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_profile_assignments_profile ON profile_assignments(profile_id, version)`,
 	}
 
 	tx, err := db.conn.BeginTx(ctx, nil)
@@ -998,5 +1039,164 @@ func (db *DB) UpdateConnectionMethodLastSeen(ctx context.Context, id string) err
 		return fmt.Errorf("failed to update connection method last seen: %w", err)
 	}
 
+	return nil
+}
+
+// Profile operations (005)
+
+// CreateProfile inserts a new profile
+func (db *DB) CreateProfile(ctx context.Context, p *models.Profile) error {
+	if p.ID == "" {
+		p.ID = fmt.Sprintf("p_%d", time.Now().UnixNano())
+	}
+	q := `INSERT INTO profiles (id, name, description, created_by, hardware_selector, firmware_ranges_json) VALUES (?, ?, ?, ?, ?, ?)`
+	_, err := db.conn.ExecContext(ctx, q, p.ID, p.Name, p.Description, p.CreatedBy, p.HardwareSelector, p.FirmwareRangesJSON)
+	if err != nil {
+		return fmt.Errorf("create profile: %w", err)
+	}
+	p.CreatedAt = time.Now()
+	p.UpdatedAt = time.Now()
+	return nil
+}
+
+// UpdateProfile updates mutable fields of a profile
+func (db *DB) UpdateProfile(ctx context.Context, p *models.Profile) error {
+	q := `UPDATE profiles SET name = ?, description = ?, created_by = ?, hardware_selector = ?, firmware_ranges_json = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?`
+	_, err := db.conn.ExecContext(ctx, q, p.Name, p.Description, p.CreatedBy, p.HardwareSelector, p.FirmwareRangesJSON, p.ID)
+	if err != nil {
+		return fmt.Errorf("update profile: %w", err)
+	}
+	return nil
+}
+
+// GetProfiles lists profiles
+func (db *DB) GetProfiles(ctx context.Context) ([]models.Profile, error) {
+	rows, err := db.conn.QueryContext(ctx, `SELECT id, name, description, created_by, hardware_selector, firmware_ranges_json, created_at, updated_at FROM profiles ORDER BY name`)
+	if err != nil {
+		return nil, fmt.Errorf("list profiles: %w", err)
+	}
+	defer rows.Close()
+	var out []models.Profile
+	for rows.Next() {
+		var p models.Profile
+		if err := rows.Scan(&p.ID, &p.Name, &p.Description, &p.CreatedBy, &p.HardwareSelector, &p.FirmwareRangesJSON, &p.CreatedAt, &p.UpdatedAt); err != nil {
+			return nil, fmt.Errorf("scan profile: %w", err)
+		}
+		out = append(out, p)
+	}
+	return out, rows.Err()
+}
+
+// GetProfile retrieves a profile by id
+func (db *DB) GetProfile(ctx context.Context, id string) (*models.Profile, error) {
+	var p models.Profile
+	err := db.conn.QueryRowContext(ctx, `SELECT id, name, description, created_by, hardware_selector, firmware_ranges_json, created_at, updated_at FROM profiles WHERE id = ?`, id).Scan(&p.ID, &p.Name, &p.Description, &p.CreatedBy, &p.HardwareSelector, &p.FirmwareRangesJSON, &p.CreatedAt, &p.UpdatedAt)
+	if err == sql.ErrNoRows { return nil, nil }
+	if err != nil { return nil, fmt.Errorf("get profile: %w", err) }
+	return &p, nil
+}
+
+// DeleteProfile deletes a profile by id
+func (db *DB) DeleteProfile(ctx context.Context, id string) error {
+	_, err := db.conn.ExecContext(ctx, `DELETE FROM profiles WHERE id = ?`, id)
+	if err != nil { return fmt.Errorf("delete profile: %w", err) }
+	return nil
+}
+
+// CreateProfileVersion creates a new version row and associated entries
+func (db *DB) CreateProfileVersion(ctx context.Context, v *models.ProfileVersion) error {
+	if v.ID == "" { v.ID = fmt.Sprintf("pv_%d", time.Now().UnixNano()) }
+	tx, err := db.conn.BeginTx(ctx, nil)
+	if err != nil { return fmt.Errorf("begin tx: %w", err) }
+	defer tx.Rollback()
+
+	_, err = tx.ExecContext(ctx, `INSERT INTO profile_versions (id, profile_id, version, notes) VALUES (?, ?, ?, ?)`, v.ID, v.ProfileID, v.Version, v.Notes)
+	if err != nil { return fmt.Errorf("insert version: %w", err) }
+
+	if len(v.Entries) > 0 {
+		stmt, err := tx.PrepareContext(ctx, `INSERT INTO profile_entries (id, profile_version_id, resource_path, attribute, desired_value_json, apply_time_preference, oem_vendor) VALUES (?, ?, ?, ?, ?, ?, ?)`)
+		if err != nil { return fmt.Errorf("prepare entries: %w", err) }
+		defer stmt.Close()
+		for i := range v.Entries {
+			e := &v.Entries[i]
+			if e.ID == "" { e.ID = fmt.Sprintf("pe_%d", time.Now().UnixNano()) }
+			var dv string
+			if e.DesiredValue != nil {
+				if b, err := json.Marshal(e.DesiredValue); err == nil { dv = string(b) }
+			}
+			if _, err := stmt.ExecContext(ctx, e.ID, v.ID, e.ResourcePath, e.Attribute, dv, e.ApplyTimePreference, e.OEMVendor); err != nil {
+				return fmt.Errorf("insert entry: %w", err)
+			}
+			e.ProfileVersionID = v.ID
+		}
+	}
+
+	if err := tx.Commit(); err != nil { return fmt.Errorf("commit version: %w", err) }
+	v.CreatedAt = time.Now()
+	return nil
+}
+
+// GetProfileVersions lists versions for a profile
+func (db *DB) GetProfileVersions(ctx context.Context, profileID string) ([]models.ProfileVersion, error) {
+	rows, err := db.conn.QueryContext(ctx, `SELECT id, profile_id, version, created_at, notes FROM profile_versions WHERE profile_id = ? ORDER BY version DESC`, profileID)
+	if err != nil { return nil, fmt.Errorf("list versions: %w", err) }
+	defer rows.Close()
+	var out []models.ProfileVersion
+	for rows.Next() {
+		var v models.ProfileVersion
+		if err := rows.Scan(&v.ID, &v.ProfileID, &v.Version, &v.CreatedAt, &v.Notes); err != nil { return nil, fmt.Errorf("scan version: %w", err) }
+		out = append(out, v)
+	}
+	return out, rows.Err()
+}
+
+// GetProfileVersion loads a version and entries
+func (db *DB) GetProfileVersion(ctx context.Context, profileID string, version int) (*models.ProfileVersion, error) {
+	var v models.ProfileVersion
+	err := db.conn.QueryRowContext(ctx, `SELECT id, profile_id, version, created_at, notes FROM profile_versions WHERE profile_id = ? AND version = ?`, profileID, version).Scan(&v.ID, &v.ProfileID, &v.Version, &v.CreatedAt, &v.Notes)
+	if err == sql.ErrNoRows { return nil, nil }
+	if err != nil { return nil, fmt.Errorf("get version: %w", err) }
+	erows, err := db.conn.QueryContext(ctx, `SELECT id, resource_path, attribute, desired_value_json, apply_time_preference, oem_vendor FROM profile_entries WHERE profile_version_id = ? ORDER BY resource_path, attribute`, v.ID)
+	if err != nil { return nil, fmt.Errorf("list entries: %w", err) }
+	defer erows.Close()
+	for erows.Next() {
+		var e models.ProfileEntry
+		var dv string
+		if err := erows.Scan(&e.ID, &e.ResourcePath, &e.Attribute, &dv, &e.ApplyTimePreference, &e.OEMVendor); err != nil { return nil, fmt.Errorf("scan entry: %w", err) }
+		if dv != "" { _ = json.Unmarshal([]byte(dv), &e.DesiredValue) }
+		e.ProfileVersionID = v.ID
+		v.Entries = append(v.Entries, e)
+	}
+	if err := erows.Err(); err != nil { return nil, err }
+	return &v, nil
+}
+
+// CreateProfileAssignment adds an assignment
+func (db *DB) CreateProfileAssignment(ctx context.Context, a *models.ProfileAssignment) error {
+	if a.ID == "" { a.ID = fmt.Sprintf("pa_%d", time.Now().UnixNano()) }
+	_, err := db.conn.ExecContext(ctx, `INSERT INTO profile_assignments (id, profile_id, version, target_type, target_value) VALUES (?, ?, ?, ?, ?)`, a.ID, a.ProfileID, a.Version, a.TargetType, a.TargetValue)
+	if err != nil { return fmt.Errorf("create assignment: %w", err) }
+	a.CreatedAt = time.Now()
+	return nil
+}
+
+// GetProfileAssignments lists assignments for a profile
+func (db *DB) GetProfileAssignments(ctx context.Context, profileID string) ([]models.ProfileAssignment, error) {
+	rows, err := db.conn.QueryContext(ctx, `SELECT id, profile_id, version, target_type, target_value, created_at FROM profile_assignments WHERE profile_id = ? ORDER BY created_at DESC`, profileID)
+	if err != nil { return nil, fmt.Errorf("list assignments: %w", err) }
+	defer rows.Close()
+	var out []models.ProfileAssignment
+	for rows.Next() {
+		var a models.ProfileAssignment
+		if err := rows.Scan(&a.ID, &a.ProfileID, &a.Version, &a.TargetType, &a.TargetValue, &a.CreatedAt); err != nil { return nil, fmt.Errorf("scan assignment: %w", err) }
+		out = append(out, a)
+	}
+	return out, rows.Err()
+}
+
+// DeleteProfileAssignment deletes an assignment by id
+func (db *DB) DeleteProfileAssignment(ctx context.Context, id string) error {
+	_, err := db.conn.ExecContext(ctx, `DELETE FROM profile_assignments WHERE id = ?`, id)
+	if err != nil { return fmt.Errorf("delete assignment: %w", err) }
 	return nil
 }

--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -127,64 +127,108 @@ func TestProfilesPersistence(t *testing.T) {
 	dbPath := filepath.Join(tmpDir, "test.db")
 
 	db, err := New(dbPath)
-	if err != nil { t.Fatalf("Failed to create database: %v", err) }
+	if err != nil {
+		t.Fatalf("Failed to create database: %v", err)
+	}
 	defer db.Close()
 
 	ctx := context.Background()
-	if err := db.Migrate(ctx); err != nil { t.Fatalf("Migration failed: %v", err) }
+	if err := db.Migrate(ctx); err != nil {
+		t.Fatalf("Migration failed: %v", err)
+	}
 
 	// Create profile
 	p := &models.Profile{ID: "p1", Name: "Baseline BIOS", Description: "desc", CreatedBy: "tester"}
-	if err := db.CreateProfile(ctx, p); err != nil { t.Fatalf("create profile: %v", err) }
+	if err := db.CreateProfile(ctx, p); err != nil {
+		t.Fatalf("create profile: %v", err)
+	}
 
 	// List and get
 	list, err := db.GetProfiles(ctx)
-	if err != nil { t.Fatalf("list profiles: %v", err) }
-	if len(list) != 1 || list[0].Name != "Baseline BIOS" { t.Fatalf("unexpected list: %+v", list) }
+	if err != nil {
+		t.Fatalf("list profiles: %v", err)
+	}
+	if len(list) != 1 || list[0].Name != "Baseline BIOS" {
+		t.Fatalf("unexpected list: %+v", list)
+	}
 
 	got, err := db.GetProfile(ctx, p.ID)
-	if err != nil { t.Fatalf("get profile: %v", err) }
-	if got == nil || got.ID != p.ID { t.Fatalf("unexpected profile: %+v", got) }
+	if err != nil {
+		t.Fatalf("get profile: %v", err)
+	}
+	if got == nil || got.ID != p.ID {
+		t.Fatalf("unexpected profile: %+v", got)
+	}
 
 	// Create version with entries
 	v := &models.ProfileVersion{ProfileID: p.ID, Version: 1, Notes: "v1", Entries: []models.ProfileEntry{
 		{ResourcePath: "/redfish/v1/Systems/1/Bios", Attribute: "HyperThreading", DesiredValue: false},
 		{ResourcePath: "/redfish/v1/Managers/1/NetworkProtocol", Attribute: "SSH/Enabled", DesiredValue: true},
 	}}
-	if err := db.CreateProfileVersion(ctx, v); err != nil { t.Fatalf("create version: %v", err) }
+	if err := db.CreateProfileVersion(ctx, v); err != nil {
+		t.Fatalf("create version: %v", err)
+	}
 
 	// Get versions list
 	vers, err := db.GetProfileVersions(ctx, p.ID)
-	if err != nil { t.Fatalf("list versions: %v", err) }
-	if len(vers) != 1 || vers[0].Version != 1 { t.Fatalf("unexpected versions: %+v", vers) }
+	if err != nil {
+		t.Fatalf("list versions: %v", err)
+	}
+	if len(vers) != 1 || vers[0].Version != 1 {
+		t.Fatalf("unexpected versions: %+v", vers)
+	}
 
 	// Get version detail
 	vgot, err := db.GetProfileVersion(ctx, p.ID, 1)
-	if err != nil { t.Fatalf("get version: %v", err) }
-	if vgot == nil || len(vgot.Entries) != 2 { t.Fatalf("unexpected version detail: %+v", vgot) }
+	if err != nil {
+		t.Fatalf("get version: %v", err)
+	}
+	if vgot == nil || len(vgot.Entries) != 2 {
+		t.Fatalf("unexpected version detail: %+v", vgot)
+	}
 
 	// Assignment
 	a := &models.ProfileAssignment{ProfileID: p.ID, Version: 1, TargetType: "bmc", TargetValue: "b1"}
-	if err := db.CreateProfileAssignment(ctx, a); err != nil { t.Fatalf("create assignment: %v", err) }
+	if err := db.CreateProfileAssignment(ctx, a); err != nil {
+		t.Fatalf("create assignment: %v", err)
+	}
 
 	as, err := db.GetProfileAssignments(ctx, p.ID)
-	if err != nil { t.Fatalf("list assignments: %v", err) }
-	if len(as) != 1 || as[0].TargetValue != "b1" { t.Fatalf("unexpected assignments: %+v", as) }
+	if err != nil {
+		t.Fatalf("list assignments: %v", err)
+	}
+	if len(as) != 1 || as[0].TargetValue != "b1" {
+		t.Fatalf("unexpected assignments: %+v", as)
+	}
 
-	if err := db.DeleteProfileAssignment(ctx, as[0].ID); err != nil { t.Fatalf("delete assignment: %v", err) }
+	if err := db.DeleteProfileAssignment(ctx, as[0].ID); err != nil {
+		t.Fatalf("delete assignment: %v", err)
+	}
 
 	as, err = db.GetProfileAssignments(ctx, p.ID)
-	if err != nil { t.Fatalf("list assignments after delete: %v", err) }
-	if len(as) != 0 { t.Fatalf("expected 0 assignments, got %d", len(as)) }
+	if err != nil {
+		t.Fatalf("list assignments after delete: %v", err)
+	}
+	if len(as) != 0 {
+		t.Fatalf("expected 0 assignments, got %d", len(as))
+	}
 
 	// Update and delete profile
 	p.Description = "updated"
-	if err := db.UpdateProfile(ctx, p); err != nil { t.Fatalf("update profile: %v", err) }
-	if err := db.DeleteProfile(ctx, p.ID); err != nil { t.Fatalf("delete profile: %v", err) }
+	if err := db.UpdateProfile(ctx, p); err != nil {
+		t.Fatalf("update profile: %v", err)
+	}
+	if err := db.DeleteProfile(ctx, p.ID); err != nil {
+		t.Fatalf("delete profile: %v", err)
+	}
 
 	gone, err := db.GetProfile(ctx, p.ID)
-	if err != nil { t.Fatalf("get after delete: %v", err) }
-	if gone != nil { t.Fatalf("expected profile to be deleted") }
+	if err != nil {
+		t.Fatalf("get after delete: %v", err)
+	}
+	if gone != nil {
+		t.Fatalf("expected profile to be deleted")
+	}
 }
 
 func TestBMCOperations(t *testing.T) {

--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -122,6 +122,71 @@ func TestSettingsPersistence(t *testing.T) {
 	}
 }
 
+func TestProfilesPersistence(t *testing.T) {
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "test.db")
+
+	db, err := New(dbPath)
+	if err != nil { t.Fatalf("Failed to create database: %v", err) }
+	defer db.Close()
+
+	ctx := context.Background()
+	if err := db.Migrate(ctx); err != nil { t.Fatalf("Migration failed: %v", err) }
+
+	// Create profile
+	p := &models.Profile{ID: "p1", Name: "Baseline BIOS", Description: "desc", CreatedBy: "tester"}
+	if err := db.CreateProfile(ctx, p); err != nil { t.Fatalf("create profile: %v", err) }
+
+	// List and get
+	list, err := db.GetProfiles(ctx)
+	if err != nil { t.Fatalf("list profiles: %v", err) }
+	if len(list) != 1 || list[0].Name != "Baseline BIOS" { t.Fatalf("unexpected list: %+v", list) }
+
+	got, err := db.GetProfile(ctx, p.ID)
+	if err != nil { t.Fatalf("get profile: %v", err) }
+	if got == nil || got.ID != p.ID { t.Fatalf("unexpected profile: %+v", got) }
+
+	// Create version with entries
+	v := &models.ProfileVersion{ProfileID: p.ID, Version: 1, Notes: "v1", Entries: []models.ProfileEntry{
+		{ResourcePath: "/redfish/v1/Systems/1/Bios", Attribute: "HyperThreading", DesiredValue: false},
+		{ResourcePath: "/redfish/v1/Managers/1/NetworkProtocol", Attribute: "SSH/Enabled", DesiredValue: true},
+	}}
+	if err := db.CreateProfileVersion(ctx, v); err != nil { t.Fatalf("create version: %v", err) }
+
+	// Get versions list
+	vers, err := db.GetProfileVersions(ctx, p.ID)
+	if err != nil { t.Fatalf("list versions: %v", err) }
+	if len(vers) != 1 || vers[0].Version != 1 { t.Fatalf("unexpected versions: %+v", vers) }
+
+	// Get version detail
+	vgot, err := db.GetProfileVersion(ctx, p.ID, 1)
+	if err != nil { t.Fatalf("get version: %v", err) }
+	if vgot == nil || len(vgot.Entries) != 2 { t.Fatalf("unexpected version detail: %+v", vgot) }
+
+	// Assignment
+	a := &models.ProfileAssignment{ProfileID: p.ID, Version: 1, TargetType: "bmc", TargetValue: "b1"}
+	if err := db.CreateProfileAssignment(ctx, a); err != nil { t.Fatalf("create assignment: %v", err) }
+
+	as, err := db.GetProfileAssignments(ctx, p.ID)
+	if err != nil { t.Fatalf("list assignments: %v", err) }
+	if len(as) != 1 || as[0].TargetValue != "b1" { t.Fatalf("unexpected assignments: %+v", as) }
+
+	if err := db.DeleteProfileAssignment(ctx, as[0].ID); err != nil { t.Fatalf("delete assignment: %v", err) }
+
+	as, err = db.GetProfileAssignments(ctx, p.ID)
+	if err != nil { t.Fatalf("list assignments after delete: %v", err) }
+	if len(as) != 0 { t.Fatalf("expected 0 assignments, got %d", len(as)) }
+
+	// Update and delete profile
+	p.Description = "updated"
+	if err := db.UpdateProfile(ctx, p); err != nil { t.Fatalf("update profile: %v", err) }
+	if err := db.DeleteProfile(ctx, p.ID); err != nil { t.Fatalf("delete profile: %v", err) }
+
+	gone, err := db.GetProfile(ctx, p.ID)
+	if err != nil { t.Fatalf("get after delete: %v", err) }
+	if gone != nil { t.Fatalf("expected profile to be deleted") }
+}
+
 func TestBMCOperations(t *testing.T) {
 	tmpDir := t.TempDir()
 	dbPath := filepath.Join(tmpDir, "test.db")

--- a/pkg/models/models.go
+++ b/pkg/models/models.go
@@ -181,14 +181,14 @@ type SettingValue struct {
 
 // Profile represents a reusable set of desired settings
 type Profile struct {
-	ID                  string    `json:"id" db:"id"`
-	Name                string    `json:"name" db:"name"`
-	Description         string    `json:"description,omitempty" db:"description"`
-	CreatedBy           string    `json:"created_by,omitempty" db:"created_by"`
-	HardwareSelector    string    `json:"hardware_selector,omitempty" db:"hardware_selector"`
-	FirmwareRangesJSON  string    `json:"firmware_ranges_json,omitempty" db:"firmware_ranges_json"`
-	CreatedAt           time.Time `json:"created_at" db:"created_at"`
-	UpdatedAt           time.Time `json:"updated_at" db:"updated_at"`
+	ID                 string    `json:"id" db:"id"`
+	Name               string    `json:"name" db:"name"`
+	Description        string    `json:"description,omitempty" db:"description"`
+	CreatedBy          string    `json:"created_by,omitempty" db:"created_by"`
+	HardwareSelector   string    `json:"hardware_selector,omitempty" db:"hardware_selector"`
+	FirmwareRangesJSON string    `json:"firmware_ranges_json,omitempty" db:"firmware_ranges_json"`
+	CreatedAt          time.Time `json:"created_at" db:"created_at"`
+	UpdatedAt          time.Time `json:"updated_at" db:"updated_at"`
 }
 
 // ProfileVersion is a versioned collection of entries
@@ -203,21 +203,21 @@ type ProfileVersion struct {
 
 // ProfileEntry specifies a desired value for a setting
 type ProfileEntry struct {
-	ID                string      `json:"id" db:"id"`
-	ProfileVersionID  string      `json:"profile_version_id" db:"profile_version_id"`
-	ResourcePath      string      `json:"resource_path" db:"resource_path"`
-	Attribute         string      `json:"attribute" db:"attribute"`
-	DesiredValue      interface{} `json:"desired_value,omitempty"`
-	ApplyTimePreference string    `json:"apply_time_preference,omitempty" db:"apply_time_preference"`
-	OEMVendor         string      `json:"oem_vendor,omitempty" db:"oem_vendor"`
+	ID                  string      `json:"id" db:"id"`
+	ProfileVersionID    string      `json:"profile_version_id" db:"profile_version_id"`
+	ResourcePath        string      `json:"resource_path" db:"resource_path"`
+	Attribute           string      `json:"attribute" db:"attribute"`
+	DesiredValue        interface{} `json:"desired_value,omitempty"`
+	ApplyTimePreference string      `json:"apply_time_preference,omitempty" db:"apply_time_preference"`
+	OEMVendor           string      `json:"oem_vendor,omitempty" db:"oem_vendor"`
 }
 
 // ProfileAssignment binds a profile/version to a target
 type ProfileAssignment struct {
-	ID         string    `json:"id" db:"id"`
-	ProfileID  string    `json:"profile_id" db:"profile_id"`
-	Version    int       `json:"version" db:"version"`
-	TargetType string    `json:"target_type" db:"target_type"`   // e.g., "bmc" or "group"
-	TargetValue string   `json:"target_value" db:"target_value"` // e.g., BMC name or group name
-	CreatedAt  time.Time `json:"created_at" db:"created_at"`
+	ID          string    `json:"id" db:"id"`
+	ProfileID   string    `json:"profile_id" db:"profile_id"`
+	Version     int       `json:"version" db:"version"`
+	TargetType  string    `json:"target_type" db:"target_type"`   // e.g., "bmc" or "group"
+	TargetValue string    `json:"target_value" db:"target_value"` // e.g., BMC name or group name
+	CreatedAt   time.Time `json:"created_at" db:"created_at"`
 }

--- a/pkg/models/models.go
+++ b/pkg/models/models.go
@@ -176,3 +176,48 @@ type SettingValue struct {
 	CurrentValue    interface{} `json:"current_value" db:"current_value"`
 	SourceTimestamp string      `json:"source_timestamp" db:"source_timestamp"`
 }
+
+// Profiles (005)
+
+// Profile represents a reusable set of desired settings
+type Profile struct {
+	ID                  string    `json:"id" db:"id"`
+	Name                string    `json:"name" db:"name"`
+	Description         string    `json:"description,omitempty" db:"description"`
+	CreatedBy           string    `json:"created_by,omitempty" db:"created_by"`
+	HardwareSelector    string    `json:"hardware_selector,omitempty" db:"hardware_selector"`
+	FirmwareRangesJSON  string    `json:"firmware_ranges_json,omitempty" db:"firmware_ranges_json"`
+	CreatedAt           time.Time `json:"created_at" db:"created_at"`
+	UpdatedAt           time.Time `json:"updated_at" db:"updated_at"`
+}
+
+// ProfileVersion is a versioned collection of entries
+type ProfileVersion struct {
+	ID        string         `json:"id" db:"id"`
+	ProfileID string         `json:"profile_id" db:"profile_id"`
+	Version   int            `json:"version" db:"version"`
+	CreatedAt time.Time      `json:"created_at" db:"created_at"`
+	Notes     string         `json:"notes,omitempty" db:"notes"`
+	Entries   []ProfileEntry `json:"entries,omitempty"`
+}
+
+// ProfileEntry specifies a desired value for a setting
+type ProfileEntry struct {
+	ID                string      `json:"id" db:"id"`
+	ProfileVersionID  string      `json:"profile_version_id" db:"profile_version_id"`
+	ResourcePath      string      `json:"resource_path" db:"resource_path"`
+	Attribute         string      `json:"attribute" db:"attribute"`
+	DesiredValue      interface{} `json:"desired_value,omitempty"`
+	ApplyTimePreference string    `json:"apply_time_preference,omitempty" db:"apply_time_preference"`
+	OEMVendor         string      `json:"oem_vendor,omitempty" db:"oem_vendor"`
+}
+
+// ProfileAssignment binds a profile/version to a target
+type ProfileAssignment struct {
+	ID         string    `json:"id" db:"id"`
+	ProfileID  string    `json:"profile_id" db:"profile_id"`
+	Version    int       `json:"version" db:"version"`
+	TargetType string    `json:"target_type" db:"target_type"`   // e.g., "bmc" or "group"
+	TargetValue string   `json:"target_value" db:"target_value"` // e.g., BMC name or group name
+	CreatedAt  time.Time `json:"created_at" db:"created_at"`
+}


### PR DESCRIPTION
Implements design/005 Configuration Profiles end-to-end:

- Database + CRUD for profiles, versions, entries, assignments
- Profiles API: list/detail/create/delete; versions CRUD; assignments CRUD
- Preview endpoint: `GET /api/profiles/{id}/preview?bmc={name}[&version=N]` with nested key flattening (e.g., `HTTPS.Port`, `Attributes.LogicalProc`)
- Export/Import endpoints for portability
- Snapshot endpoint: `POST /api/profiles/snapshot?bmc={name}` to capture live settings into a new version
- Diff endpoint: `POST /api/profiles/diff` to compare two versions (Added/Removed/Changed with summary)
- Tests covering CRUD, versions, assignments, preview, import/export, snapshot, and diff
- README updated with Configuration Profiles API examples
- design/005 milestones updated (Snapshot + Diff marked done)

Validation:
- `python3 build.py validate` passes: all tests green, coverage ~55.8%, build succeeds

Notes:
- Apply planning/execution is deferred to a follow-on design (006)
- No new dependencies introduced; license-compatible
