### PR TITLE
Design: Milestones 010 (Profiles UI Read) and 011 (Snapshot from BMC)

### DIFF
--- a/design/010_Config_Profiles_UI_Read.md
+++ b/design/010_Config_Profiles_UI_Read.md
@@ -1,0 +1,77 @@
+# Milestone 010: Configuration Profiles UI (Read-Only)
+
+## 1. Overview
+
+This milestone introduces the foundational, read-only user interface for managing Configuration Profiles. The goal is to provide administrators and operators with the ability to view existing profiles, inspect their versions, and see the specific settings captured in each version.
+
+This work is the first step towards a full CRUD interface and intentionally defers create, update, and delete operations to a subsequent milestone.
+
+## 2. Rationale
+
+- **Visibility**: Users need to see what profiles exist before they can manage them.
+- **Incremental Development**: Building the read-only views first establishes the UI structure and data flow without the complexity of handling user input and state changes.
+- **Agent Task Scoping**: This milestone represents a clear, self-contained unit of work suitable for a single PR.
+
+## 3. Scope
+
+### 3.1. Key Features
+
+- **Profile List Page**: A new page at `/profiles` that displays a table of all existing configuration profiles.
+  - Columns: Profile Name, Description, Number of Versions, Created/Updated Timestamps.
+  - Each profile name will be a link to its detail page.
+- **Profile Detail Page**: A new page at `/profiles/{id}` that shows:
+  - The profile's name and description.
+  - A table listing all versions of the profile, with columns for Version Number, Number of Entries, and Creation Date.
+  - Each version number will be a link to the version detail page.
+- **Version Detail Page**: A new page at `/profiles/{id}/versions/{version}` that displays:
+  - A table of all setting entries (key-value pairs) for that specific version.
+  - Columns: Resource Path, Attribute, and Stored Value.
+- **Navigation**: Add a "Profiles" link to the main navigation bar in the web UI, visible to authenticated users.
+
+### 3.2. Out of Scope
+
+- Creating, editing, or deleting profiles.
+- Creating new profile versions (including snapshots).
+- Applying profiles to a BMC.
+- Comparing (diffing) profile versions.
+
+## 4. Technical Design
+
+### 4.1. Web Layer (`internal/web`)
+
+- **New Handlers**:
+  - `handler.go`:
+    - `profilesPage(w, r)`: Handles `GET /profiles`. Fetches all profiles from the database and renders the `profiles.html` template.
+    - `profileDetailPage(w, r)`: Handles `GET /profiles/{id}`. Fetches profile details and its versions, then renders `profile_detail.html`.
+    - `profileVersionDetailPage(w, r)`: Handles `GET /profiles/{id}/versions/{version}`. Fetches the specific profile version and its entries, then renders `profile_version_detail.html`.
+- **New Router Entries**:
+  - `web.go`: Register the new routes in the main router, ensuring they are protected by the authentication middleware.
+- **New Templates**:
+  - `templates/profiles.html`: Main list view. Will contain a table iterating over `[]models.ConfigProfile`.
+  - `templates/profile_detail.html`: Detail view. Will show profile metadata and a table iterating over `[]models.ConfigProfileVersion`.
+  - `templates/profile_version_detail.html`: Version detail view. Will show a table iterating over `[]models.ConfigProfileEntry`.
+- **Navigation Update**:
+  - `templates/base.html` (or equivalent layout template): Add a link to `/profiles` in the navigation menu.
+
+### 4.2. Database Layer (`internal/database`)
+
+The existing API already implies that functions to fetch profiles and their sub-components exist. This milestone will primarily involve exposing them to the web handlers. If any of the following functions do not exist, they must be created.
+
+- `database.go`:
+  - `GetConfigProfiles() ([]*models.ConfigProfile, error)`: Fetch all profiles.
+  - `GetConfigProfile(id string) (*models.ConfigProfile, error)`: Fetch a single profile by its ID.
+  - `GetConfigProfileVersions(profileID string) ([]*models.ConfigProfileVersion, error)`: Fetch all versions for a given profile.
+  - `GetConfigProfileVersion(profileID string, version int) (*models.ConfigProfileVersion, error)`: Fetch a specific version, including its entries.
+
+## 5. Acceptance Criteria
+
+- An AI agent can implement these changes in a single pull request.
+- All new pages render correctly without errors.
+- The "Profiles" link appears in the main navigation for logged-in users.
+- The profile list at `/profiles` accurately reflects the profiles stored in the database.
+- Clicking a profile name navigates to `/profiles/{id}`.
+- The profile detail page correctly displays the versions for that profile.
+- Clicking a version number navigates to `/profiles/{id}/versions/{version}`.
+- The version detail page correctly displays the settings captured in that version.
+- All existing tests, including the `build.py validate` pipeline, must pass.
+- New tests should be added to cover the new handlers.

