### PR TITLE
chore: dead code removal sweep (+ allowlist docs)

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -157,7 +157,6 @@ func (a *Authenticator) RequireAuth(next http.Handler) http.Handler {
 }
 
 // GetUserFromContext extracts the authenticated user from request context
-// (Removed exported GetUserFromContext: duplicate of local helpers in web package and unused in application runtime)
 
 // generateID generates a random ID for sessions
 func generateID() (string, error) {

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -157,10 +157,7 @@ func (a *Authenticator) RequireAuth(next http.Handler) http.Handler {
 }
 
 // GetUserFromContext extracts the authenticated user from request context
-func GetUserFromContext(ctx context.Context) (*models.User, bool) {
-	user, ok := ctx.Value(ctxkeys.User).(*models.User)
-	return user, ok
-}
+// (Removed exported GetUserFromContext: duplicate of local helpers in web package and unused in application runtime)
 
 // generateID generates a random ID for sessions
 func generateID() (string, error) {

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -393,8 +393,6 @@ func TestRequireAuthMiddleware(t *testing.T) {
 	}
 }
 
-// (Removed TestGetUserFromContext: function under test deleted as dead code)
-
 func TestGenerateIDAndToken(t *testing.T) {
 	// Test generateID
 	id1, err := generateID()

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -329,7 +329,7 @@ func TestRequireAuthMiddleware(t *testing.T) {
 
 	// Create a test handler
 	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		user, ok := GetUserFromContext(r.Context())
+		user, ok := r.Context().Value(ctxkeys.User).(*models.User)
 		if !ok {
 			t.Error("User should be in context")
 			http.Error(w, "No user in context", http.StatusInternalServerError)
@@ -393,50 +393,7 @@ func TestRequireAuthMiddleware(t *testing.T) {
 	}
 }
 
-func TestGetUserFromContext(t *testing.T) {
-	// Test with user in context
-	user := &models.User{
-		ID:       "test-user",
-		Username: "testuser",
-		Role:     "admin",
-		Enabled:  true,
-	}
-
-	ctx := context.WithValue(context.Background(), ctxkeys.User, user)
-
-	retrievedUser, ok := GetUserFromContext(ctx)
-	if !ok {
-		t.Error("Should find user in context")
-	}
-	if retrievedUser == nil {
-		t.Fatal("Retrieved user should not be nil")
-	}
-	if retrievedUser.ID != user.ID {
-		t.Errorf("Expected user ID %s, got %s", user.ID, retrievedUser.ID)
-	}
-
-	// Test with no user in context
-	ctx = context.Background()
-
-	retrievedUser, ok = GetUserFromContext(ctx)
-	if ok {
-		t.Error("Should not find user in empty context")
-	}
-	if retrievedUser != nil {
-		t.Error("Retrieved user should be nil")
-	}
-
-	// Test with wrong type in context
-	ctx = context.WithValue(context.Background(), ctxkeys.User, "not-a-user")
-
-	retrievedUser, ok = GetUserFromContext(ctx)
-	if ok {
-		t.Error("Should not find user with wrong type")
-	}
-	if retrievedUser != nil {
-		t.Error("Retrieved user should be nil for wrong type")
-	}
-}
+// (Removed TestGetUserFromContext: function under test deleted as dead code)
 
 func TestGenerateIDAndToken(t *testing.T) {
 	// Test generateID

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -692,6 +692,7 @@ func (db *DB) DeleteSession(ctx context.Context, token string) error {
 }
 
 // CleanupExpiredSessions removes expired sessions
+// NOTE: Test-only utility currently used in tests; retained for potential future scheduled cleanup task.
 func (db *DB) CleanupExpiredSessions(ctx context.Context) error {
 	query := `DELETE FROM sessions WHERE expires_at <= ?`
 
@@ -752,6 +753,7 @@ func (db *DB) DeleteSessionByID(ctx context.Context, id string) error {
 }
 
 // DisableForeignKeys disables foreign key constraints (for testing)
+// NOTE: Test-only helper used by unit/integration tests to bypass FK ordering constraints; not used in production code.
 func (db *DB) DisableForeignKeys() error {
 	_, err := db.conn.Exec("PRAGMA foreign_keys=OFF")
 	return err
@@ -965,6 +967,7 @@ func (db *DB) CreateConnectionMethod(ctx context.Context, method *models.Connect
 }
 
 // UpdateConnectionMethodAggregatedData updates the cached aggregated data for a connection method
+// NOTE: Currently only exercised in tests; retained to support future aggregation caching logic.
 func (db *DB) UpdateConnectionMethodAggregatedData(ctx context.Context, id string, managers, systems string) error {
 	query := `UPDATE connection_methods SET aggregated_managers = ?, aggregated_systems = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?`
 
@@ -989,6 +992,7 @@ func (db *DB) DeleteConnectionMethod(ctx context.Context, id string) error {
 }
 
 // UpdateConnectionMethodLastSeen updates the last seen timestamp
+// NOTE: Currently only exercised in tests; retained for prospective connection method monitoring.
 func (db *DB) UpdateConnectionMethodLastSeen(ctx context.Context, id string) error {
 	query := `UPDATE connection_methods SET last_seen = CURRENT_TIMESTAMP WHERE id = ?`
 

--- a/internal/web/auth_test.go
+++ b/internal/web/auth_test.go
@@ -574,17 +574,7 @@ func TestAuthenticationMiddleware(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	viewerPasswordHash, _ := pkgAuth.HashPassword("viewerpass")
-	viewerUser := &models.User{
-		ID:           "viewer-user-id",
-		Username:     "viewer",
-		PasswordHash: viewerPasswordHash,
-		Role:         "viewer",
-		Enabled:      true,
-	}
-	if err := db.CreateUser(context.Background(), viewerUser); err != nil {
-		t.Fatal(err)
-	}
+	// viewer user removed (no operator middleware tests)
 
 	// Create session for admin
 	adminSession := &models.Session{
@@ -640,18 +630,6 @@ func TestAuthenticationMiddleware(t *testing.T) {
 			name:           "requireAdmin with non-admin user",
 			middleware:     h.requireAdmin,
 			basicAuth:      &struct{ username, password string }{"operator", "operatorpass"},
-			wantStatusCode: http.StatusForbidden,
-		},
-		{
-			name:           "requireOperator with operator user",
-			middleware:     h.requireOperator,
-			basicAuth:      &struct{ username, password string }{"operator", "operatorpass"},
-			wantStatusCode: http.StatusOK,
-		},
-		{
-			name:           "requireOperator with viewer user",
-			middleware:     h.requireOperator,
-			basicAuth:      &struct{ username, password string }{"viewer", "viewerpass"},
 			wantStatusCode: http.StatusForbidden,
 		},
 	}

--- a/internal/web/auth_test.go
+++ b/internal/web/auth_test.go
@@ -574,8 +574,6 @@ func TestAuthenticationMiddleware(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// viewer user removed (no operator middleware tests)
-
 	// Create session for admin
 	adminSession := &models.Session{
 		ID:        "admin-session-id",

--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -2108,16 +2108,7 @@ func (h *Handler) requireAdmin(next http.Handler) http.Handler {
 }
 
 // requireOperator middleware ensures user has operator role or higher
-func (h *Handler) requireOperator(next http.Handler) http.Handler {
-	return h.requireAuth(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		user := getUserFromContext(r.Context())
-		if !auth.IsOperator(user) {
-			http.Error(w, "Access denied. Operator privileges required.", http.StatusForbidden)
-			return
-		}
-		next.ServeHTTP(w, r)
-	}))
-}
+// (Removed requireOperator middleware: unused in runtime; tests adjusted accordingly)
 
 // getUserFromContext retrieves the authenticated user from the request context
 func getUserFromContext(ctx context.Context) *models.User {

--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -2108,7 +2108,6 @@ func (h *Handler) requireAdmin(next http.Handler) http.Handler {
 }
 
 // requireOperator middleware ensures user has operator role or higher
-// (Removed requireOperator middleware: unused in runtime; tests adjusted accordingly)
 
 // getUserFromContext retrieves the authenticated user from the request context
 func getUserFromContext(ctx context.Context) *models.User {

--- a/pkg/auth/password.go
+++ b/pkg/auth/password.go
@@ -58,8 +58,8 @@ func VerifyPassword(password, hash string) error {
 	return nil
 }
 
-// IsHashed checks if a string appears to be a bcrypt hash
-func IsHashed(s string) bool {
+// isHashed checks if a string appears to be a bcrypt hash (internal helper; tests call it directly in same package)
+func isHashed(s string) bool {
 	// Bcrypt hashes start with $2a$, $2b$, or $2y$ followed by cost parameter
 	if len(s) < 60 {
 		return false

--- a/pkg/auth/password_test.go
+++ b/pkg/auth/password_test.go
@@ -67,7 +67,7 @@ func TestHashPassword(t *testing.T) {
 				if hash == tt.password {
 					t.Error("HashPassword() returned plaintext password")
 				}
-				if !IsHashed(hash) {
+				if !isHashed(hash) {
 					t.Error("HashPassword() returned invalid hash format")
 				}
 			}
@@ -211,7 +211,7 @@ func TestIsHashed(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := IsHashed(tt.s); got != tt.want {
+			if got := isHashed(tt.s); got != tt.want {
 				t.Errorf("IsHashed() = %v, want %v", got, tt.want)
 			}
 		})

--- a/pkg/auth/rbac.go
+++ b/pkg/auth/rbac.go
@@ -31,34 +31,7 @@ func IsOperator(user *models.User) bool {
 }
 
 // IsViewer checks if the user has any valid role (can view)
-func IsViewer(user *models.User) bool {
-	return user != nil && user.Enabled
-}
-
-// CanManageUsers checks if the user can manage other users (admin only)
-func CanManageUsers(user *models.User) bool {
-	return IsAdmin(user)
-}
-
-// CanManageBMCs checks if the user can add/edit/delete BMCs (admin or operator)
-func CanManageBMCs(user *models.User) bool {
-	return IsOperator(user)
-}
-
-// CanExecutePowerActions checks if the user can execute power actions (admin or operator)
-func CanExecutePowerActions(user *models.User) bool {
-	return IsOperator(user)
-}
-
-// CanViewBMCs checks if the user can view BMCs (any authenticated user)
-func CanViewBMCs(user *models.User) bool {
-	return IsViewer(user)
-}
-
-// CanChangeOwnPassword checks if the user can change their own password
-func CanChangeOwnPassword(user *models.User) bool {
-	return user != nil && user.Enabled
-}
+// (Removed unused RBAC helper functions: IsViewer, CanManageUsers, CanManageBMCs, CanExecutePowerActions, CanViewBMCs, CanChangeOwnPassword)
 
 // GetRoleDisplayName returns a human-friendly name for a role
 func GetRoleDisplayName(role string) string {
@@ -75,15 +48,4 @@ func GetRoleDisplayName(role string) string {
 }
 
 // GetRoleDescription returns a description of what a role can do
-func GetRoleDescription(role string) string {
-	switch role {
-	case models.RoleAdmin:
-		return "Full access to all features including user management"
-	case models.RoleOperator:
-		return "Can manage BMCs and execute power actions, but cannot manage users"
-	case models.RoleViewer:
-		return "Read-only access to view BMCs and their status"
-	default:
-		return "Unknown role"
-	}
-}
+// (Removed GetRoleDescription: unused)

--- a/pkg/auth/rbac.go
+++ b/pkg/auth/rbac.go
@@ -31,7 +31,6 @@ func IsOperator(user *models.User) bool {
 }
 
 // IsViewer checks if the user has any valid role (can view)
-// (Removed unused RBAC helper functions: IsViewer, CanManageUsers, CanManageBMCs, CanExecutePowerActions, CanViewBMCs, CanChangeOwnPassword)
 
 // GetRoleDisplayName returns a human-friendly name for a role
 func GetRoleDisplayName(role string) string {
@@ -48,4 +47,3 @@ func GetRoleDisplayName(role string) string {
 }
 
 // GetRoleDescription returns a description of what a role can do
-// (Removed GetRoleDescription: unused)


### PR DESCRIPTION
This PR removes unused exports flagged by deadcode, unexports test-only helpers, and documents the deadcode protocol & allowlist in AGENTS.md.

What's in here:
- Remove unused RBAC helpers and operator middleware
- Unexport test-only password helper
- Add NOTE comments to intentional DB helpers
- Add AGENTS.md section: how to run deadcode, allowlist rationale, PR checklist
- Address review feedback: drop stale explanatory comments

Validation:
- python3 build.py validate → PASS (format, lint, tests, build)
- Coverage: ~55.8%
- deadcode re-run leaves only allowlisted items

Next steps:
- Merge when green