### PR TITLE
008: Attribute Registry Resolution & ActionInfo Enrichment

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,7 @@ curl -H "X-Auth-Token: <token>" http://localhost:8080/redfish/v1/
     - `oem`: Optional. Filter OEM vs non‑OEM settings. Accepted values: `true|false|1|0|yes|no`.
     - `page`: Optional. 1‑based page number for pagination.
     - `page_size`: Optional. Page size for pagination. When omitted, returns all filtered results.
+    - `refresh`: Optional. `true` to bypass caches and force re-discovery/enrichment. Requires operator or admin.
   - Legacy compatibility: the query-form endpoint `GET /api/bmcs/settings?name={bmc-name}` supports the same query parameters.
   - Returns: a JSON object with discovered setting descriptors for the target BMC. Current scope focuses on common Redfish settings surfaces that expose `@Redfish.Settings` such as `Systems/<id>/Bios` and `Managers/<id>/NetworkProtocol`.
 
@@ -393,6 +394,14 @@ Response shape (example):
 
 Notes:
 - The legacy query form `GET /api/bmcs/settings?name={bmc-name}[&resource=...&search=...&oem=...&page=...&page_size=...]` is still supported for backward compatibility.
+
+Enrichment (008):
+- Descriptors include enriched metadata resolved from Redfish Attribute Registries and ActionInfo where available:
+  - `display_name`, `description`, `type`, `read_only`
+  - Constraints: `enum_values`, `min`, `max`, `pattern`, `units`
+  - Apply semantics: `apply_times` from `@Redfish.Settings.SupportedApplyTimes`
+  - Action semantics: `action_target` and allowable values via `@Redfish.ActionInfo`
+  - OEM tagging: `oem` and `oem_vendor` when vendor registries are detected
 
 Current limitations (to be expanded in future milestones):
 - AttributeRegistry, ActionInfo, and full constraints (enums, ranges) are not yet fully resolved

--- a/design/008_Attribute_Registry_Resolution.md
+++ b/design/008_Attribute_Registry_Resolution.md
@@ -62,15 +62,29 @@ Note: Database schema already supports these fields (added in 004 persistence wo
 - No new endpoints. Existing read-only endpoints from 004 now return enriched data:
   - `GET /api/bmcs/{name}/settings[?resource=...]`
   - `GET /api/bmcs/{name}/settings/{descriptor_id}`
+   - Optional: `?refresh=true` query parameter on the list/detail read paths to bypass caches and re-run discovery/enrichment on-demand (see Refresh Semantics). This is additive and backwards-compatible.
 
 ## Caching & Performance
-- Cache registry payloads per BMC for a TTL (e.g., 10–30 minutes) to avoid re-fetching large registries on each call.
-- Store enriched fields in DB; subsequent reads can serve from DB without re-resolving unless cache expired or a refresh is requested.
+- Per-BMC TTL cache for registry payloads and action metadata. Default TTL: 15 minutes (configurable in code constant; can be promoted to flag later if needed).
+- Store enriched fields in DB; reads serve from DB without re-resolving unless:
+   - Cache expired, or
+   - Caller provides `?refresh=true`, or
+   - Descriptor is missing enrichment fields (bootstrap/first run).
+- Limit concurrent registry fetches per BMC to avoid stampedes (simple mutex/once around resolution is sufficient for now).
+- All Redfish fetches go through the existing proxy path to benefit from authentication + auditing.
+
+### Refresh Semantics
+- `refresh=true` forces a fresh resolve of registries and actions for the targeted BMC/resource, bypassing in-memory caches. DB will be upserted with the latest enrichment.
+- RBAC: viewers can read cached data; forcing `refresh=true` requires operator or admin privileges.
+- Use sparingly; large registries can be multi-hundred KB.
 
 ## Edge Cases
 - Missing/invalid registry references: return basic descriptors as in 004.
 - Partial OEM coverage: enrich what is known; mark OEM vendor when detected.
 - Large registries: avoid fetching repeatedly; paginate only at UI layer if needed.
+- ActionInfo present but not attribute-specific: do not attempt to map AllowableValues unless a parameter can be unambiguously associated with a single attribute.
+- BIOS attributes that only accept changes via Action POST: set `action_target` and leave `enum_values` unchanged unless ActionInfo provides explicit allowable values.
+- If both Registry enum candidates and ActionInfo allowable values exist and differ, prefer ActionInfo for the action-specific context and keep Registry values as secondary reference.
 
 ## Testing Strategy
 - Unit tests for registry parsing (DMTF BIOS-like payload with Attributes array).
@@ -80,6 +94,7 @@ Note: Database schema already supports these fields (added in 004 persistence wo
   - BIOS with `AttributeRegistry` and `@Redfish.Settings`
   - Manager NetworkProtocol with an Action plus `ActionInfo`
   - An OEM registry sample (Dell or Supermicro) stub
+   - Note for tests: when targeting the local httptest server, use explicit `http://` in BMC URLs to avoid the default-https normalization in `buildBMCURL()`.
 
 ## Milestones
 1. BIOS Registry Enrichment: Resolve `AttributeRegistry` for BIOS; populate display/description/type/enums/min/max/pattern/units/read_only.
@@ -93,3 +108,24 @@ Note: Database schema already supports these fields (added in 004 persistence wo
 - Keep logic in `internal/bmc` (e.g., new helpers `resolveAttributeRegistry`, `enrichWithRegistry`, `resolveActionInfo`).
 - Prefer standard library; no new dependencies unless strictly necessary and AGPLv3-compatible.
 - Update existing DB upsert to include enriched fields (already supported by schema).
+
+### ActionInfo Parameter Matching
+- Map `ActionInfo.Parameters[*]` to attributes when there is a clear key match. Prefer these hints in order:
+   1) A parameter name that exactly equals the attribute name.
+   2) A JSON pointer/path or property name that clearly references the attribute within the Attributes bag.
+   3) Vendor documentation hints (only for targeted OEM cases we explicitly support in tests).
+- If no unambiguous mapping exists, do not attach `AllowableValues` to the descriptor.
+
+### OEM Handling Nuance
+- Detect OEM registries by vendor fields within the registry payload (e.g., `OwningEntity`, `RegistryPrefix`, or vendor namespaces). Set `oem=true` and `oem_vendor` accordingly.
+- Do not guess semantics or normalize OEM attributes; surface vendor-provided metadata as-is.
+- Prefer DMTF fields when present; augment with OEM fields only when DMTF-equivalent is absent.
+
+### Security & Auditing
+- All registry and ActionInfo fetches are proxied and audited per existing mechanisms (request/response truncated/redacted as configured).
+- Do not persist secrets; only persist metadata and non-sensitive enumerations/ranges.
+- Respect existing role gates on settings endpoints; require operator/admin for `refresh=true` as noted above.
+
+### Failure Behavior
+- Network/parse errors during enrichment must not break settings reads; fall back to previously persisted descriptors or the basic 004 descriptors.
+- Log at debug level with concise context (BMC, resource, error category) without dumping full payloads.

