### PR TITLE
fix(web): dedupe BMC Details title on details page

### DIFF
--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -876,7 +876,8 @@ func (h *Handler) handleBMCDetails(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := PageData{
-		Title: fmt.Sprintf("BMC Details - %s", bmcName),
+		// Title should be just the BMC name; the template adds the 'BMC Details - ' prefix
+		Title: bmcName,
 	}
 	user := getUserFromContext(r.Context())
 	if user != nil {

--- a/internal/web/web_test.go
+++ b/internal/web/web_test.go
@@ -526,7 +526,7 @@ func TestHandleBMCDetails(t *testing.T) {
 		}
 
 		body := w.Body.String()
-		if !strings.Contains(body, "BMC Details - BMC Details - test-details-bmc") {
+		if !strings.Contains(body, "BMC Details - test-details-bmc") {
 			t.Error("Response should contain BMC details title")
 		}
 		// Drag-and-drop Boot Order list should be present


### PR DESCRIPTION
Fixes a minor UI bug where the BMC Details page title rendered as "BMC Details - BMC Details - <name>".

Change summary:
- Set PageData.Title to the BMC name only in handleBMCDetails
- Keep the template header "BMC Details - {{.Title}}" so it renders once
- Update web test expectation accordingly

Validation:
- python3 build.py validate → PASS (format, lint, tests, build)
- Coverage unchanged at ~55.8%

No behavior changes beyond the header text rendering.