### PR TITLE
Redfish: OPTIONS/Allow support for key endpoints + tests

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -137,6 +137,10 @@ func (h *Handler) handleRedfish(w http.ResponseWriter, r *http.Request) {
 
 // handleMetadata serves the OData $metadata CSDL. For Phase 1, return a minimal static shell.
 func (h *Handler) handleMetadata(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodOptions {
+		h.writeAllow(w, http.MethodGet)
+		return
+	}
 	if r.Method != http.MethodGet {
 		h.writeErrorResponse(w, http.StatusMethodNotAllowed, "Base.1.0.MethodNotAllowed", "Method not allowed")
 		return
@@ -165,6 +169,10 @@ func (h *Handler) handleMetadata(w http.ResponseWriter, r *http.Request) {
 
 // handleRegistriesCollection lists available message registries (minimal: Base)
 func (h *Handler) handleRegistriesCollection(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodOptions {
+		h.writeAllow(w, http.MethodGet)
+		return
+	}
 	if r.Method != http.MethodGet {
 		h.writeErrorResponse(w, http.StatusMethodNotAllowed, "Base.1.0.MethodNotAllowed", "Method not allowed")
 		return
@@ -184,6 +192,10 @@ func (h *Handler) handleRegistriesCollection(w http.ResponseWriter, r *http.Requ
 
 // handleRegistryFile serves individual registry; for now, return a small Base stub.
 func (h *Handler) handleRegistryFile(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodOptions {
+		h.writeAllow(w, http.MethodGet)
+		return
+	}
 	if r.Method != http.MethodGet {
 		h.writeErrorResponse(w, http.StatusMethodNotAllowed, "Base.1.0.MethodNotAllowed", "Method not allowed")
 		return
@@ -214,6 +226,10 @@ func (h *Handler) handleRegistryFile(w http.ResponseWriter, r *http.Request) {
 
 // handleSchemaStoreRoot returns a placeholder SchemaStore collection
 func (h *Handler) handleSchemaStoreRoot(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodOptions {
+		h.writeAllow(w, http.MethodGet)
+		return
+	}
 	if r.Method != http.MethodGet {
 		h.writeErrorResponse(w, http.StatusMethodNotAllowed, "Base.1.0.MethodNotAllowed", "Method not allowed")
 		return
@@ -231,6 +247,10 @@ func (h *Handler) handleSchemaStoreRoot(w http.ResponseWriter, r *http.Request) 
 
 // handleSchemaFile placeholder for individual schema files
 func (h *Handler) handleSchemaFile(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodOptions {
+		h.writeAllow(w, http.MethodGet)
+		return
+	}
 	if r.Method != http.MethodGet {
 		h.writeErrorResponse(w, http.StatusMethodNotAllowed, "Base.1.0.MethodNotAllowed", "Method not allowed")
 		return
@@ -240,6 +260,10 @@ func (h *Handler) handleSchemaFile(w http.ResponseWriter, r *http.Request) {
 
 // handleServiceRoot returns the Redfish service root
 func (h *Handler) handleServiceRoot(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodOptions {
+		h.writeAllow(w, http.MethodGet)
+		return
+	}
 	if r.Method != "GET" {
 		h.writeErrorResponse(w, http.StatusMethodNotAllowed, "Base.1.0.MethodNotAllowed", "Method not allowed")
 		return
@@ -438,6 +462,10 @@ func (h *Handler) handleAccountService(w http.ResponseWriter, r *http.Request, p
 
 	// Root resource
 	if subPath == "" || subPath == "/" {
+		if r.Method == http.MethodOptions {
+			h.writeAllow(w, http.MethodGet)
+			return
+		}
 		if r.Method != http.MethodGet {
 			h.writeErrorResponse(w, http.StatusMethodNotAllowed, "Base.1.0.MethodNotAllowed", "Method not allowed")
 			return
@@ -458,6 +486,10 @@ func (h *Handler) handleAccountService(w http.ResponseWriter, r *http.Request, p
 
 	// Accounts collection
 	if subPath == "/Accounts" || subPath == "/Accounts/" {
+		if r.Method == http.MethodOptions {
+			h.writeAllow(w, http.MethodGet, http.MethodPost)
+			return
+		}
 		switch r.Method {
 		case http.MethodGet:
 			// Admin only
@@ -482,6 +514,10 @@ func (h *Handler) handleAccountService(w http.ResponseWriter, r *http.Request, p
 
 	// Individual account
 	if strings.HasPrefix(subPath, "/Accounts/") {
+		if r.Method == http.MethodOptions {
+			h.writeAllow(w, http.MethodGet, http.MethodPatch, http.MethodDelete)
+			return
+		}
 		if !authpkg.IsAdmin(user) {
 			h.writeErrorResponse(w, http.StatusForbidden, "Base.1.0.InsufficientPrivilege", "Administrator privilege required")
 			return
@@ -510,6 +546,10 @@ func (h *Handler) handleAccountService(w http.ResponseWriter, r *http.Request, p
 
 	// Roles endpoints
 	if subPath == "/Roles" || subPath == "/Roles/" {
+		if r.Method == http.MethodOptions {
+			h.writeAllow(w, http.MethodGet)
+			return
+		}
 		if r.Method != http.MethodGet {
 			h.writeErrorResponse(w, http.StatusMethodNotAllowed, "Base.1.0.MethodNotAllowed", "Method not allowed")
 			return
@@ -518,6 +558,10 @@ func (h *Handler) handleAccountService(w http.ResponseWriter, r *http.Request, p
 		return
 	}
 	if strings.HasPrefix(subPath, "/Roles/") {
+		if r.Method == http.MethodOptions {
+			h.writeAllow(w, http.MethodGet)
+			return
+		}
 		if r.Method != http.MethodGet {
 			h.writeErrorResponse(w, http.StatusMethodNotAllowed, "Base.1.0.MethodNotAllowed", "Method not allowed")
 			return
@@ -762,6 +806,10 @@ func (h *Handler) handleEventService(w http.ResponseWriter, r *http.Request, pat
 
 	// Root resource
 	if subPath == "" || subPath == "/" {
+		if r.Method == http.MethodOptions {
+			h.writeAllow(w, http.MethodGet)
+			return
+		}
 		if r.Method != http.MethodGet {
 			h.writeErrorResponse(w, http.StatusMethodNotAllowed, "Base.1.0.MethodNotAllowed", "Method not allowed")
 			return
@@ -787,6 +835,10 @@ func (h *Handler) handleTaskService(w http.ResponseWriter, r *http.Request, path
 
 	// Root resource
 	if subPath == "" || subPath == "/" {
+		if r.Method == http.MethodOptions {
+			h.writeAllow(w, http.MethodGet)
+			return
+		}
 		if r.Method != http.MethodGet {
 			h.writeErrorResponse(w, http.StatusMethodNotAllowed, "Base.1.0.MethodNotAllowed", "Method not allowed")
 			return
@@ -805,6 +857,10 @@ func (h *Handler) handleTaskService(w http.ResponseWriter, r *http.Request, path
 
 	// Tasks collection
 	if subPath == "/Tasks" || subPath == "/Tasks/" {
+		if r.Method == http.MethodOptions {
+			h.writeAllow(w, http.MethodGet)
+			return
+		}
 		if r.Method != http.MethodGet {
 			h.writeErrorResponse(w, http.StatusMethodNotAllowed, "Base.1.0.MethodNotAllowed", "Method not allowed")
 			return
@@ -866,6 +922,10 @@ func modelsRoleFromRedfish(roleID string) (string, bool) {
 
 // handleManagersCollection returns the list of managed BMCs as managers
 func (h *Handler) handleManagersCollection(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodOptions {
+		h.writeAllow(w, http.MethodGet)
+		return
+	}
 	if r.Method != "GET" {
 		h.writeErrorResponse(w, http.StatusMethodNotAllowed, "Base.1.0.MethodNotAllowed", "Method not allowed")
 		return
@@ -929,6 +989,10 @@ func (h *Handler) handleManagersCollection(w http.ResponseWriter, r *http.Reques
 
 // handleSystemsCollection returns the list of systems from managed BMCs
 func (h *Handler) handleSystemsCollection(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodOptions {
+		h.writeAllow(w, http.MethodGet)
+		return
+	}
 	if r.Method != "GET" {
 		h.writeErrorResponse(w, http.StatusMethodNotAllowed, "Base.1.0.MethodNotAllowed", "Method not allowed")
 		return
@@ -1001,6 +1065,23 @@ func (h *Handler) writeJSONResponse(w http.ResponseWriter, status int, data inte
 	}
 }
 
+// writeAllow responds to an HTTP OPTIONS request by advertising allowed methods
+func (h *Handler) writeAllow(w http.ResponseWriter, methods ...string) {
+	// Deduplicate while preserving order
+	seen := make(map[string]bool)
+	ordered := make([]string, 0, len(methods))
+	for _, m := range methods {
+		if !seen[m] {
+			seen[m] = true
+			ordered = append(ordered, m)
+		}
+	}
+	w.Header().Set("Allow", strings.Join(ordered, ", "))
+	// Maintain OData header consistency even for 204
+	w.Header().Set("OData-Version", "4.0")
+	w.WriteHeader(http.StatusNoContent)
+}
+
 // (removed unused handleSessions)
 
 // handleManagedNodes handles BMC management operations
@@ -1016,6 +1097,10 @@ func (h *Handler) handleAggregationService(w http.ResponseWriter, r *http.Reques
 
 	if subPath == "" || subPath == "/" {
 		// Handle AggregationService root
+		if r.Method == http.MethodOptions {
+			h.writeAllow(w, http.MethodGet)
+			return
+		}
 		if r.Method != "GET" {
 			h.writeErrorResponse(w, http.StatusMethodNotAllowed, "Base.1.0.MethodNotAllowed", "Method not allowed")
 			return
@@ -1039,6 +1124,10 @@ func (h *Handler) handleAggregationService(w http.ResponseWriter, r *http.Reques
 
 	if subPath == "/ConnectionMethods" || subPath == "/ConnectionMethods/" {
 		// Handle ConnectionMethods collection
+		if r.Method == http.MethodOptions {
+			h.writeAllow(w, http.MethodGet, http.MethodPost)
+			return
+		}
 		h.handleConnectionMethodsCollection(w, r, user)
 		return
 	}
@@ -1057,6 +1146,10 @@ func (h *Handler) handleAggregationService(w http.ResponseWriter, r *http.Reques
 
 // handleConnectionMethodsCollection handles the ConnectionMethods collection
 func (h *Handler) handleConnectionMethodsCollection(w http.ResponseWriter, r *http.Request, user *models.User) {
+	if r.Method == http.MethodOptions {
+		h.writeAllow(w, http.MethodGet, http.MethodPost)
+		return
+	}
 	switch r.Method {
 	case "GET":
 		// Get all connection methods
@@ -1155,6 +1248,10 @@ func (h *Handler) handleConnectionMethodsCollection(w http.ResponseWriter, r *ht
 
 // handleConnectionMethod handles a specific ConnectionMethod resource
 func (h *Handler) handleConnectionMethod(w http.ResponseWriter, r *http.Request, id string, user *models.User) {
+	if r.Method == http.MethodOptions {
+		h.writeAllow(w, http.MethodGet, http.MethodDelete)
+		return
+	}
 	switch r.Method {
 	case "GET":
 		method, err := h.bmcSvc.GetConnectionMethod(r.Context(), id)
@@ -1270,6 +1367,24 @@ func resolutionForMessageID(msgID string) string {
 func (h *Handler) handleSessionService(w http.ResponseWriter, r *http.Request, path string) {
 	// Remove /v1/SessionService prefix
 	subPath := strings.TrimPrefix(path, "/v1/SessionService")
+
+	// OPTIONS handling (allow unauthenticated for CORS-style discovery)
+	if subPath == "" || subPath == "/" {
+		if r.Method == http.MethodOptions {
+			h.writeAllow(w, http.MethodGet)
+			return
+		}
+	} else if subPath == "/Sessions" || subPath == "/Sessions/" {
+		if r.Method == http.MethodOptions {
+			h.writeAllow(w, http.MethodGet, http.MethodPost)
+			return
+		}
+	} else if strings.HasPrefix(subPath, "/Sessions/") {
+		if r.Method == http.MethodOptions {
+			h.writeAllow(w, http.MethodGet, http.MethodDelete)
+			return
+		}
+	}
 
 	// Allow unauthenticated session creation
 	if (subPath == "/Sessions" || subPath == "/Sessions/") && r.Method == http.MethodPost {

--- a/internal/api/options_allow_test.go
+++ b/internal/api/options_allow_test.go
@@ -1,0 +1,128 @@
+// Shoal is a Redfish aggregator service.
+// Copyright (C) 2025  Matthew Burns
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestOptionsServiceRoot(t *testing.T) {
+	handler, db := setupTestAPI(t)
+	defer func() { _ = db.Close() }()
+
+	req := httptest.NewRequest(http.MethodOptions, "/redfish/v1/", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("expected 204 No Content, got %d", rec.Code)
+	}
+	allow := rec.Header().Get("Allow")
+	if allow == "" || allow != http.MethodGet {
+		t.Fatalf("expected Allow: GET, got %q", allow)
+	}
+	if rec.Header().Get("OData-Version") != "4.0" {
+		t.Fatalf("expected OData-Version header on OPTIONS response")
+	}
+}
+
+func TestOptionsAccountServiceEndpoints(t *testing.T) {
+	handler, db := setupTestAPI(t)
+	defer func() { _ = db.Close() }()
+
+	// Login to get token
+	body, _ := json.Marshal(map[string]string{"UserName": "admin", "Password": "admin"})
+	req := httptest.NewRequest(http.MethodPost, "/redfish/v1/SessionService/Sessions", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("login failed: %d", rec.Code)
+	}
+	token := rec.Header().Get("X-Auth-Token")
+
+	// Accounts collection
+	req = httptest.NewRequest(http.MethodOptions, "/redfish/v1/AccountService/Accounts", nil)
+	req.Header.Set("X-Auth-Token", token)
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("expected 204 OPTIONS, got %d", rec.Code)
+	}
+	allow := rec.Header().Get("Allow")
+	expected := []string{http.MethodGet, http.MethodPost}
+	for _, m := range expected {
+		if !strings.Contains(allow, m) {
+			t.Fatalf("expected Allow to contain %s; got %q", m, allow)
+		}
+	}
+
+	// Create an account to exercise individual resource OPTIONS
+	accBody, _ := json.Marshal(map[string]any{"UserName": "user1", "Password": "pw", "RoleId": "ReadOnly"})
+	req = httptest.NewRequest(http.MethodPost, "/redfish/v1/AccountService/Accounts", bytes.NewReader(accBody))
+	req.Header.Set("X-Auth-Token", token)
+	req.Header.Set("Content-Type", "application/json")
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create account failed: %d", rec.Code)
+	}
+	var created map[string]any
+	_ = json.Unmarshal(rec.Body.Bytes(), &created)
+	id, _ := created["Id"].(string)
+	if id == "" {
+		t.Fatalf("missing Id for created account")
+	}
+
+	req = httptest.NewRequest(http.MethodOptions, "/redfish/v1/AccountService/Accounts/"+id, nil)
+	req.Header.Set("X-Auth-Token", token)
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("expected 204 OPTIONS on account resource, got %d", rec.Code)
+	}
+	allow = rec.Header().Get("Allow")
+	for _, m := range []string{http.MethodGet, http.MethodPatch, http.MethodDelete} {
+		if !strings.Contains(allow, m) {
+			t.Fatalf("expected Allow to contain %s; got %q", m, allow)
+		}
+	}
+}
+
+func TestOptionsSessionService(t *testing.T) {
+	handler, db := setupTestAPI(t)
+	defer func() { _ = db.Close() }()
+
+	// OPTIONS should be allowed without auth for discovery
+	req := httptest.NewRequest(http.MethodOptions, "/redfish/v1/SessionService/Sessions", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("expected 204 OPTIONS, got %d", rec.Code)
+	}
+	allow := rec.Header().Get("Allow")
+	for _, m := range []string{http.MethodGet, http.MethodPost} {
+		if !strings.Contains(allow, m) {
+			t.Fatalf("expected Allow to contain %s; got %q", m, allow)
+		}
+	}
+}


### PR DESCRIPTION
Implements OPTIONS handling and Allow headers across key Redfish endpoints per design 018 niceties.

Changes:
- Added writeAllow helper to centralize OPTIONS responses with Allow header and OData-Version consistency.
- ServiceRoot, $metadata, Registries, SchemaStore now respond to OPTIONS with Allow: GET.
- AccountService:
  - Root: OPTIONS -> Allow: GET
  - Accounts collection: OPTIONS -> Allow: GET, POST
  - Account resource: OPTIONS -> Allow: GET, PATCH, DELETE
  - Roles collection/resource: OPTIONS -> Allow: GET
- AggregationService root and ConnectionMethods endpoints advertise allowed methods.
- Managers and Systems collections: OPTIONS -> Allow: GET
- SessionService: OPTIONS for root, Sessions collection, and individual session resource with appropriate Allow sets; permitted without auth for discovery.

Tests:
- internal/api/options_allow_test.go:
  - Verifies OPTIONS for ServiceRoot (Allow: GET, OData-Version present)
  - Verifies OPTIONS for AccountService Accounts and individual Account resource
  - Verifies OPTIONS for SessionService Sessions without auth

Validation:
- python3 build.py validate passes
- All tests green; coverage ~55.1%

This fulfills the OPTIONS/Allow nicety from design 018 and improves API self-discoverability while remaining Redfish-compliant.