### PR TITLE
BMC Details: Add per-BMC Changes tab + audit UI/API polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -580,6 +580,7 @@ Every build goes through automated quality gates:
 Shoal records an audit trail for proxied Redfish operations and other actions.
 
 - UI: Navigate to `/audit` (link visible to admins). Filter by BMC, user, action, method, path substring, HTTP status range, and date range. Results render a table and provide a JSON export link.
+- Per-BMC view: On the BMC details page (`/bmcs/details?name=...`), a "Changes" tab shows audits scoped to that BMC with the same filters and an export link. Non-admins see metadata only; admins see full request/response bodies.
 
 - API: `GET /api/audit` supports filters and a limit parameter:
   - `bmc`: exact BMC name

--- a/README.md
+++ b/README.md
@@ -575,6 +575,15 @@ go test -race ./...
 
 Every build goes through automated quality gates:
 
+## Audit Logging
+
+- Admin-only JSON endpoints expose recent audit records of proxied Redfish operations:
+  - `GET /api/audit?bmc={name}&limit={N}` — List recent audits (default limit 100; max 500). Request/response bodies are truncated in list results.
+  - `GET /api/audit/{id}` — Full audit record by ID.
+- Each audit captures: timestamp, user (if known), BMC name, HTTP method/path, status code, duration, and request/response bodies.
+- Sensitive values in JSON payloads (e.g., Password, tokens) are redacted before storage; very large bodies are truncated.
+- Access is restricted to admin role via existing middleware. Consider external log shipping or periodic pruning for long-term retention.
+
 ```bash
 # Full validation (all quality gates)
 python3 build.py validate

--- a/README.md
+++ b/README.md
@@ -577,12 +577,27 @@ Every build goes through automated quality gates:
 
 ## Audit Logging
 
-- Admin-only JSON endpoints expose recent audit records of proxied Redfish operations:
-  - `GET /api/audit?bmc={name}&limit={N}` — List recent audits (default limit 100; max 500). Request/response bodies are truncated in list results.
-  - `GET /api/audit/{id}` — Full audit record by ID.
-- Each audit captures: timestamp, user (if known), BMC name, HTTP method/path, status code, duration, and request/response bodies.
-- Sensitive values in JSON payloads (e.g., Password, tokens) are redacted before storage; very large bodies are truncated.
-- Access is restricted to admin role via existing middleware. Consider external log shipping or periodic pruning for long-term retention.
+Shoal records an audit trail for proxied Redfish operations and other actions.
+
+- UI: Navigate to `/audit` (link visible to admins). Filter by BMC, user, action, method, path substring, HTTP status range, and date range. Results render a table and provide a JSON export link.
+
+- API: `GET /api/audit` supports filters and a limit parameter:
+  - `bmc`: exact BMC name
+  - `user`: exact username
+  - `action`: e.g., `proxy`, `power`, `apply_profile`
+  - `method`: HTTP method (e.g., `GET`, `POST`)
+  - `path`: substring match on request path
+  - `status_min`, `status_max`: HTTP code bounds
+  - `since`, `until`: ISO dates `YYYY-MM-DD` (`until` inclusive of that day)
+  - `limit`: number of rows (default 100, max 500)
+
+Endpoints:
+- `GET /api/audit?...` — list recent audit entries matching filters (request/response bodies truncated in list views)
+- `GET /api/audit/{id}` — full audit record by ID
+
+Notes:
+- Sensitive fields in JSON payloads are redacted before storage; very large bodies are truncated.
+- All audit endpoints and the `/audit` UI require `admin` role.
 
 ```bash
 # Full validation (all quality gates)

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -239,6 +239,7 @@ func (h *Handler) handleBMCProxy(w http.ResponseWriter, r *http.Request, path st
 	user, _ := h.auth.AuthenticateRequest(r)
 	ctx := r.Context()
 	if user != nil {
+		// Use web handler's typed context key if available via import; otherwise keep legacy for API path
 		ctx = context.WithValue(ctx, "user", user)
 	}
 	// Proxy request to BMC

--- a/internal/bmc/audit_test.go
+++ b/internal/bmc/audit_test.go
@@ -1,0 +1,112 @@
+// Shoal is a Redfish aggregator service.
+// Copyright (C) 2025  Matthew Burns
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package bmc
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"shoal/internal/database"
+	"shoal/pkg/models"
+)
+
+func TestProxyRequestCreatesAudit(t *testing.T) {
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "test.db")
+	db, err := database.New(dbPath)
+	if err != nil {
+		t.Fatalf("db new: %v", err)
+	}
+	defer db.Close()
+
+	ctx := context.Background()
+	if err := db.Migrate(ctx); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	// Seed a BMC
+	b := &models.BMC{Name: "b1", Address: "", Username: "admin", Password: "password", Enabled: true}
+	if err := db.CreateBMC(ctx, b); err != nil {
+		t.Fatalf("create bmc: %v", err)
+	}
+
+	// Mock downstream BMC that expects basic auth and echoes JSON
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		user, pass, ok := r.BasicAuth()
+		if !ok || user != "admin" || pass != "password" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		// Return a small json body
+		json.NewEncoder(w).Encode(map[string]any{"ok": true})
+	}))
+	defer server.Close()
+
+	// Update BMC address to server URL
+	b.Address = server.URL
+	if err := db.UpdateBMC(ctx, b); err != nil {
+		t.Fatalf("update bmc: %v", err)
+	}
+
+	svc := New(db)
+
+	// Prepare a request with a body containing a secret key to test redaction
+	body := map[string]any{"Password": "supersecret", "note": "x"}
+	bb, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPost, "/redfish/v1/anything", bytes.NewReader(bb))
+	req.Header.Set("Content-Type", "application/json")
+
+	// Put user into context to test attribution
+	user := &models.User{ID: "u1", Username: "admin"}
+	ctx = context.WithValue(req.Context(), "user", user)
+	req = req.WithContext(ctx)
+
+	// Execute proxy
+	resp, err := svc.ProxyRequest(ctx, "b1", "/redfish/v1/Managers", req)
+	if err != nil {
+		t.Fatalf("proxy request failed: %v", err)
+	}
+	if resp == nil || resp.StatusCode != http.StatusOK {
+		t.Fatalf("unexpected response: %+v", resp)
+	}
+
+	// Verify an audit was recorded
+	audits, err := db.ListAudits(ctx, "", 10)
+	if err != nil {
+		t.Fatalf("list audits: %v", err)
+	}
+	if len(audits) != 1 {
+		t.Fatalf("expected 1 audit, got %d", len(audits))
+	}
+	a := audits[0]
+	if a.BMCName != "b1" || a.Method != http.MethodPost || a.Path != "/redfish/v1/Managers" {
+		t.Fatalf("unexpected audit fields: %+v", a)
+	}
+	if a.UserID != "u1" || a.UserName != "admin" {
+		t.Fatalf("missing user attribution: %+v", a)
+	}
+	// Ensure redaction occurred for Password
+	if bytes.Contains([]byte(a.RequestBody), []byte("supersecret")) {
+		t.Fatalf("expected password to be redacted, got: %s", a.RequestBody)
+	}
+}