--- a/design/009_Expanded_Resource_Coverage.md
+++ b/design/009_Expanded_Resource_Coverage.md
@@ -1,0 +1,79 @@
+# 009: Expanded Resource Coverage for Network and Storage
+
+## Summary
+This milestone expands on the settings discovery and enrichment framework established in `004` and `008`. The goal is to extend coverage to include network (`EthernetInterfaces`) and storage (`Storage` controllers, volumes, and drives) resources within a system. This will allow Shoal to provide a more comprehensive view of a server's configurable settings.
+
+## Goals
+- Discover and persist settings from `EthernetInterfaces` resources.
+- Discover and persist settings from `Storage` collections, including associated `StorageControllers`, `Volumes`, and `Drives`.
+- Apply the existing attribute registry and `ActionInfo` enrichment logic from `008` to these newly discovered settings.
+- Ensure the existing UI and API surfaces can display and filter these new settings without requiring new endpoints.
+
+## Non-Goals
+- Implementation of complex storage operations (e.g., creating RAID volumes, managing virtual disks). This design focuses on discovering and displaying existing settings, not executing complex actions.
+- Deep configuration of network switch hardware. The focus is on the server's own network interfaces.
+
+## Inputs & Surfaces
+The discovery process will be extended to probe the following Redfish paths:
+
+- **Network Interfaces:**
+  - `Systems/<id>/EthernetInterfaces` (Collection)
+  - `Systems/<id>/EthernetInterfaces/<id>` (Individual NIC)
+- **Storage Subsystems:**
+  - `Systems/<id>/Storage` (Collection)
+  - `Systems/<id>/Storage/<id>` (Individual Storage Subsystem)
+  - `Systems/<id>/Storage/<id>/StorageControllers/<id>`
+  - `Systems/<id>/Storage/<id>/Volumes` (Collection)
+  - `Systems/<id>/Storage/<id>/Volumes/<id>`
+  - `Systems/<id>/Storage/<id>/Drives` (Collection)
+  - `Systems/<id>/Storage/<id>/Drives/<id>`
+
+## Data Mapping to Internal Model
+The existing `pkg/models.SettingDescriptor` model is sufficient to store settings from these new resources. No schema changes are required.
+
+Examples of settings we expect to discover include:
+
+- **Network (`EthernetInterfaces`):**
+  - `DHCPv4.Enabled`, `DHCPv6.OperatingMode`
+  - `StaticIPv4Addresses`, `StaticIPv6Addresses`
+  - `VLAN.Enabled`, `VLAN.Id`
+  - `LinkStatus`, `SpeedMbps` (as read-only attributes)
+- **Storage (`Storage`, `StorageControllers`, `Drives`):**
+  - `RAID.Enable`, `Controller.Mode`
+  - `Drive.WriteCache`, `Drive.EncryptionStatus`
+  - `Security.EraseOnDelete`
+  - `Identifiers.DurableName` (as a read-only attribute)
+
+## Discovery Algorithm
+The discovery logic in `internal/bmc/service.go` will be updated to traverse these new collections.
+
+1.  **Extend Resource Probing:** The main discovery function will be modified to iterate through the `EthernetInterfaces` and `Storage` collections found on a `System` resource.
+2.  **Recursive Discovery:** For each member of these collections, the system will recursively call the resource discovery function, which already handles `@Redfish.Settings`, attributes, and actions.
+3.  **Apply Enrichment:** The existing enrichment logic (`enrichDescriptors`) will be applied to the settings found in these new resources. No changes to the enrichment functions themselves are anticipated, as they are designed to be generic.
+4.  **Persistence:** The newly discovered and enriched `SettingDescriptor` objects will be upserted into the database using the existing `UpsertSettingDescriptors` method.
+
+## API Impact
+- **No New Endpoints:** The new settings will be automatically included in the responses from the existing settings endpoints:
+  - `GET /api/bmcs/{name}/settings`
+  - `GET /api/bmcs/{name}/settings/{descriptor_id}`
+- **Filtering:** The `?resource=...` query parameter can be used to filter for the new resource types. For example:
+  - `?resource=EthernetInterfaces`
+  - `?resource=Storage`
+
+## UI Impact
+- The "Settings" tab on the BMC details page will automatically display settings from network and storage devices.
+- The resource path filter on the UI may need to be enhanced to better handle the deeper and more complex paths of these new resources. A tree-view or grouped filter could be considered to improve usability.
+
+## Testing Strategy
+- **Mock Server Updates:** The `httptest` server used in integration tests will be updated with handlers for the new Redfish paths (`EthernetInterfaces`, `Storage`, etc.).
+- **Mock Payloads:** These handlers will serve realistic JSON payloads, including attributes, `@Redfish.Settings` annotations, and `Actions` with associated `ActionInfo` links.
+- **New Tests:** New test cases will be added to `internal/bmc/service_test.go` to:
+  - Verify that settings from `EthernetInterfaces` are discovered and correctly enriched.
+  - Verify that settings from `Storage` controllers and drives are discovered and enriched.
+  - Confirm that filtering by the new resource paths works as expected.
+
+## Milestones
+1.  **Network Interface Discovery:** Implement the logic to traverse `EthernetInterfaces` collections and discover their settings.
+2.  **Storage Discovery:** Implement the logic to traverse `Storage` collections and their sub-resources (`StorageControllers`, `Drives`, `Volumes`).
+3.  **UI Enhancements:** Improve the filtering or grouping on the settings UI to better accommodate the new resource types.
+4.  **Validation:** Add comprehensive tests and run the full validation pipeline to ensure correctness and prevent regressions.


