### PR TITLE
Redfish: EventService and TaskService stubs + ServiceRoot links

### DIFF
--- a/docs/3_api.md
+++ b/docs/3_api.md
@@ -25,6 +25,9 @@ The API supports two authentication methods:
 ## Core Redfish Endpoints
 
 - `GET /redfish/v1/`: Service root.
+- `GET /redfish/v1/EventService`: Minimal EventService stub (ServiceEnabled=false).
+- `GET /redfish/v1/TaskService`: Minimal TaskService stub.
+- `GET /redfish/v1/TaskService/Tasks`: Empty Tasks collection.
 - `GET /redfish/v1/Managers`: List of aggregated managers from all BMCs.
 - `GET /redfish/v1/Systems`: List of aggregated systems from all BMCs.
 - `GET /redfish/v1/Managers/{bmc-name}`: Proxy to a specific BMC manager.

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -119,6 +119,18 @@ func (h *Handler) handleRedfish(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Handle EventService endpoints (stub)
+	if strings.HasPrefix(path, "/v1/EventService") {
+		h.handleEventService(w, r, path, user)
+		return
+	}
+
+	// Handle TaskService endpoints (stub)
+	if strings.HasPrefix(path, "/v1/TaskService") {
+		h.handleTaskService(w, r, path, user)
+		return
+	}
+
 	// Handle aggregator-specific endpoints
 	h.handleAggregatorEndpoints(w, r, path, user)
 }
@@ -257,6 +269,9 @@ func (h *Handler) handleServiceRoot(w http.ResponseWriter, r *http.Request) {
 	serviceRoot.JsonSchemas = &redfish.ODataIDRef{ODataID: "/redfish/v1/SchemaStore"}
 	// Phase 2 link
 	serviceRoot.AccountService = &redfish.ODataIDRef{ODataID: "/redfish/v1/AccountService"}
+	// Phase 3 links (stubs)
+	serviceRoot.EventService = &redfish.ODataIDRef{ODataID: "/redfish/v1/EventService"}
+	serviceRoot.TaskService = &redfish.ODataIDRef{ODataID: "/redfish/v1/TaskService"}
 
 	h.writeJSONResponse(w, http.StatusOK, serviceRoot)
 }
@@ -739,6 +754,74 @@ func (h *Handler) handleGetRole(w http.ResponseWriter, r *http.Request, roleID s
 	default:
 		h.writeErrorResponse(w, http.StatusNotFound, "Base.1.0.ResourceNotFound", "Role not found")
 	}
+}
+
+// handleEventService provides a minimal EventService stub
+func (h *Handler) handleEventService(w http.ResponseWriter, r *http.Request, path string, user *models.User) {
+	subPath := strings.TrimPrefix(path, "/v1/EventService")
+
+	// Root resource
+	if subPath == "" || subPath == "/" {
+		if r.Method != http.MethodGet {
+			h.writeErrorResponse(w, http.StatusMethodNotAllowed, "Base.1.0.MethodNotAllowed", "Method not allowed")
+			return
+		}
+		svc := redfish.EventService{
+			ODataContext:   "/redfish/v1/$metadata#EventService.EventService",
+			ODataID:        "/redfish/v1/EventService",
+			ODataType:      "#EventService.v1_0_0.EventService",
+			ID:             "EventService",
+			Name:           "Event Service",
+			ServiceEnabled: false,
+		}
+		h.writeJSONResponse(w, http.StatusOK, svc)
+		return
+	}
+
+	h.writeErrorResponse(w, http.StatusNotFound, "Base.1.0.ResourceNotFound", "Resource not found")
+}
+
+// handleTaskService provides a minimal TaskService stub
+func (h *Handler) handleTaskService(w http.ResponseWriter, r *http.Request, path string, user *models.User) {
+	subPath := strings.TrimPrefix(path, "/v1/TaskService")
+
+	// Root resource
+	if subPath == "" || subPath == "/" {
+		if r.Method != http.MethodGet {
+			h.writeErrorResponse(w, http.StatusMethodNotAllowed, "Base.1.0.MethodNotAllowed", "Method not allowed")
+			return
+		}
+		svc := redfish.TaskService{
+			ODataContext: "/redfish/v1/$metadata#TaskService.TaskService",
+			ODataID:      "/redfish/v1/TaskService",
+			ODataType:    "#TaskService.v1_0_0.TaskService",
+			ID:           "TaskService",
+			Name:         "Task Service",
+			Tasks:        redfish.ODataIDRef{ODataID: "/redfish/v1/TaskService/Tasks"},
+		}
+		h.writeJSONResponse(w, http.StatusOK, svc)
+		return
+	}
+
+	// Tasks collection
+	if subPath == "/Tasks" || subPath == "/Tasks/" {
+		if r.Method != http.MethodGet {
+			h.writeErrorResponse(w, http.StatusMethodNotAllowed, "Base.1.0.MethodNotAllowed", "Method not allowed")
+			return
+		}
+		coll := redfish.Collection{
+			ODataContext: "/redfish/v1/$metadata#TaskCollection.TaskCollection",
+			ODataID:      "/redfish/v1/TaskService/Tasks",
+			ODataType:    "#TaskCollection.TaskCollection",
+			Name:         "Task Collection",
+			Members:      []redfish.ODataIDRef{},
+			MembersCount: 0,
+		}
+		h.writeJSONResponse(w, http.StatusOK, coll)
+		return
+	}
+
+	h.writeErrorResponse(w, http.StatusNotFound, "Base.1.0.ResourceNotFound", "Resource not found")
 }
 
 // toRedfishAccount converts models.User to Redfish ManagerAccount

