### PR TITLE
phase1: Redfish compliance scaffolding ($metadata, Registries, headers, UUID, ExtendedInfo)

### DIFF
--- a/pkg/redfish/types.go
+++ b/pkg/redfish/types.go
@@ -34,6 +34,8 @@ type ServiceRoot struct {
 	Managers           ODataIDRef       `json:"Managers"`
 	SessionService     ODataIDRef       `json:"SessionService"`
 	AggregationService *ODataIDRef      `json:"AggregationService,omitempty"`
+	Registries         *ODataIDRef      `json:"Registries,omitempty"`
+	JsonSchemas        *ODataIDRef      `json:"JsonSchemas,omitempty"`
 	Links              ServiceRootLinks `json:"Links"`
 }
 


### PR DESCRIPTION
Phase 1 for design 018.

- Add `OData-Version: 4.0` header to Redfish JSON responses
- Persist a stable service UUID in DB (settings table + helpers) and return it on ServiceRoot
- Add minimal `$metadata` endpoint (CSDL skeleton) at `/redfish/v1/$metadata`
- Add Registries collection and Base registry stub; link from ServiceRoot
- Add SchemaStore root stub and link from ServiceRoot
- Return `@Message.ExtendedInfo` in error responses with Base MessageIds and basic severity/resolution mapping

Notes:
- Schemas/registries are minimal stubs for now; follow-ups will embed official DMTF artifacts.
- All tests pass locally via `python3 build.py validate` (lint/security tools not installed).

Follow-up (Phase 1.1):
- Replace stubs with embedded official CSDL/JSON schema and Base registry files
- Expand `$metadata` to cover all exposed entities and contexts