### PR DESCRIPTION
This PR implements the 008 milestone as designed in `design/008_Attribute_Registry_Resolution.md`.

Key Features
- Attribute Registry enrichment for settings (DisplayName, Description, Type, ReadOnly, constraints: EnumValues/Min/Max/Pattern/Units)
- SupportedApplyTimes and SettingsObject capture from @Redfish.Settings
- Actions + @Redfish.ActionInfo resolution for allowable values; prefer ActionInfo when both exist
- Per‑BMC TTL caches (15m) for registry/action payloads with refresh bypass
- Optional `?refresh=true` on settings endpoints guarded by operator/admin RBAC
- OEM/vendor tagging best-effort via registry metadata

Code Changes
- `internal/bmc/service.go`: enrichment, caches, refresh semantics; apply-times/action-target population
- `internal/web/web.go`: `?refresh=true` handling and RBAC enforcement for settings endpoints
- `internal/bmc/service_test.go`: new tests for apply-times/action-target, registry enrichment, ActionInfo mapping, and refresh bypass behavior
- `README.md`: document refresh parameter and enriched fields
- `design/008_Attribute_Registry_Resolution.md`: previously updated with refresh/TTL/ActionInfo/OEM/failure behavior (for reviewer context)

Validation
- `python3 build.py validate` passes locally; tests green; coverage ~56.7%
- `golangci-lint` and `gosec` are optional in our pipeline and were skipped if unavailable

Notes
- Enrichment fails gracefully when registries or action info are missing or unparsable; basic descriptors are returned.
- Schema already supported enrichment fields; no migrations required.

Request
- Please review and, if acceptable, merge with squash as usual.