--- a/internal/api/event_task_service_test.go
+++ b/internal/api/event_task_service_test.go
@@ -1,0 +1,150 @@
+// Shoal is a Redfish aggregator service.
+// Copyright (C) 2025  Matthew Burns
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestServiceRootHasEventAndTaskLinks(t *testing.T) {
+	handler, db := setupTestAPI(t)
+	defer func() { _ = db.Close() }()
+
+	// Login to get token
+	loginBody, _ := json.Marshal(map[string]string{"UserName": "admin", "Password": "admin"})
+	req := httptest.NewRequest(http.MethodPost, "/redfish/v1/SessionService/Sessions", bytes.NewReader(loginBody))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201 Created on login, got %d", rec.Code)
+	}
+	token := rec.Header().Get("X-Auth-Token")
+
+	// Fetch service root (no auth required, but ensure headers set uniformly)
+	req = httptest.NewRequest(http.MethodGet, "/redfish/v1/", nil)
+	if token != "" {
+		req.Header.Set("X-Auth-Token", token)
+	}
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 for service root, got %d", rec.Code)
+	}
+	var root map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &root); err != nil {
+		t.Fatalf("failed to parse service root: %v", err)
+	}
+	if _, ok := root["EventService"].(map[string]any); !ok {
+		t.Fatalf("expected EventService link in service root")
+	}
+	if _, ok := root["TaskService"].(map[string]any); !ok {
+		t.Fatalf("expected TaskService link in service root")
+	}
+}
+
+func TestEventServiceStub(t *testing.T) {
+	handler, db := setupTestAPI(t)
+	defer func() { _ = db.Close() }()
+
+	// EventService root requires auth via top-level gate
+	req := httptest.NewRequest(http.MethodGet, "/redfish/v1/EventService", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 for unauthenticated EventService root, got %d", rec.Code)
+	}
+
+	// Login and fetch
+	loginBody, _ := json.Marshal(map[string]string{"UserName": "admin", "Password": "admin"})
+	req = httptest.NewRequest(http.MethodPost, "/redfish/v1/SessionService/Sessions", bytes.NewReader(loginBody))
+	req.Header.Set("Content-Type", "application/json")
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201 Created on login, got %d", rec.Code)
+	}
+	token := rec.Header().Get("X-Auth-Token")
+
+	req = httptest.NewRequest(http.MethodGet, "/redfish/v1/EventService", nil)
+	req.Header.Set("X-Auth-Token", token)
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 for EventService root, got %d", rec.Code)
+	}
+	var svc map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &svc); err != nil {
+		t.Fatalf("failed to parse EventService: %v", err)
+	}
+	if svc["ServiceEnabled"] != false {
+		t.Fatalf("expected ServiceEnabled=false in EventService stub")
+	}
+}
+
+func TestTaskServiceStub(t *testing.T) {
+	handler, db := setupTestAPI(t)
+	defer func() { _ = db.Close() }()
+
+	// Unauthenticated should be 401
+	req := httptest.NewRequest(http.MethodGet, "/redfish/v1/TaskService", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 for unauthenticated TaskService root, got %d", rec.Code)
+	}
+
+	// Login
+	loginBody, _ := json.Marshal(map[string]string{"UserName": "admin", "Password": "admin"})
+	req = httptest.NewRequest(http.MethodPost, "/redfish/v1/SessionService/Sessions", bytes.NewReader(loginBody))
+	req.Header.Set("Content-Type", "application/json")
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201 Created on login, got %d", rec.Code)
+	}
+	token := rec.Header().Get("X-Auth-Token")
+
+	// Fetch TaskService root
+	req = httptest.NewRequest(http.MethodGet, "/redfish/v1/TaskService", nil)
+	req.Header.Set("X-Auth-Token", token)
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 for TaskService root, got %d", rec.Code)
+	}
+
+	// Fetch Tasks collection
+	req = httptest.NewRequest(http.MethodGet, "/redfish/v1/TaskService/Tasks", nil)
+	req.Header.Set("X-Auth-Token", token)
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 for TaskService Tasks collection, got %d", rec.Code)
+	}
+	var coll map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &coll); err != nil {
+		t.Fatalf("failed to parse Tasks collection: %v", err)
+	}
+	if count, ok := coll["Members@odata.count"].(float64); !ok || int(count) != 0 {
+		t.Fatalf("expected empty Tasks collection, got %v", coll["Members@odata.count"])
+	}
+}