--- a/internal/database/audit_test.go
+++ b/internal/database/audit_test.go
@@ -1,0 +1,95 @@
+// Shoal is a Redfish aggregator service.
+// Copyright (C) 2025  Matthew Burns
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package database
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"shoal/pkg/models"
+)
+
+func TestAuditsPersistence(t *testing.T) {
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "test.db")
+	db, err := New(dbPath)
+	if err != nil {
+		t.Fatalf("db new: %v", err)
+	}
+	defer db.Close()
+
+	ctx := context.Background()
+	if err := db.Migrate(ctx); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	// Create several audit records
+	longBody := strings.Repeat("x", 10000)
+	a1 := &models.AuditRecord{UserID: "u1", UserName: "admin", BMCName: "b1", Action: "proxy", Method: "GET", Path: "/redfish/v1/Systems", StatusCode: 200, DurationMS: 10, RequestBody: longBody, ResponseBody: longBody}
+	if err := db.CreateAudit(ctx, a1); err != nil {
+		t.Fatalf("create a1: %v", err)
+	}
+	// Small delay to ensure ordering by created_at
+	time.Sleep(5 * time.Millisecond)
+	a2 := &models.AuditRecord{UserID: "u2", UserName: "op", BMCName: "b1", Action: "proxy", Method: "POST", Path: "/redfish/v1/Actions", StatusCode: 204, DurationMS: 15}
+	if err := db.CreateAudit(ctx, a2); err != nil {
+		t.Fatalf("create a2: %v", err)
+	}
+	time.Sleep(5 * time.Millisecond)
+	a3 := &models.AuditRecord{UserID: "u3", UserName: "view", BMCName: "b2", Action: "proxy", Method: "GET", Path: "/redfish/v1/Managers", StatusCode: 200, DurationMS: 12}
+	if err := db.CreateAudit(ctx, a3); err != nil {
+		t.Fatalf("create a3: %v", err)
+	}
+
+	// List without filter (default limit)
+	list, err := db.ListAudits(ctx, "", 0)
+	if err != nil {
+		t.Fatalf("list all: %v", err)
+	}
+	if len(list) != 3 {
+		t.Fatalf("expected 3 audits, got %d", len(list))
+	}
+
+	// List with filter and limit
+	listB1, err := db.ListAudits(ctx, "b1", 1)
+	if err != nil {
+		t.Fatalf("list b1: %v", err)
+	}
+	if len(listB1) != 1 {
+		t.Fatalf("expected 1 audit for b1 with limit 1, got %d", len(listB1))
+	}
+	if listB1[0].BMCName != "b1" {
+		t.Fatalf("unexpected bmc name: %s", listB1[0].BMCName)
+	}
+
+	// Bodies in list should be truncated to <= 4096
+	if len(list[0].RequestBody) > 4096 || len(list[0].ResponseBody) > 4096 {
+		t.Fatalf("expected truncated bodies <= 4096, got %d/%d", len(list[0].RequestBody), len(list[0].ResponseBody))
+	}
+
+	// Get by ID
+	got, err := db.GetAudit(ctx, a2.ID)
+	if err != nil {
+		t.Fatalf("get by id: %v", err)
+	}
+	if got == nil || got.ID != a2.ID || got.Method != "POST" {
+		t.Fatalf("unexpected audit: %+v", got)
+	}
+}

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -1345,6 +1345,7 @@ type AuditFilter struct {
 	Action       string
 	Method       string
 	PathContains string
+	Query        string
 	StatusMin    int
 	StatusMax    int
 	Since        time.Time
@@ -1379,6 +1380,11 @@ func (db *DB) ListAuditsFiltered(ctx context.Context, f AuditFilter) ([]models.A
 	if strings.TrimSpace(f.PathContains) != "" {
 		where = append(where, "path LIKE ?")
 		args = append(args, "%"+f.PathContains+"%")
+	}
+	if q := strings.TrimSpace(f.Query); q != "" {
+		like := "%" + q + "%"
+		where = append(where, "(path LIKE ? OR user_name LIKE ? OR action LIKE ? OR method LIKE ?)")
+		args = append(args, like, like, like, like)
 	}
 	if f.StatusMin > 0 {
 		where = append(where, "status_code >= ?")

--- a/pkg/models/models.go
+++ b/pkg/models/models.go
@@ -221,3 +221,20 @@ type ProfileAssignment struct {
 	TargetValue string    `json:"target_value" db:"target_value"` // e.g., BMC name or group name
 	CreatedAt   time.Time `json:"created_at" db:"created_at"`
 }
+
+// AuditRecord captures an auditable operation performed by the aggregator
+type AuditRecord struct {
+	ID           string    `json:"id" db:"id"`
+	CreatedAt    time.Time `json:"created_at" db:"created_at"`
+	UserID       string    `json:"user_id,omitempty" db:"user_id"`
+	UserName     string    `json:"user_name,omitempty" db:"user_name"`
+	BMCName      string    `json:"bmc_name,omitempty" db:"bmc_name"`
+	Action       string    `json:"action" db:"action"`           // e.g., "proxy", "power", "apply_profile"
+	Method       string    `json:"method,omitempty" db:"method"` // HTTP verb for proxy operations
+	Path         string    `json:"path,omitempty" db:"path"`
+	StatusCode   int       `json:"status_code" db:"status_code"`
+	DurationMS   int64     `json:"duration_ms" db:"duration_ms"`
+	RequestBody  string    `json:"request_body,omitempty" db:"request_body"`
+	ResponseBody string    `json:"response_body,omitempty" db:"response_body"`
+	Error        string    `json:"error,omitempty" db:"error"`
+}


### PR DESCRIPTION
This PR adds a per-BMC "Changes" tab on the BMC details page and rounds out the auditing capabilities from design 006.

Highlights
- UI: New tabs on `/bmcs/details?name=...` with a "Changes" tab that lists audits scoped to that BMC. Includes filters (status range, method, path substring, search, since/until, limit) and an Export JSONL link.
- API: Reuse existing `GET /api/audit` with extended filters and `GET/POST /api/audit/export` to drive the tab. Results mask request/response bodies for non-admins per RBAC.
- RBAC: Enforced in handlers so audit endpoints are visible to authenticated users, with bodies only visible to admins.
- DX: Replaced string context key with typed key in web middleware to satisfy lint guidance (back-compat kept where legacy string is used elsewhere).
- Tests: Extend `internal/web/web_test.go` to assert the Changes tab elements render on the details page. All tests pass locally via `python3 build.py validate`.
- Docs: README updated to document the new per-BMC Changes view and RBAC behavior.

Why
- Completes the UI browsing experience called for in design/006_Change_Tracking_and_Auditing.md: per-BMC "Changes" (audit) view, search, export, and RBAC-based visibility.

Notes
- Optional follow-ups from 006 are intentionally deferred: explicit high-level records for `apply-profile` start/finish, set-attribute convenience entries, and a deeper drill-down view with pre/post diffs.

Validation
- `python3 build.py validate` passes (format, vet, tests, build). Coverage ~55%.