--- a/design/011_Config_Profiles_UI_Snapshot.md
+++ b/design/011_Config_Profiles_UI_Snapshot.md
@@ -1,0 +1,74 @@
+# Milestone 011: Configuration Profiles UI (Snapshot)
+
+## 1. Overview
+
+This milestone builds upon the read-only UI established in Milestone 010. It introduces the first write operation: the ability to "snapshot" the current configuration of a BMC and save it as a new version of a Configuration Profile.
+
+This feature will be accessible from the BMC Details page, providing a direct and intuitive workflow for capturing a baseline configuration.
+
+## 2. Rationale
+
+- **User Workflow**: The most common first step in using profiles is to capture a "golden" or baseline configuration from a known-good machine. This feature directly enables that workflow.
+- **Scoped Interaction**: This change is limited to a single button and a modal form, making it a well-defined and manageable task for an agent.
+- **API Utilization**: It leverages the existing `POST /api/profiles/snapshot` API endpoint, focusing the work on the UI/frontend implementation.
+
+## 3. Scope
+
+### 3.1. Key Features
+
+- **Snapshot Button**: On the BMC Details page (`/bmcs/details?name={bmc-name}`), specifically on the "Settings" tab, add a "Snapshot Configuration" button.
+- **Snapshot Modal**:
+  - Clicking the button will open a modal dialog.
+  - The modal will contain a form with two options:
+    1.  **Create New Profile**: A text input for the `name` of a new profile. A `description` field is optional.
+    2.  **Add to Existing Profile**: A dropdown/select menu populated with existing profiles.
+  - A "Save Snapshot" button within the modal will trigger the snapshot action.
+- **Client-Side Logic**:
+  - JavaScript is required to handle opening the modal and submitting the form data to the Shoal API.
+  - The submission will be an AJAX `POST` request to the `POST /api/profiles/snapshot?bmc={bmc-name}` endpoint.
+  - The request body will contain either `{ "name": "new-profile-name", "description": "..." }` or `{ "profile_id": "existing-profile-id" }`.
+  - Upon a successful API response, the modal should close, and a success notification (toast/alert) should be displayed.
+  - On failure, an error notification should be displayed with a relevant message.
+
+### 3.2. Out of Scope
+
+- A dedicated "Create Profile" page. Profile creation is handled implicitly through the snapshot modal.
+- Editing or deleting profiles.
+- Applying or diffing profiles.
+
+## 4. Technical Design
+
+### 4.1. Web Layer (`internal/web`)
+
+- **Handler Modifications**:
+  - `bmcDetailPage(w, r)`: When rendering the BMC details, this handler must now also fetch a list of all existing configuration profiles (`database.GetConfigProfiles()`). This list will be passed to the template to populate the "Add to Existing Profile" dropdown in the modal.
+- **Template Modifications**:
+  - `templates/bmc_detail.html` (or the template for the "Settings" tab):
+    - Add the HTML for the "Snapshot Configuration" button.
+    - Add the HTML structure for the modal dialog, including the form, inputs, and select menu. The select menu should be populated by iterating over the profiles passed from the handler.
+- **Static Assets (`static/js`)**:
+  - A new or existing JavaScript file will need to contain the logic for:
+    - An event listener for the "Snapshot Configuration" button to open the modal.
+    - An event listener for the modal's form submission.
+    - The `fetch` call to the snapshot API endpoint, constructing the correct URL and body based on form input.
+    - Handling the success and error responses from the API.
+
+### 4.2. API Layer (`internal/api`)
+
+- No changes are expected. The `POST /api/profiles/snapshot` endpoint should already support creating a new profile or adding a version to an existing one based on the request body. The agent should verify this behavior and implement it if it's missing.
+
+### 4.3. Database Layer (`internal/database`)
+
+- No changes are expected, as the required `GetConfigProfiles()` function should already exist from the previous milestone.
+
+## 5. Acceptance Criteria
+
+- An AI agent can implement these changes in a single pull request.
+- The "Snapshot Configuration" button is visible on the BMC Details/Settings page.
+- Clicking the button opens a modal with a form.
+- The dropdown in the modal is correctly populated with the names of existing profiles.
+- Submitting the form with a new profile name successfully creates a new profile and a new version containing the snapshot.
+- Submitting the form with an existing profile selected successfully creates a new version for that profile.
+- The user receives clear success or error feedback after the operation.
+- All existing tests, including the `build.py validate` pipeline, must pass.
+- New JavaScript behavior should be tested manually or with new end-to-end tests if the framework is available.


### PR DESCRIPTION
Add design documents for the next milestones focusing on Configuration Profiles UI:

- 010: Read-only UI to list profiles, view profile details, and view version entries. New routes/pages `/profiles`, `/profiles/{id}`, `/profiles/{id}/versions/{version}`. Out of scope: create/delete/apply/diff.
- 011: Snapshot capability from BMC Details/Settings page via modal, posting to existing `POST /api/profiles/snapshot?bmc={name}`. Out of scope: apply/diff/edit/delete.

Consistency Check
- Backend API endpoints for profiles already exist (`/api/profiles`, `/api/profiles/snapshot`, etc.).
- No existing web routes conflict with the proposed `/profiles` pages.
- Validation passed locally with `python3 build.py validate`.

These docs scope work into single-PR milestones for an AI agent to implement.
