### PR TITLE
feat(redfish): serve embedded registries and schemas via internal assets

### DIFF
--- a/static/redfish/Base.json
+++ b/static/redfish/Base.json
@@ -1,0 +1,15 @@
+{
+  "Id": "Base",
+  "Name": "Base Message Registry (Shoal minimal)",
+  "Language": "en",
+  "OwningEntity": "DMTF",
+  "RegistryPrefix": "Base",
+  "RegistryVersion": "1.0.0",
+  "Messages": {
+    "GeneralError": {"Message": "A general error has occurred. See ExtendedInfo for more information.", "NumberOfArgs": 0, "Resolution": "See ExtendedInfo for more information.", "Severity": "Critical"},
+    "ResourceNotFound": {"Message": "The resource was not found.", "NumberOfArgs": 1, "Resolution": "Provide a valid resource and resubmit the request.", "Severity": "Warning"},
+    "MethodNotAllowed": {"Message": "The HTTP method is not allowed on the resource.", "NumberOfArgs": 0, "Resolution": "Change the method and resubmit the request.", "Severity": "Warning"},
+    "Unauthorized": {"Message": "The request requires user authentication.", "NumberOfArgs": 0, "Resolution": "Provide valid credentials and resubmit the request.", "Severity": "Critical"},
+    "InsufficientPrivilege": {"Message": "The user does not have sufficient privilege to perform the requested operation.", "NumberOfArgs": 0, "Resolution": "Use an account with the required privilege or contact your administrator.", "Severity": "Critical"}
+  }
+}


### PR DESCRIPTION
Embed initial Redfish assets and serve from embedded FS per design 018:

- Embed minimal Base message registry as static/redfish/Base.json (to be replaced by official DMTF registry later)
- Serve /redfish/v1/Registries dynamically by discovering embedded registry files
- Serve /redfish/v1/Registries/<Name> and nested paths from embedded FS
- Extend SchemaStore to discover and serve embedded JSON schema files under static/schemas (placeholder for upcoming DMTF CSDL/JSON-Schema assets)

Notes:
- No external deps added; uses existing internal/assets embed FS
- Tests remain green; validation pipeline passes (format, lint, tests, build)

Follow-ups:
- Replace minimal Base.json with official DMTF Base registry
- Embed DMTF CSDL and JSON Schema sets; update $metadata handler to serve real CSDL
- Add tests validating schema/registry discovery and content types