--- a/pkg/redfish/types.go
+++ b/pkg/redfish/types.go
@@ -37,6 +37,8 @@ type ServiceRoot struct {
 	Registries         *ODataIDRef      `json:"Registries,omitempty"`
 	JsonSchemas        *ODataIDRef      `json:"JsonSchemas,omitempty"`
 	AccountService     *ODataIDRef      `json:"AccountService,omitempty"`
+	EventService       *ODataIDRef      `json:"EventService,omitempty"`
+	TaskService        *ODataIDRef      `json:"TaskService,omitempty"`
 	Links              ServiceRootLinks `json:"Links"`
 }
 
@@ -157,4 +159,34 @@ type ConnectionMethodVariant struct {
 type ConnectionAuthentication struct {
 	Username string `json:"Username"`
 	Password string `json:"Password"`
+}
+
+// EventService represents Redfish EventService (stub)
+type EventService struct {
+	ODataContext   string `json:"@odata.context"`
+	ODataID        string `json:"@odata.id"`
+	ODataType      string `json:"@odata.type"`
+	ID             string `json:"Id"`
+	Name           string `json:"Name"`
+	ServiceEnabled bool   `json:"ServiceEnabled"`
+}
+
+// TaskService represents Redfish TaskService (stub)
+type TaskService struct {
+	ODataContext string     `json:"@odata.context"`
+	ODataID      string     `json:"@odata.id"`
+	ODataType    string     `json:"@odata.type"`
+	ID           string     `json:"Id"`
+	Name         string     `json:"Name"`
+	Tasks        ODataIDRef `json:"Tasks"`
+}
+
+// Task represents a Redfish Task (stub)
+type Task struct {
+	ODataContext string `json:"@odata.context"`
+	ODataID      string `json:"@odata.id"`
+	ODataType    string `json:"@odata.type"`
+	ID           string `json:"Id"`
+	Name         string `json:"Name"`
+	TaskState    string `json:"TaskState"`
 }


### PR DESCRIPTION
This PR completes the optional Phase 3 stubs from design/018:

- Add EventService and TaskService stubs
  - GET /redfish/v1/EventService returns minimal service (ServiceEnabled=false)
  - GET /redfish/v1/TaskService returns minimal service
  - GET /redfish/v1/TaskService/Tasks returns an empty collection
- Wire ServiceRoot links to EventService and TaskService
- Add tests for these endpoints and ServiceRoot links
- Update API docs to include the new endpoints

Validation:
- python3 build.py validate passes locally
- Test coverage increased slightly to ~55.5%

Notes:
- These are intentionally minimal stubs to satisfy common Redfish validators and client expectations. Full eventing and task orchestration remain out of scope for now.

License headers have been included on new files per AGENTS.md.