### PR TITLE
feat: Phase 2 thesis spike — BMC provisioning + SOL feedback

### DIFF
--- a/docs/lab-runbook.md
+++ b/docs/lab-runbook.md
@@ -30,6 +30,33 @@ If `vault.yml` is encrypted, add `--ask-vault-pass` (or `--vault-password-file <
 ansible-playbook -i infra/ansible/inventory/lab-vm.yml infra/ansible/playbooks/up.yml
 ansible-playbook -i infra/ansible/inventory/lab-vm.yml infra/ansible/playbooks/smoke.yml
 ```
+`up.yml` ends by building/publishing the Phase 2 marker ISO to `/srv/iso/shoal-marker.iso`
+(via `build_marker_iso.yml`). Rebuild ISO only:
+
+```bash
+ansible-playbook -i infra/ansible/inventory/lab-vm.yml \
+  infra/ansible/playbooks/build_marker_iso.yml
+```
+
+### Phase 2 app smoke (from L0 against VM lab)
+```bash
+export SHOAL_BMC_USERNAME=...   # vault
+export SHOAL_BMC_PASSWORD=...
+export SHOAL_TELEMETRY_DATABASE_URL='postgres://shoal:…@192.168.122.100:5433/shoal_telemetry?sslmode=disable'
+export SHOAL_SERIAL_SSH_HOST=192.168.122.100
+export SHOAL_SERIAL_SSH_KEY=$HOME/.ssh/shoal_lab_vm
+
+go test ./internal/deploy/job ./internal/common/redfish ./internal/deploy/jobstore \
+  -tags=integration -count=1 -v
+
+go run ./cmd/shoal deploy run \
+  -device-id shoal-node-1 \
+  -bmc-url http://192.168.122.100:8001 \
+  -serial-target shoal-node-1 \
+  -iso-url http://192.168.124.1:8080/shoal-marker.iso
+```
+
+See also [phase2-live-image.md](./phase2-live-image.md).
 
 ## 2) Fast stop (teardown / clean slate)
 ```bash

--- a/docs/phase2-live-image.md
+++ b/docs/phase2-live-image.md
@@ -1,0 +1,39 @@
+# Phase 2 live image (marker producer)
+
+Phase 2 needs a minimal live image that emits `SHOAL|…` markers over serial
+(`console=ttyS0,115200n8`) and is published to the lab ISO HTTP tree (`:8080`).
+
+## Protocol
+
+```
+SHOAL|<schema_ver>|<seq>|<iso8601_utc>|<phase>|<percent>|<state>|<detail>
+```
+
+See design §4.3. Reference emitter: [`infra/scripts/marker-producer.sh`](../infra/scripts/marker-producer.sh).
+
+## Publish contract
+
+1. Build ISO (primary: Ansible on lab VM; alternate: workstation).
+2. Copy into lab ISO dir (e.g. `/srv/iso/shoal-marker.iso`).
+3. BMC-reachable URL examples:
+   - VM-hosted: `http://192.168.122.100:8080/shoal-marker.iso`
+   - Direct: `http://127.0.0.1:8080/shoal-marker.iso`
+4. Pass as `-iso-url` to `shoal deploy run`.
+
+In-process ISO serving is **not** required for Phase 2.
+
+## Primary build host (lab VM Ansible)
+
+Documented path (to be role-ified): install `dracut`/`xorriso` (or equivalent) on
+the L1 lab VM, build the marker image, write into `shoal_iso_server_dir`, print URL.
+
+## Alternate (workstation)
+
+Build locally, then `scp`/`rsync` into the lab ISO directory so sushy-tools nodes
+can fetch the image over the management network.
+
+## Spike without a full ISO
+
+For app-level tests, feed marker lines into a pipe/PTY using `marker-producer.sh`
+and point `-serial-target` at that console path. Unit tests use an in-process
+`ReaderTransport` instead of libvirt.

--- a/docs/phase2-live-image.md
+++ b/docs/phase2-live-image.md
@@ -80,5 +80,33 @@ is omitted (sushy-tools multi-system).
 ## Spike without a full ISO
 
 Unit tests inject markers via `ReaderTransport`. Lab integration tests
-(`-tags=integration`) use live sushy Virtual Media + injected SOL markers when
-a bootable ISO is not required for that test case.
+(`-tags=integration`) cover:
+
+| Test | Path |
+|------|------|
+| `TestLabDeployRealBMCInjectedSOL` | Live BMC + injected SOL → DONE |
+| `TestLabDeployCancel` | Live BMC + cancel → FAILED + cleanup |
+| `TestLabDeployStall` | Live BMC + SOL silence → stall FAILED + cleanup |
+| `TestLabDeployRealSOLSSH` | Live BMC + SSH serial + bootable ISO → DONE |
+
+```bash
+export SHOAL_BMC_USERNAME=... SHOAL_BMC_PASSWORD=...
+export SHOAL_TELEMETRY_DATABASE_URL='postgres://shoal:…@192.168.122.100:5433/shoal_telemetry?sslmode=disable'
+export SHOAL_SERIAL_SSH_HOST=192.168.122.100   # for RealSOLSSH
+export SHOAL_SERIAL_SSH_KEY=$HOME/.ssh/shoal_lab_vm
+
+go test ./internal/deploy/job -tags=integration -count=1 -v
+```
+
+## API
+
+With `shoal serve` (job store + orchestrator wired):
+
+- `GET /v1/jobs/{id}` — poll status
+- `POST /v1/jobs/{id}/cancel` — request cancel (async cleanup → `failed`)
+
+## Lab quirks (sushy-tools)
+
+- Boot override “Once” may appear as `Continuous` + `Cd`; cleanup sets `Hdd`.
+- Marker ISO powers off when DONE; power state may be `Off` after success.
+- Nested serial PTYs are on L1 only — use SSH serial from L0.

--- a/docs/phase2-live-image.md
+++ b/docs/phase2-live-image.md
@@ -9,31 +9,76 @@ Phase 2 needs a minimal live image that emits `SHOAL|…` markers over serial
 SHOAL|<schema_ver>|<seq>|<iso8601_utc>|<phase>|<percent>|<state>|<detail>
 ```
 
-See design §4.3. Reference emitter: [`infra/scripts/marker-producer.sh`](../infra/scripts/marker-producer.sh).
+See design §4.3. Reference shell emitter (non-bootable harness):
+[`infra/scripts/marker-producer.sh`](../infra/scripts/marker-producer.sh).
 
-## Publish contract
+## Build + publish
 
-1. Build ISO (primary: Ansible on lab VM; alternate: workstation).
-2. Copy into lab ISO dir (e.g. `/srv/iso/shoal-marker.iso`).
-3. BMC-reachable URL examples:
-   - VM-hosted: `http://192.168.122.100:8080/shoal-marker.iso`
-   - Direct: `http://127.0.0.1:8080/shoal-marker.iso`
-4. Pass as `-iso-url` to `shoal deploy run`.
+### Primary: Ansible on lab VM (L1)
 
-In-process ISO serving is **not** required for Phase 2.
+```bash
+ansible-playbook -i infra/ansible/inventory/lab-vm.yml \
+  infra/ansible/playbooks/build_marker_iso.yml
+```
 
-## Primary build host (lab VM Ansible)
+This installs build deps on the lab host, runs
+`infra/scripts/build-marker-iso.sh` (busybox initramfs + host kernel + isolinux),
+and writes `{{ shoal_iso_server_dir }}/shoal-marker.iso` (default `/srv/iso/`).
 
-Documented path (to be role-ified): install `dracut`/`xorriso` (or equivalent) on
-the L1 lab VM, build the marker image, write into `shoal_iso_server_dir`, print URL.
+### Alternate: workstation
 
-## Alternate (workstation)
+```bash
+# needs busybox, cpio, gzip, xorriso, isolinux/syslinux-common, a kernel
+./infra/scripts/build-marker-iso.sh ./shoal-marker.iso
+scp -i ~/.ssh/shoal_lab_vm ./shoal-marker.iso lab@192.168.122.100:/tmp/
+ssh -i ~/.ssh/shoal_lab_vm lab@192.168.122.100 \
+  'sudo cp /tmp/shoal-marker.iso /srv/iso/shoal-marker.iso'
+```
 
-Build locally, then `scp`/`rsync` into the lab ISO directory so sushy-tools nodes
-can fetch the image over the management network.
+## URLs
+
+| Viewer | URL |
+|--------|-----|
+| Operator (VM mode L0) | `http://192.168.122.100:8080/shoal-marker.iso` |
+| Nested BMC nodes | `http://192.168.124.1:8080/shoal-marker.iso` |
+| Direct mode | `http://127.0.0.1:8080/shoal-marker.iso` |
+
+Pass the **BMC-reachable** URL as `-iso-url` to `shoal deploy run`.
+
+## Serial (VM mode)
+
+Nested domains live on L1. From L0 set:
+
+```bash
+export SHOAL_SERIAL_SSH_HOST=192.168.122.100
+export SHOAL_SERIAL_SSH_USER=lab
+export SHOAL_SERIAL_SSH_KEY=$HOME/.ssh/shoal_lab_vm
+```
+
+Or flags: `-serial-ssh-host`, `-serial-ssh-user`, `-serial-ssh-key`.
+
+## Example deploy (VM lab)
+
+```bash
+export SHOAL_BMC_USERNAME=admin   # vault
+export SHOAL_BMC_PASSWORD=...
+export SHOAL_TELEMETRY_DATABASE_URL='postgres://shoal:…@192.168.122.100:5433/shoal_telemetry?sslmode=disable'
+export SHOAL_SERIAL_SSH_HOST=192.168.122.100
+export SHOAL_SERIAL_SSH_KEY=$HOME/.ssh/shoal_lab_vm
+
+go run ./cmd/shoal deploy run \
+  -device-id shoal-node-1 \
+  -bmc-url http://192.168.122.100:8001 \
+  -serial-target shoal-node-1 \
+  -iso-url http://192.168.124.1:8080/shoal-marker.iso \
+  -wait-timeout 5m
+```
+
+`device-id` is also used as the Redfish system **name** lookup when `-system-id`
+is omitted (sushy-tools multi-system).
 
 ## Spike without a full ISO
 
-For app-level tests, feed marker lines into a pipe/PTY using `marker-producer.sh`
-and point `-serial-target` at that console path. Unit tests use an in-process
-`ReaderTransport` instead of libvirt.
+Unit tests inject markers via `ReaderTransport`. Lab integration tests
+(`-tags=integration`) use live sushy Virtual Media + injected SOL markers when
+a bootable ISO is not required for that test case.

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,10 @@ module github.com/mattcburns/shoal
 
 go 1.22
 
-require github.com/jackc/pgx/v5 v5.7.4
+require (
+	github.com/jackc/pgx/v5 v5.7.4
+	github.com/stmcginnis/gofish v0.20.0
+)
 
 require (
 	github.com/jackc/pgpassfile v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stmcginnis/gofish v0.20.0 h1:hH2V2Qe898F2wWT1loApnkDUrXXiLKqbSlMaH3Y1n08=
+github.com/stmcginnis/gofish v0.20.0/go.mod h1:PzF5i8ecRG9A2ol8XT64npKUunyraJ+7t0kYMpQAtqU=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=

--- a/infra/ansible/playbooks/build_marker_iso.yml
+++ b/infra/ansible/playbooks/build_marker_iso.yml
@@ -1,0 +1,17 @@
+---
+# Build/publish Phase 2 marker live ISO on the lab service host.
+#
+# VM mode:
+#   ansible-playbook -i infra/ansible/inventory/lab-vm.yml \
+#     infra/ansible/playbooks/build_marker_iso.yml
+#
+# Direct mode:
+#   ansible-playbook -i infra/ansible/inventory/lab.yml \
+#     infra/ansible/playbooks/build_marker_iso.yml
+
+- name: Build Shoal marker ISO
+  hosts: lab_vms:lab
+  gather_facts: true
+  roles:
+    - role: marker_iso
+      tags: [marker_iso, iso]

--- a/infra/ansible/playbooks/up.yml
+++ b/infra/ansible/playbooks/up.yml
@@ -11,3 +11,5 @@
 - import_playbook: preflight.yml
 - import_playbook: lab_up.yml
 - import_playbook: bootstrap_netbox.yml
+# Phase 2 marker live ISO into lab nginx :8080 (idempotent rebuild).
+- import_playbook: build_marker_iso.yml

--- a/infra/ansible/roles/marker_iso/files/build-marker-iso.sh
+++ b/infra/ansible/roles/marker_iso/files/build-marker-iso.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# build-marker-iso.sh — build a minimal bootable live ISO that emits SHOAL| markers
+# on the serial console (ttyS0 / console), then powers off.
+#
+# Primary: run on the lab VM (L1) so the ISO lands in /srv/iso for nginx :8080.
+# Alternate: run on a workstation and scp the artifact into the lab ISO dir.
+#
+# Requirements: busybox (static preferred), cpio, gzip, xorriso, isolinux/syslinux.
+#
+# Usage:
+#   ./infra/scripts/build-marker-iso.sh [/output/path/shoal-marker.iso]
+#   SHOAL_ISO_OUT=/srv/iso/shoal-marker.iso ./infra/scripts/build-marker-iso.sh
+
+set -euo pipefail
+
+OUT="${1:-${SHOAL_ISO_OUT:-./shoal-marker.iso}}"
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/shoal-marker-iso.XXXXXX")"
+cleanup() { rm -rf "$WORK"; }
+trap cleanup EXIT
+
+KERNEL="${SHOAL_KERNEL:-}"
+if [[ -z "$KERNEL" ]]; then
+  for k in /boot/vmlinuz /boot/vmlinuz-linux /boot/vmlinuz-generic; do
+    if [[ -r "$k" ]]; then KERNEL="$k"; break; fi
+  done
+  if [[ -z "$KERNEL" ]]; then
+    # Prefer versioned kernels
+    KERNEL="$(ls -1 /boot/vmlinuz-* 2>/dev/null | tail -1 || true)"
+  fi
+fi
+if [[ -z "$KERNEL" || ! -r "$KERNEL" ]]; then
+  echo "error: no readable kernel; set SHOAL_KERNEL=/boot/vmlinuz-..." >&2
+  exit 1
+fi
+
+BUSYBOX="$(command -v busybox || true)"
+if [[ -z "$BUSYBOX" ]]; then
+  echo "error: busybox not found" >&2
+  exit 1
+fi
+if [[ -x /bin/busybox ]]; then
+  BUSYBOX=/bin/busybox
+fi
+
+ISOLINUX_BIN=""
+for p in \
+  /usr/lib/ISOLINUX/isolinux.bin \
+  /usr/lib/syslinux/isolinux.bin \
+  /usr/share/syslinux/isolinux.bin
+do
+  if [[ -r "$p" ]]; then ISOLINUX_BIN="$p"; break; fi
+done
+LDLINUX=""
+for p in \
+  /usr/lib/syslinux/modules/bios/ldlinux.c32 \
+  /usr/lib/ISOLINUX/ldlinux.c32 \
+  /usr/share/syslinux/ldlinux.c32
+do
+  if [[ -r "$p" ]]; then LDLINUX="$p"; break; fi
+done
+if [[ -z "$ISOLINUX_BIN" ]]; then
+  echo "error: isolinux.bin not found (install isolinux / syslinux-common)" >&2
+  exit 1
+fi
+if ! command -v xorriso >/dev/null 2>&1; then
+  echo "error: xorriso required" >&2
+  exit 1
+fi
+
+echo "kernel:  $KERNEL"
+echo "busybox: $BUSYBOX"
+echo "output:  $OUT"
+
+# --- initramfs rootfs ---
+ROOT="$WORK/rootfs"
+mkdir -p "$ROOT"/{bin,dev,proc,sys,tmp}
+
+cp "$BUSYBOX" "$ROOT/bin/busybox"
+chmod 755 "$ROOT/bin/busybox"
+# Install common applets used by /init
+for app in sh mount umount mkdir sleep cat echo poweroff reboot mkdir ln; do
+  ln -sf busybox "$ROOT/bin/$app"
+done
+
+# Init emits markers then powers off. console=ttyS0 from kernel cmdline.
+cat > "$ROOT/init" << 'INIT'
+#!/bin/busybox sh
+export PATH=/bin
+
+/bin/busybox mount -t proc none /proc 2>/dev/null || true
+/bin/busybox mount -t sysfs none /sys 2>/dev/null || true
+/bin/busybox mount -t devtmpfs none /dev 2>/dev/null || true
+
+# Prefer serial console for markers
+for dev in /dev/ttyS0 /dev/console /dev/tty0; do
+  if [ -w "$dev" ]; then
+    exec >"$dev" 2>&1
+    break
+  fi
+done
+
+seq=0
+emit() {
+  phase="$1"; percent="$2"; state="$3"; detail="${4:-}"
+  seq=$((seq + 1))
+  ts="$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo 1970-01-01T00:00:00Z)"
+  printf 'SHOAL|1|%s|%s|%s|%s|%s|%s\n' "$seq" "$ts" "$phase" "$percent" "$state" "$detail"
+}
+
+# Short Phase-2 demonstration sequence (no real disk write).
+emit BOOT 0 OK "marker live image started"
+sleep 1
+emit BOOT - HEARTBEAT ""
+sleep 1
+emit IMAGE_WRITE 25 OK "simulated write"
+sleep 1
+emit IMAGE_WRITE - HEARTBEAT ""
+sleep 1
+emit IMAGE_WRITE 75 OK "simulated sync"
+sleep 1
+emit VERIFY 90 OK "ok"
+sleep 1
+emit DONE 100 OK "reboot pending"
+
+sleep 1
+# Prefer poweroff so the emulator can observe power transitions.
+/bin/busybox poweroff -f 2>/dev/null || /bin/busybox reboot -f 2>/dev/null || true
+# hang if poweroff unavailable
+while true; do sleep 3600; done
+INIT
+chmod 755 "$ROOT/init"
+
+# Build initrd (newc cpio + gzip)
+INITRD="$WORK/initrd.img"
+(
+  cd "$ROOT"
+  find . | cpio -o -H newc --quiet | gzip -9 > "$INITRD"
+)
+
+# ISO tree
+ISO="$WORK/iso"
+mkdir -p "$ISO/boot/isolinux"
+cp "$KERNEL" "$ISO/boot/vmlinuz"
+cp "$INITRD" "$ISO/boot/initrd.img"
+cp "$ISOLINUX_BIN" "$ISO/boot/isolinux/isolinux.bin"
+if [[ -n "$LDLINUX" ]]; then
+  cp "$LDLINUX" "$ISO/boot/isolinux/ldlinux.c32"
+fi
+
+cat > "$ISO/boot/isolinux/isolinux.cfg" << 'CFG'
+DEFAULT shoal
+PROMPT 0
+TIMEOUT 10
+LABEL shoal
+  KERNEL /boot/vmlinuz
+  APPEND initrd=/boot/initrd.img console=ttyS0,115200n8 console=tty0 quiet
+CFG
+
+mkdir -p "$(dirname "$OUT")"
+xorriso -as mkisofs \
+  -quiet \
+  -o "$OUT" \
+  -V "SHOAL_MARKER" \
+  -b boot/isolinux/isolinux.bin \
+  -c boot/isolinux/boot.cat \
+  -no-emul-boot \
+  -boot-load-size 4 \
+  -boot-info-table \
+  "$ISO"
+
+chmod 644 "$OUT" 2>/dev/null || true
+SIZE="$(wc -c < "$OUT" | tr -d ' ')"
+echo "built $OUT ($SIZE bytes)"
+echo "publish: copy into lab ISO dir and serve as http://<lab>:8080/$(basename "$OUT")"
+echo "BMC-reachable (VM lab nodes): http://192.168.124.1:8080/$(basename "$OUT")"

--- a/infra/ansible/roles/marker_iso/tasks/main.yml
+++ b/infra/ansible/roles/marker_iso/tasks/main.yml
@@ -1,0 +1,47 @@
+---
+# Build and publish the Phase 2 SHOAL marker live ISO into the lab ISO HTTP tree.
+# Primary build host: lab VM (L1). Artifact: {{ shoal_iso_server_dir }}/shoal-marker.iso
+
+- name: Install marker ISO build packages
+  ansible.builtin.apt:
+    name:
+      - busybox-static
+      - cpio
+      - gzip
+      - xorriso
+      - isolinux
+      - syslinux-common
+    state: present
+    update_cache: true
+    cache_valid_time: 3600
+  become: true
+
+- name: Ensure ISO server directory exists
+  ansible.builtin.file:
+    path: "{{ shoal_iso_server_dir }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+  become: true
+
+- name: Stage build-marker-iso.sh on target
+  ansible.builtin.copy:
+    src: build-marker-iso.sh
+    dest: /tmp/shoal-build-marker-iso.sh
+    mode: "0755"
+
+- name: Build and publish shoal-marker.iso
+  ansible.builtin.command:
+    cmd: /tmp/shoal-build-marker-iso.sh {{ shoal_iso_server_dir }}/shoal-marker.iso
+  become: true
+  register: marker_iso_build
+  changed_when: true
+
+- name: Show marker ISO URL
+  ansible.builtin.debug:
+    msg: |
+      Marker ISO published to {{ shoal_iso_server_dir }}/shoal-marker.iso
+      Operator URL: http://{{ shoal_service_host | default(shoal_lab_vm_host) }}:{{ shoal_iso_server_port }}/shoal-marker.iso
+      BMC (lab net): http://{{ shoal_lab_network_gateway }}:{{ shoal_iso_server_port }}/shoal-marker.iso
+      {{ marker_iso_build.stdout | default('') }}

--- a/infra/scripts/build-marker-iso.sh
+++ b/infra/scripts/build-marker-iso.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# build-marker-iso.sh — build a minimal bootable live ISO that emits SHOAL| markers
+# on the serial console (ttyS0 / console), then powers off.
+#
+# Primary: run on the lab VM (L1) so the ISO lands in /srv/iso for nginx :8080.
+# Alternate: run on a workstation and scp the artifact into the lab ISO dir.
+#
+# Requirements: busybox (static preferred), cpio, gzip, xorriso, isolinux/syslinux.
+#
+# Usage:
+#   ./infra/scripts/build-marker-iso.sh [/output/path/shoal-marker.iso]
+#   SHOAL_ISO_OUT=/srv/iso/shoal-marker.iso ./infra/scripts/build-marker-iso.sh
+
+set -euo pipefail
+
+OUT="${1:-${SHOAL_ISO_OUT:-./shoal-marker.iso}}"
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/shoal-marker-iso.XXXXXX")"
+cleanup() { rm -rf "$WORK"; }
+trap cleanup EXIT
+
+KERNEL="${SHOAL_KERNEL:-}"
+if [[ -z "$KERNEL" ]]; then
+  for k in /boot/vmlinuz /boot/vmlinuz-linux /boot/vmlinuz-generic; do
+    if [[ -r "$k" ]]; then KERNEL="$k"; break; fi
+  done
+  if [[ -z "$KERNEL" ]]; then
+    # Prefer versioned kernels
+    KERNEL="$(ls -1 /boot/vmlinuz-* 2>/dev/null | tail -1 || true)"
+  fi
+fi
+if [[ -z "$KERNEL" || ! -r "$KERNEL" ]]; then
+  echo "error: no readable kernel; set SHOAL_KERNEL=/boot/vmlinuz-..." >&2
+  exit 1
+fi
+
+BUSYBOX="$(command -v busybox || true)"
+if [[ -z "$BUSYBOX" ]]; then
+  echo "error: busybox not found" >&2
+  exit 1
+fi
+if [[ -x /bin/busybox ]]; then
+  BUSYBOX=/bin/busybox
+fi
+
+ISOLINUX_BIN=""
+for p in \
+  /usr/lib/ISOLINUX/isolinux.bin \
+  /usr/lib/syslinux/isolinux.bin \
+  /usr/share/syslinux/isolinux.bin
+do
+  if [[ -r "$p" ]]; then ISOLINUX_BIN="$p"; break; fi
+done
+LDLINUX=""
+for p in \
+  /usr/lib/syslinux/modules/bios/ldlinux.c32 \
+  /usr/lib/ISOLINUX/ldlinux.c32 \
+  /usr/share/syslinux/ldlinux.c32
+do
+  if [[ -r "$p" ]]; then LDLINUX="$p"; break; fi
+done
+if [[ -z "$ISOLINUX_BIN" ]]; then
+  echo "error: isolinux.bin not found (install isolinux / syslinux-common)" >&2
+  exit 1
+fi
+if ! command -v xorriso >/dev/null 2>&1; then
+  echo "error: xorriso required" >&2
+  exit 1
+fi
+
+echo "kernel:  $KERNEL"
+echo "busybox: $BUSYBOX"
+echo "output:  $OUT"
+
+# --- initramfs rootfs ---
+ROOT="$WORK/rootfs"
+mkdir -p "$ROOT"/{bin,dev,proc,sys,tmp}
+
+cp "$BUSYBOX" "$ROOT/bin/busybox"
+chmod 755 "$ROOT/bin/busybox"
+# Install common applets used by /init
+for app in sh mount umount mkdir sleep cat echo poweroff reboot mkdir ln; do
+  ln -sf busybox "$ROOT/bin/$app"
+done
+
+# Init emits markers then powers off. console=ttyS0 from kernel cmdline.
+cat > "$ROOT/init" << 'INIT'
+#!/bin/busybox sh
+export PATH=/bin
+
+/bin/busybox mount -t proc none /proc 2>/dev/null || true
+/bin/busybox mount -t sysfs none /sys 2>/dev/null || true
+/bin/busybox mount -t devtmpfs none /dev 2>/dev/null || true
+
+# Prefer serial console for markers
+for dev in /dev/ttyS0 /dev/console /dev/tty0; do
+  if [ -w "$dev" ]; then
+    exec >"$dev" 2>&1
+    break
+  fi
+done
+
+seq=0
+emit() {
+  phase="$1"; percent="$2"; state="$3"; detail="${4:-}"
+  seq=$((seq + 1))
+  ts="$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo 1970-01-01T00:00:00Z)"
+  printf 'SHOAL|1|%s|%s|%s|%s|%s|%s\n' "$seq" "$ts" "$phase" "$percent" "$state" "$detail"
+}
+
+# Short Phase-2 demonstration sequence (no real disk write).
+emit BOOT 0 OK "marker live image started"
+sleep 1
+emit BOOT - HEARTBEAT ""
+sleep 1
+emit IMAGE_WRITE 25 OK "simulated write"
+sleep 1
+emit IMAGE_WRITE - HEARTBEAT ""
+sleep 1
+emit IMAGE_WRITE 75 OK "simulated sync"
+sleep 1
+emit VERIFY 90 OK "ok"
+sleep 1
+emit DONE 100 OK "reboot pending"
+
+sleep 1
+# Prefer poweroff so the emulator can observe power transitions.
+/bin/busybox poweroff -f 2>/dev/null || /bin/busybox reboot -f 2>/dev/null || true
+# hang if poweroff unavailable
+while true; do sleep 3600; done
+INIT
+chmod 755 "$ROOT/init"
+
+# Build initrd (newc cpio + gzip)
+INITRD="$WORK/initrd.img"
+(
+  cd "$ROOT"
+  find . | cpio -o -H newc --quiet | gzip -9 > "$INITRD"
+)
+
+# ISO tree
+ISO="$WORK/iso"
+mkdir -p "$ISO/boot/isolinux"
+cp "$KERNEL" "$ISO/boot/vmlinuz"
+cp "$INITRD" "$ISO/boot/initrd.img"
+cp "$ISOLINUX_BIN" "$ISO/boot/isolinux/isolinux.bin"
+if [[ -n "$LDLINUX" ]]; then
+  cp "$LDLINUX" "$ISO/boot/isolinux/ldlinux.c32"
+fi
+
+cat > "$ISO/boot/isolinux/isolinux.cfg" << 'CFG'
+DEFAULT shoal
+PROMPT 0
+TIMEOUT 10
+LABEL shoal
+  KERNEL /boot/vmlinuz
+  APPEND initrd=/boot/initrd.img console=ttyS0,115200n8 console=tty0 quiet
+CFG
+
+mkdir -p "$(dirname "$OUT")"
+xorriso -as mkisofs \
+  -quiet \
+  -o "$OUT" \
+  -V "SHOAL_MARKER" \
+  -b boot/isolinux/isolinux.bin \
+  -c boot/isolinux/boot.cat \
+  -no-emul-boot \
+  -boot-load-size 4 \
+  -boot-info-table \
+  "$ISO"
+
+chmod 644 "$OUT" 2>/dev/null || true
+SIZE="$(wc -c < "$OUT" | tr -d ' ')"
+echo "built $OUT ($SIZE bytes)"
+echo "publish: copy into lab ISO dir and serve as http://<lab>:8080/$(basename "$OUT")"
+echo "BMC-reachable (VM lab nodes): http://192.168.124.1:8080/$(basename "$OUT")"

--- a/infra/scripts/marker-producer.sh
+++ b/infra/scripts/marker-producer.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# marker-producer.sh — emit SHOAL|… protocol lines on stdout (serial console simulation).
+#
+# Used for:
+#   - unit/integration harnesses that feed a PTY or pipe into Observe
+#   - a minimal live-image boot script (console=ttyS0,115200n8) that sources this logic
+#
+# Protocol (design §4.3):
+#   SHOAL|<schema_ver>|<seq>|<iso8601_utc>|<phase>|<percent>|<state>|<detail>
+#
+# Usage:
+#   ./marker-producer.sh              # full BOOT → DONE sequence with heartbeats
+#   ./marker-producer.sh --loop       # heartbeats only (stall tests: kill the process)
+#   ./marker-producer.sh --error      # end with ERROR
+
+set -euo pipefail
+
+INTERVAL="${SHOAL_MARKER_INTERVAL:-1}"
+MODE="full"
+for arg in "$@"; do
+  case "$arg" in
+    --loop) MODE="loop" ;;
+    --error) MODE="error" ;;
+  esac
+done
+
+seq=0
+emit() {
+  local phase="$1" percent="$2" state="$3" detail="${4:-}"
+  seq=$((seq + 1))
+  local ts
+  ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+  printf 'SHOAL|1|%s|%s|%s|%s|%s|%s\n' "$seq" "$ts" "$phase" "$percent" "$state" "$detail"
+}
+
+heartbeat() {
+  local phase="$1"
+  emit "$phase" "-" "HEARTBEAT" ""
+}
+
+case "$MODE" in
+  loop)
+    while true; do
+      heartbeat "WAIT"
+      sleep "$INTERVAL"
+    done
+    ;;
+  error)
+    emit "BOOT" "0" "OK" "starting"
+    sleep "$INTERVAL"
+    emit "IMAGE_WRITE" "20" "OK" "writing"
+    sleep "$INTERVAL"
+    emit "IMAGE_WRITE" "-" "ERROR" "simulated failure"
+    ;;
+  full|*)
+    emit "BOOT" "0" "OK" "live image started"
+    sleep "$INTERVAL"
+    heartbeat "BOOT"
+    sleep "$INTERVAL"
+    emit "IMAGE_WRITE" "25" "OK" "writing rootfs"
+    sleep "$INTERVAL"
+    heartbeat "IMAGE_WRITE"
+    sleep "$INTERVAL"
+    emit "IMAGE_WRITE" "75" "OK" "syncing"
+    sleep "$INTERVAL"
+    emit "VERIFY" "90" "OK" "checksum ok"
+    sleep "$INTERVAL"
+    emit "DONE" "100" "OK" "reboot pending"
+    ;;
+esac

--- a/internal/api/jobs.go
+++ b/internal/api/jobs.go
@@ -1,0 +1,39 @@
+package api
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/mattcburns/shoal/internal/deploy/jobstore"
+)
+
+// WithJobStore attaches a job store for GET /v1/jobs/{id}.
+func (s *Server) WithJobStore(store jobstore.Store) *Server {
+	s.jobs = store
+	return s
+}
+
+func (s *Server) handleGetJob(w http.ResponseWriter, r *http.Request) {
+	if s.jobs == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]any{
+			"error": "job store not configured",
+		})
+		return
+	}
+	id := r.PathValue("id")
+	if id == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "missing job id"})
+		return
+	}
+	j, err := s.jobs.Get(r.Context(), id)
+	if err != nil {
+		if errors.Is(err, jobstore.ErrNotFound) {
+			writeJSON(w, http.StatusNotFound, map[string]any{"error": "not found"})
+			return
+		}
+		s.log.Error("get job", "err", err.Error())
+		writeJSON(w, http.StatusInternalServerError, map[string]any{"error": "internal error"})
+		return
+	}
+	writeJSON(w, http.StatusOK, j)
+}

--- a/internal/api/jobs.go
+++ b/internal/api/jobs.go
@@ -1,15 +1,33 @@
 package api
 
 import (
+	"context"
 	"errors"
 	"net/http"
 
+	"github.com/mattcburns/shoal/internal/common/models"
 	"github.com/mattcburns/shoal/internal/deploy/jobstore"
 )
+
+// JobReader loads jobs for status polling.
+type JobReader interface {
+	Get(ctx context.Context, id string) (models.ProvisioningJob, error)
+}
+
+// JobCanceler cancels an in-flight job (Orchestrator).
+type JobCanceler interface {
+	Cancel(ctx context.Context, jobID string) error
+}
 
 // WithJobStore attaches a job store for GET /v1/jobs/{id}.
 func (s *Server) WithJobStore(store jobstore.Store) *Server {
 	s.jobs = store
+	return s
+}
+
+// WithJobCanceler attaches cancel support for POST /v1/jobs/{id}/cancel.
+func (s *Server) WithJobCanceler(c JobCanceler) *Server {
+	s.cancel = c
 	return s
 }
 
@@ -36,4 +54,45 @@ func (s *Server) handleGetJob(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, j)
+}
+
+func (s *Server) handleCancelJob(w http.ResponseWriter, r *http.Request) {
+	if s.cancel == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]any{
+			"error": "job cancel not configured",
+		})
+		return
+	}
+	if s.jobs == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]any{
+			"error": "job store not configured",
+		})
+		return
+	}
+	id := r.PathValue("id")
+	if id == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "missing job id"})
+		return
+	}
+	if err := s.cancel.Cancel(r.Context(), id); err != nil {
+		// Not found vs other errors
+		if errors.Is(err, jobstore.ErrNotFound) {
+			writeJSON(w, http.StatusNotFound, map[string]any{"error": "not found"})
+			return
+		}
+		// Cancel of non-provisioning jobs returns a plain error from Orchestrator
+		s.log.Warn("cancel job", "job_id", id, "err", err.Error())
+		writeJSON(w, http.StatusConflict, map[string]any{"error": err.Error()})
+		return
+	}
+	// Async terminal — poll briefly for updated state
+	j, err := s.jobs.Get(r.Context(), id)
+	if err != nil {
+		writeJSON(w, http.StatusAccepted, map[string]any{
+			"job_id": id,
+			"status": "cancel_requested",
+		})
+		return
+	}
+	writeJSON(w, http.StatusAccepted, j)
 }

--- a/internal/api/jobs_test.go
+++ b/internal/api/jobs_test.go
@@ -1,0 +1,115 @@
+package api_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/mattcburns/shoal/internal/api"
+	"github.com/mattcburns/shoal/internal/common/config"
+	"github.com/mattcburns/shoal/internal/common/models"
+	"github.com/mattcburns/shoal/internal/deploy/jobstore"
+)
+
+func TestGetJob(t *testing.T) {
+	store := jobstore.NewMemory()
+	now := time.Now().UTC()
+	_ = store.Insert(context.Background(), models.ProvisioningJob{
+		ID: "j1", DeviceID: "d1", State: models.StateProvisioning,
+		UpdatedAt: &now,
+	})
+	s := api.New(config.Config{}, nil).WithJobStore(store)
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/jobs/j1", nil)
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status %d body=%s", rr.Code, rr.Body.String())
+	}
+	var j models.ProvisioningJob
+	if err := json.Unmarshal(rr.Body.Bytes(), &j); err != nil {
+		t.Fatal(err)
+	}
+	if j.ID != "j1" {
+		t.Fatalf("id %s", j.ID)
+	}
+}
+
+func TestGetJobNotFound(t *testing.T) {
+	s := api.New(config.Config{}, nil).WithJobStore(jobstore.NewMemory())
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/jobs/missing", nil)
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("status %d", rr.Code)
+	}
+}
+
+type fakeCanceler struct {
+	err error
+	id  string
+}
+
+func (f *fakeCanceler) Cancel(_ context.Context, jobID string) error {
+	f.id = jobID
+	return f.err
+}
+
+func TestCancelJob(t *testing.T) {
+	store := jobstore.NewMemory()
+	now := time.Now().UTC()
+	_ = store.Insert(context.Background(), models.ProvisioningJob{
+		ID: "j1", DeviceID: "d1", State: models.StateProvisioning, UpdatedAt: &now,
+	})
+	fc := &fakeCanceler{}
+	s := api.New(config.Config{}, nil).WithJobStore(store).WithJobCanceler(fc)
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/jobs/j1/cancel", nil)
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusAccepted {
+		t.Fatalf("status %d body=%s", rr.Code, rr.Body.String())
+	}
+	if fc.id != "j1" {
+		t.Fatalf("cancel id %q", fc.id)
+	}
+}
+
+func TestCancelJobNotConfigured(t *testing.T) {
+	s := api.New(config.Config{}, nil).WithJobStore(jobstore.NewMemory())
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/jobs/j1/cancel", nil)
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status %d", rr.Code)
+	}
+}
+
+func TestCancelJobNotFound(t *testing.T) {
+	fc := &fakeCanceler{err: jobstore.ErrNotFound}
+	s := api.New(config.Config{}, nil).WithJobStore(jobstore.NewMemory()).WithJobCanceler(fc)
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/jobs/nope/cancel", nil)
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("status %d", rr.Code)
+	}
+}
+
+func TestCancelJobConflict(t *testing.T) {
+	fc := &fakeCanceler{err: errors.New("job: cannot cancel job in state provisioned")}
+	store := jobstore.NewMemory()
+	now := time.Now().UTC()
+	_ = store.Insert(context.Background(), models.ProvisioningJob{
+		ID: "j1", DeviceID: "d1", State: models.StateProvisioned, UpdatedAt: &now,
+	})
+	s := api.New(config.Config{}, nil).WithJobStore(store).WithJobCanceler(fc)
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/jobs/j1/cancel", nil)
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusConflict {
+		t.Fatalf("status %d", rr.Code)
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -10,15 +10,17 @@ import (
 
 	"github.com/mattcburns/shoal/internal/common/config"
 	"github.com/mattcburns/shoal/internal/common/telemetry"
+	"github.com/mattcburns/shoal/internal/deploy/jobstore"
 )
 
-// Server is the HTTP API surface for Phase 1 (health endpoints).
+// Server is the HTTP API surface (health + job status).
 type Server struct {
 	cfg config.Config
 	log *slog.Logger
 	mux *http.ServeMux
 	// PingDB may be overridden in tests; defaults to telemetry.PingDB.
 	PingDB func(ctx context.Context, dsn string) error
+	jobs   jobstore.Store
 }
 
 // New constructs a Server with routes registered.
@@ -44,6 +46,7 @@ func (s *Server) Handler() http.Handler {
 func (s *Server) routes() {
 	s.mux.HandleFunc("GET /healthz", s.handleHealthz)
 	s.mux.HandleFunc("GET /readyz", s.handleReadyz)
+	s.mux.HandleFunc("GET /v1/jobs/{id}", s.handleGetJob)
 }
 
 func (s *Server) handleHealthz(w http.ResponseWriter, _ *http.Request) {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -13,7 +13,7 @@ import (
 	"github.com/mattcburns/shoal/internal/deploy/jobstore"
 )
 
-// Server is the HTTP API surface (health + job status).
+// Server is the HTTP API surface (health + job status/cancel).
 type Server struct {
 	cfg config.Config
 	log *slog.Logger
@@ -21,6 +21,7 @@ type Server struct {
 	// PingDB may be overridden in tests; defaults to telemetry.PingDB.
 	PingDB func(ctx context.Context, dsn string) error
 	jobs   jobstore.Store
+	cancel JobCanceler
 }
 
 // New constructs a Server with routes registered.
@@ -47,6 +48,7 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("GET /healthz", s.handleHealthz)
 	s.mux.HandleFunc("GET /readyz", s.handleReadyz)
 	s.mux.HandleFunc("GET /v1/jobs/{id}", s.handleGetJob)
+	s.mux.HandleFunc("POST /v1/jobs/{id}/cancel", s.handleCancelJob)
 }
 
 func (s *Server) handleHealthz(w http.ResponseWriter, _ *http.Request) {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -19,7 +19,7 @@ import (
 )
 
 // Version is the application version string (overridable via -ldflags).
-var Version = "0.1.0-phase1"
+var Version = "0.2.0-phase2"
 
 // Run dispatches subcommands. args should be os.Args[1:].
 func Run(args []string) int {
@@ -32,6 +32,8 @@ func Run(args []string) int {
 		return cmdVersion(os.Stdout)
 	case "serve":
 		return cmdServe(args[1:])
+	case "deploy":
+		return cmdDeploy(args[1:])
 	case "help", "-h", "--help":
 		printUsage(os.Stdout)
 		return 0
@@ -51,6 +53,16 @@ Usage:
 Commands:
   version   Print version and exit
   serve     Run the HTTP API server
+  deploy    Provisioning: run | status | cancel
+
+Phase 2 example:
+  shoal deploy run \
+    -device-id lab-node-1 \
+    -bmc-url http://192.168.122.100:8001 \
+    -bmc-user "$SHOAL_BMC_USERNAME" \
+    -bmc-pass "$SHOAL_BMC_PASSWORD" \
+    -serial-target shoal-node-1 \
+    -iso-url http://192.168.122.100:8080/shoal-marker.iso
 
 `)
 }
@@ -79,6 +91,14 @@ func cmdServe(args []string) int {
 	slog.SetDefault(log)
 
 	srvAPI := api.New(cfg, log)
+	if store, closer, err := openJobStore(cfg); err == nil {
+		srvAPI.WithJobStore(store)
+		if closer != nil {
+			defer closer()
+		}
+	} else {
+		log.Warn("job store unavailable for API", "err", err.Error())
+	}
 	httpSrv := &http.Server{
 		Addr:              cfg.HTTPAddr,
 		Handler:           srvAPI.Handler(),

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -55,14 +55,16 @@ Commands:
   serve     Run the HTTP API server
   deploy    Provisioning: run | status | cancel
 
-Phase 2 example:
+Phase 2 example (VM lab):
+  export SHOAL_SERIAL_SSH_HOST=192.168.122.100
+  export SHOAL_SERIAL_SSH_KEY=$HOME/.ssh/shoal_lab_vm
   shoal deploy run \
-    -device-id lab-node-1 \
+    -device-id shoal-node-1 \
     -bmc-url http://192.168.122.100:8001 \
     -bmc-user "$SHOAL_BMC_USERNAME" \
     -bmc-pass "$SHOAL_BMC_PASSWORD" \
     -serial-target shoal-node-1 \
-    -iso-url http://192.168.122.100:8080/shoal-marker.iso
+    -iso-url http://192.168.124.1:8080/shoal-marker.iso
 
 `)
 }

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -16,6 +16,10 @@ import (
 	"github.com/mattcburns/shoal/internal/api"
 	"github.com/mattcburns/shoal/internal/common/config"
 	"github.com/mattcburns/shoal/internal/common/redact"
+	"github.com/mattcburns/shoal/internal/common/redfish"
+	"github.com/mattcburns/shoal/internal/common/secrets"
+	"github.com/mattcburns/shoal/internal/deploy/job"
+	"github.com/mattcburns/shoal/internal/observe/sol"
 )
 
 // Version is the application version string (overridable via -ldflags).
@@ -93,22 +97,50 @@ func cmdServe(args []string) int {
 	slog.SetDefault(log)
 
 	srvAPI := api.New(cfg, log)
-	if store, closer, err := openJobStore(cfg); err == nil {
-		srvAPI.WithJobStore(store)
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	store, closer, err := openJobStore(cfg)
+	if err != nil {
+		log.Warn("job store unavailable for API", "err", err.Error())
+	} else {
 		if closer != nil {
 			defer closer()
 		}
-	} else {
-		log.Warn("job store unavailable for API", "err", err.Error())
+		srvAPI.WithJobStore(store)
+		// Wire Orchestrator so cancel works and orphans are reconciled on boot.
+		secretBackend := openSecrets(cfg)
+		watchSvc := sol.NewWatchService(log, nil)
+		watchSvc.NewTransport = sol.NewTransportFactory(sol.SSHSerialConfig{
+			Host:    cfg.SerialSSHHost,
+			User:    cfg.SerialSSHUser,
+			KeyPath: cfg.SerialSSHKey,
+			UseSudo: cfg.SerialSSHSudo,
+		})
+		orch := job.NewOrchestrator(job.Options{
+			Log:                 log,
+			Store:               store,
+			Secrets:             secretBackend,
+			NewBMC:              redfish.NewBMC,
+			Watches:             watchSvc,
+			AuthMode:            cfg.RedfishAuthMode,
+			TLSMode:             cfg.RedfishTLSMode,
+			CAFile:              cfg.RedfishCAFile,
+			ReconcileFailOrphan: cfg.ReconcileFailOrphans,
+		})
+		defer orch.Stop()
+		watchSvc.SetProgress(orch.ProgressPort())
+		srvAPI.WithJobCanceler(orch)
+		if err := orch.ReconcileOrphans(ctx); err != nil {
+			log.Warn("orphan reconcile", "err", err.Error())
+		}
 	}
+
 	httpSrv := &http.Server{
 		Addr:              cfg.HTTPAddr,
 		Handler:           srvAPI.Handler(),
 		ReadHeaderTimeout: 10 * time.Second,
 	}
-
-	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
-	defer stop()
 
 	errCh := make(chan error, 1)
 	go func() {
@@ -133,6 +165,15 @@ func cmdServe(args []string) int {
 		}
 		return 0
 	}
+}
+
+func openSecrets(cfg config.Config) secrets.Backend {
+	if cfg.SecretsDir != "" {
+		if fb, err := secrets.NewFile(cfg.SecretsDir); err == nil {
+			return fb
+		}
+	}
+	return secrets.NewMemory()
 }
 
 func newLogger(level string) *slog.Logger {

--- a/internal/cli/deploy.go
+++ b/internal/cli/deploy.go
@@ -55,13 +55,20 @@ func cmdDeployRun(args []string) int {
 	bmcPass := fs.String("bmc-pass", cfg.BMCPassword, "BMC password (never logged)")
 	serial := fs.String("serial-target", "", "libvirt domain or console path")
 	isoURL := fs.String("iso-url", "", "BMC-reachable ISO URL on lab :8080")
-	systemID := fs.String("system-id", "", "optional Redfish system id")
+	systemID := fs.String("system-id", "", "optional Redfish system id or name")
 	profile := fs.String("profile-ref", "spike", "profile ref")
+	sshHost := fs.String("serial-ssh-host", cfg.SerialSSHHost, "SSH host for nested libvirt serial (VM mode)")
+	sshUser := fs.String("serial-ssh-user", cfg.SerialSSHUser, "SSH user for serial delegate")
+	sshKey := fs.String("serial-ssh-key", cfg.SerialSSHKey, "SSH private key for serial delegate")
 	wait := fs.Bool("wait", true, "wait for terminal job state")
 	waitTimeout := fs.Duration("wait-timeout", 30*time.Minute, "max wait when -wait")
+	stallTimeout := fs.Duration("stall-timeout", 3*time.Minute, "SOL silence before stall failure")
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
+	cfg.SerialSSHHost = *sshHost
+	cfg.SerialSSHUser = *sshUser
+	cfg.SerialSSHKey = *sshKey
 
 	dev := *deviceID
 	if dev == "" {
@@ -76,6 +83,7 @@ func cmdDeployRun(args []string) int {
 		BMCPassword:  *bmcPass,
 		SerialTarget: *serial,
 		SystemID:     *systemID,
+		StallTimeout: *stallTimeout,
 	}
 
 	store, dbCloser, err := openJobStore(cfg)
@@ -99,6 +107,12 @@ func cmdDeployRun(args []string) int {
 
 	// Wire Observe watch service with progress from orchestrator (two-step inject).
 	watchSvc := sol.NewWatchService(log, nil)
+	watchSvc.NewTransport = sol.NewTransportFactory(sol.SSHSerialConfig{
+		Host:    cfg.SerialSSHHost,
+		User:    cfg.SerialSSHUser,
+		KeyPath: cfg.SerialSSHKey,
+		UseSudo: cfg.SerialSSHSudo,
+	})
 	orch := job.NewOrchestrator(job.Options{
 		Log:                 log,
 		Store:               store,
@@ -236,6 +250,12 @@ func cmdDeployCancel(args []string) int {
 		}
 	}
 	watchSvc := sol.NewWatchService(log, nil)
+	watchSvc.NewTransport = sol.NewTransportFactory(sol.SSHSerialConfig{
+		Host:    cfg.SerialSSHHost,
+		User:    cfg.SerialSSHUser,
+		KeyPath: cfg.SerialSSHKey,
+		UseSudo: cfg.SerialSSHSudo,
+	})
 	orch := job.NewOrchestrator(job.Options{
 		Log:                 log,
 		Store:               store,

--- a/internal/cli/deploy.go
+++ b/internal/cli/deploy.go
@@ -1,0 +1,276 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/mattcburns/shoal/internal/common/config"
+	"github.com/mattcburns/shoal/internal/common/models"
+	"github.com/mattcburns/shoal/internal/common/redfish"
+	"github.com/mattcburns/shoal/internal/common/secrets"
+	"github.com/mattcburns/shoal/internal/common/telemetry"
+	"github.com/mattcburns/shoal/internal/deploy/job"
+	"github.com/mattcburns/shoal/internal/deploy/jobstore"
+	"github.com/mattcburns/shoal/internal/observe/sol"
+)
+
+func cmdDeploy(args []string) int {
+	if len(args) < 1 {
+		fmt.Fprintln(os.Stderr, "usage: shoal deploy <run|status|cancel> [flags]")
+		return 2
+	}
+	switch args[0] {
+	case "run":
+		return cmdDeployRun(args[1:])
+	case "status":
+		return cmdDeployStatus(args[1:])
+	case "cancel":
+		return cmdDeployCancel(args[1:])
+	default:
+		fmt.Fprintf(os.Stderr, "unknown deploy subcommand %q\n", args[0])
+		return 2
+	}
+}
+
+func cmdDeployRun(args []string) int {
+	cfg, err := config.Load()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "config: %v\n", err)
+		return 1
+	}
+	log := newLogger(cfg.LogLevel)
+
+	fs := flag.NewFlagSet("deploy run", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	device := fs.String("device", "", "device id (alias for -device-id)")
+	deviceID := fs.String("device-id", "", "device id for correlation")
+	bmcURL := fs.String("bmc-url", "", "Redfish base URL")
+	bmcUser := fs.String("bmc-user", cfg.BMCUsername, "BMC username")
+	bmcPass := fs.String("bmc-pass", cfg.BMCPassword, "BMC password (never logged)")
+	serial := fs.String("serial-target", "", "libvirt domain or console path")
+	isoURL := fs.String("iso-url", "", "BMC-reachable ISO URL on lab :8080")
+	systemID := fs.String("system-id", "", "optional Redfish system id")
+	profile := fs.String("profile-ref", "spike", "profile ref")
+	wait := fs.Bool("wait", true, "wait for terminal job state")
+	waitTimeout := fs.Duration("wait-timeout", 30*time.Minute, "max wait when -wait")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	dev := *deviceID
+	if dev == "" {
+		dev = *device
+	}
+	req := models.StartJobRequest{
+		DeviceID:     dev,
+		ProfileRef:   *profile,
+		ISOURL:       *isoURL,
+		BMCEndpoint:  *bmcURL,
+		BMCUsername:  *bmcUser,
+		BMCPassword:  *bmcPass,
+		SerialTarget: *serial,
+		SystemID:     *systemID,
+	}
+
+	store, dbCloser, err := openJobStore(cfg)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "jobstore: %v\n", err)
+		return 1
+	}
+	if dbCloser != nil {
+		defer dbCloser()
+	}
+
+	var secretBackend secrets.Backend = secrets.NewMemory()
+	if cfg.SecretsDir != "" {
+		fb, err := secrets.NewFile(cfg.SecretsDir)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "secrets: %v\n", err)
+			return 1
+		}
+		secretBackend = fb
+	}
+
+	// Wire Observe watch service with progress from orchestrator (two-step inject).
+	watchSvc := sol.NewWatchService(log, nil)
+	orch := job.NewOrchestrator(job.Options{
+		Log:                 log,
+		Store:               store,
+		Secrets:             secretBackend,
+		NewBMC:              redfish.NewBMC,
+		Watches:             watchSvc,
+		AuthMode:            cfg.RedfishAuthMode,
+		TLSMode:             cfg.RedfishTLSMode,
+		CAFile:              cfg.RedfishCAFile,
+		ReconcileFailOrphan: cfg.ReconcileFailOrphans,
+	})
+	defer orch.Stop()
+	watchSvc.SetProgress(orch.ProgressPort())
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	if err := orch.ReconcileOrphans(ctx); err != nil {
+		log.Warn("orphan reconcile", "err", err.Error())
+	}
+
+	j, err := orch.Start(ctx, req)
+	if err != nil {
+		// may still have a job row
+		fmt.Fprintf(os.Stderr, "deploy run failed: %v\n", err)
+		if j.ID != "" {
+			_ = json.NewEncoder(os.Stdout).Encode(j)
+		}
+		return 1
+	}
+	fmt.Fprintf(os.Stderr, "job %s started (state=%s)\n", j.ID, j.State)
+	_ = json.NewEncoder(os.Stdout).Encode(j)
+
+	if !*wait {
+		return 0
+	}
+
+	deadline := time.Now().Add(*waitTimeout)
+	for {
+		if ctx.Err() != nil {
+			fmt.Fprintln(os.Stderr, "interrupted; job continues until process exit cleanup")
+			_ = orch.Cancel(context.Background(), j.ID)
+			// give HandleTerminal a moment
+			time.Sleep(500 * time.Millisecond)
+			return 130
+		}
+		cur, err := orch.Get(ctx, j.ID)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "status: %v\n", err)
+			return 1
+		}
+		if cur.State == models.StateProvisioned {
+			_ = json.NewEncoder(os.Stdout).Encode(cur)
+			fmt.Fprintln(os.Stderr, "provisioned OK")
+			return 0
+		}
+		if cur.State == models.StateFailed {
+			_ = json.NewEncoder(os.Stdout).Encode(cur)
+			fmt.Fprintf(os.Stderr, "failed: %s\n", cur.Error)
+			return 1
+		}
+		if time.Now().After(deadline) {
+			fmt.Fprintln(os.Stderr, "wait timeout")
+			return 1
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+}
+
+func cmdDeployStatus(args []string) int {
+	cfg, err := config.Load()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "config: %v\n", err)
+		return 1
+	}
+	fs := flag.NewFlagSet("deploy status", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	jobID := fs.String("job", "", "job id")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if *jobID == "" {
+		fmt.Fprintln(os.Stderr, "-job is required")
+		return 2
+	}
+	store, closer, err := openJobStore(cfg)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "jobstore: %v\n", err)
+		return 1
+	}
+	if closer != nil {
+		defer closer()
+	}
+	j, err := store.Get(context.Background(), *jobID)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "get job: %v\n", err)
+		return 1
+	}
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	_ = enc.Encode(j)
+	return 0
+}
+
+func cmdDeployCancel(args []string) int {
+	cfg, err := config.Load()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "config: %v\n", err)
+		return 1
+	}
+	log := newLogger(cfg.LogLevel)
+	fs := flag.NewFlagSet("deploy cancel", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	jobID := fs.String("job", "", "job id")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if *jobID == "" {
+		fmt.Fprintln(os.Stderr, "-job is required")
+		return 2
+	}
+	store, closer, err := openJobStore(cfg)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "jobstore: %v\n", err)
+		return 1
+	}
+	if closer != nil {
+		defer closer()
+	}
+	// Cancel needs a live orchestrator with BMC factory for cleanup.
+	var secretBackend secrets.Backend = secrets.NewMemory()
+	if cfg.SecretsDir != "" {
+		if fb, err := secrets.NewFile(cfg.SecretsDir); err == nil {
+			secretBackend = fb
+		}
+	}
+	watchSvc := sol.NewWatchService(log, nil)
+	orch := job.NewOrchestrator(job.Options{
+		Log:                 log,
+		Store:               store,
+		Secrets:             secretBackend,
+		NewBMC:              redfish.NewBMC,
+		Watches:             watchSvc,
+		AuthMode:            cfg.RedfishAuthMode,
+		TLSMode:             cfg.RedfishTLSMode,
+		CAFile:              cfg.RedfishCAFile,
+		ReconcileFailOrphan: cfg.ReconcileFailOrphans,
+	})
+	defer orch.Stop()
+	watchSvc.SetProgress(orch.ProgressPort())
+
+	if err := orch.Cancel(context.Background(), *jobID); err != nil {
+		fmt.Fprintf(os.Stderr, "cancel: %v\n", err)
+		return 1
+	}
+	// Wait briefly for async terminal
+	time.Sleep(300 * time.Millisecond)
+	j, err := store.Get(context.Background(), *jobID)
+	if err == nil {
+		_ = json.NewEncoder(os.Stdout).Encode(j)
+	}
+	return 0
+}
+
+func openJobStore(cfg config.Config) (jobstore.Store, func(), error) {
+	if cfg.TelemetryDatabaseURL == "" {
+		// Process-local store; durable orphans require SHOAL_TELEMETRY_DATABASE_URL.
+		return jobstore.NewMemory(), nil, nil
+	}
+	db, err := telemetry.OpenAndMigrate(context.Background(), cfg.TelemetryDatabaseURL)
+	if err != nil {
+		return nil, nil, err
+	}
+	return jobstore.NewPostgres(db), func() { _ = db.Close() }, nil
+}

--- a/internal/cli/deploy.go
+++ b/internal/cli/deploy.go
@@ -13,7 +13,6 @@ import (
 	"github.com/mattcburns/shoal/internal/common/config"
 	"github.com/mattcburns/shoal/internal/common/models"
 	"github.com/mattcburns/shoal/internal/common/redfish"
-	"github.com/mattcburns/shoal/internal/common/secrets"
 	"github.com/mattcburns/shoal/internal/common/telemetry"
 	"github.com/mattcburns/shoal/internal/deploy/job"
 	"github.com/mattcburns/shoal/internal/deploy/jobstore"
@@ -95,15 +94,7 @@ func cmdDeployRun(args []string) int {
 		defer dbCloser()
 	}
 
-	var secretBackend secrets.Backend = secrets.NewMemory()
-	if cfg.SecretsDir != "" {
-		fb, err := secrets.NewFile(cfg.SecretsDir)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "secrets: %v\n", err)
-			return 1
-		}
-		secretBackend = fb
-	}
+	secretBackend := openSecrets(cfg)
 
 	// Wire Observe watch service with progress from orchestrator (two-step inject).
 	watchSvc := sol.NewWatchService(log, nil)
@@ -243,12 +234,7 @@ func cmdDeployCancel(args []string) int {
 		defer closer()
 	}
 	// Cancel needs a live orchestrator with BMC factory for cleanup.
-	var secretBackend secrets.Backend = secrets.NewMemory()
-	if cfg.SecretsDir != "" {
-		if fb, err := secrets.NewFile(cfg.SecretsDir); err == nil {
-			secretBackend = fb
-		}
-	}
+	secretBackend := openSecrets(cfg)
 	watchSvc := sol.NewWatchService(log, nil)
 	watchSvc.NewTransport = sol.NewTransportFactory(sol.SSHSerialConfig{
 		Host:    cfg.SerialSSHHost,

--- a/internal/common/config/config.go
+++ b/internal/common/config/config.go
@@ -28,6 +28,12 @@ type Config struct {
 	ISOBaseURL           string
 	ReconcileFailOrphans bool
 	SecretsDir           string
+	// Serial SSH delegate (VM-hosted lab: nest libvirt on L1).
+	SerialSSHHost string
+	SerialSSHUser string
+	SerialSSHKey  string
+	// SerialSSHSudo runs remote virsh/cat with sudo -n (default true when host set).
+	SerialSSHSudo bool
 }
 
 // Load reads SHOAL_* environment variables with Phase 1-friendly defaults.
@@ -52,6 +58,10 @@ func Load() (Config, error) {
 		ISOBaseURL:           os.Getenv("SHOAL_ISO_BASE_URL"),
 		ReconcileFailOrphans: true,
 		SecretsDir:           envOr("SHOAL_SECRETS_DIR", ""),
+		SerialSSHHost:        os.Getenv("SHOAL_SERIAL_SSH_HOST"),
+		SerialSSHUser:        envOr("SHOAL_SERIAL_SSH_USER", "lab"),
+		SerialSSHKey:         envOr("SHOAL_SERIAL_SSH_KEY", ""),
+		SerialSSHSudo:        true,
 	}
 
 	if v := os.Getenv("SHOAL_RECONCILE_FAIL_ORPHANS"); v != "" {
@@ -60,6 +70,19 @@ func Load() (Config, error) {
 			return Config{}, fmt.Errorf("config: SHOAL_RECONCILE_FAIL_ORPHANS: %w", err)
 		}
 		c.ReconcileFailOrphans = b
+	}
+	if v := os.Getenv("SHOAL_SERIAL_SSH_SUDO"); v != "" {
+		b, err := strconv.ParseBool(v)
+		if err != nil {
+			return Config{}, fmt.Errorf("config: SHOAL_SERIAL_SSH_SUDO: %w", err)
+		}
+		c.SerialSSHSudo = b
+	}
+	if c.SerialSSHKey == "" {
+		// Common lab default (not required to exist).
+		if home := os.Getenv("HOME"); home != "" {
+			c.SerialSSHKey = home + "/.ssh/shoal_lab_vm"
+		}
 	}
 
 	if err := c.validateBasics(); err != nil {

--- a/internal/common/config/config_test.go
+++ b/internal/common/config/config_test.go
@@ -49,6 +49,9 @@ func TestLoadCustom(t *testing.T) {
 	t.Setenv("SHOAL_TELEMETRY_DATABASE_URL", "postgres://shoal@localhost:5433/shoal_telemetry")
 	t.Setenv("SHOAL_AI_PROVIDER", "ollama")
 	t.Setenv("SHOAL_RECONCILE_FAIL_ORPHANS", "false")
+	t.Setenv("SHOAL_SERIAL_SSH_HOST", "192.168.122.100")
+	t.Setenv("SHOAL_SERIAL_SSH_USER", "lab")
+	t.Setenv("SHOAL_SERIAL_SSH_KEY", "/tmp/key")
 	c, err := config.Load()
 	if err != nil {
 		t.Fatal(err)
@@ -64,6 +67,9 @@ func TestLoadCustom(t *testing.T) {
 	}
 	if c.ReconcileFailOrphans {
 		t.Fatal("expected false")
+	}
+	if c.SerialSSHHost != "192.168.122.100" || c.SerialSSHKey != "/tmp/key" {
+		t.Fatalf("serial ssh: host=%q key=%q", c.SerialSSHHost, c.SerialSSHKey)
 	}
 }
 

--- a/internal/common/models/models.go
+++ b/internal/common/models/models.go
@@ -170,6 +170,8 @@ type StartJobRequest struct {
 	SerialTarget  string `json:"serial_target"`          // libvirt domain or SOL target
 	SystemID      string `json:"system_id,omitempty"`
 	CredentialRef string `json:"credential_ref,omitempty"` // alt: pre-seeded secret (skip user/pass)
+	// StallTimeout is the SOL silence window before ReportStall (0 = Orchestrator default).
+	StallTimeout time.Duration `json:"stall_timeout,omitempty"`
 }
 
 // CancelJobRequest cancels an in-flight provisioning job.

--- a/internal/common/redfish/bmc.go
+++ b/internal/common/redfish/bmc.go
@@ -1,0 +1,28 @@
+package redfish
+
+import "context"
+
+// BMC is the only Redfish surface Deploy/Observe import.
+// Implementation uses gofish under the hood; types do not leak.
+type BMC interface {
+	Open(ctx context.Context) error
+	Close(ctx context.Context) error
+	ServiceRoot(ctx context.Context) (ServiceRoot, error)
+	// ListSystems returns computer systems (systemID filter optional empty = all).
+	ListSystems(ctx context.Context) ([]SystemInfo, error)
+	GetSystem(ctx context.Context, systemID string) (SystemInfo, error)
+	GetBoot(ctx context.Context, systemID string) (BootInfo, error)
+	SetBootOverrideOnceCD(ctx context.Context, systemID string) error
+	ClearBootOverride(ctx context.Context, systemID string) error
+	// ListVirtualMedia lists media under the given system (preferred) or all managers if systemID empty.
+	ListVirtualMedia(ctx context.Context, systemID string) ([]VirtualMedia, error)
+	InsertVirtualMedia(ctx context.Context, mediaURI, imageURL string) error
+	EjectVirtualMedia(ctx context.Context, mediaURI string) error
+	// Power resetType: On | ForceOff | ForceRestart | GracefulRestart | ...
+	Power(ctx context.Context, systemID, resetType string) error
+	// CleanupMediaAndBoot ejects all inserted media for the system and clears boot override.
+	CleanupMediaAndBoot(ctx context.Context, systemID string) error
+}
+
+// Factory constructs a BMC from config (composition root injects this).
+type Factory func(cfg Config) (BMC, error)

--- a/internal/common/redfish/client.go
+++ b/internal/common/redfish/client.go
@@ -155,7 +155,7 @@ func (c *client) ListSystems(_ context.Context) ([]SystemInfo, error) {
 	return out, nil
 }
 
-// GetSystem returns one system by ID (or first if systemID empty and only one exists).
+// GetSystem returns one system by ID or Name (or first if systemID empty and only one exists).
 func (c *client) GetSystem(ctx context.Context, systemID string) (SystemInfo, error) {
 	systems, err := c.ListSystems(ctx)
 	if err != nil {
@@ -166,12 +166,12 @@ func (c *client) GetSystem(ctx context.Context, systemID string) (SystemInfo, er
 			return SystemInfo{}, fmt.Errorf("redfish: no systems")
 		}
 		if len(systems) > 1 {
-			return SystemInfo{}, fmt.Errorf("redfish: multiple systems; specify system id")
+			return SystemInfo{}, fmt.Errorf("redfish: multiple systems; specify system id or name")
 		}
 		return systems[0], nil
 	}
 	for _, s := range systems {
-		if s.ID == systemID || strings.HasSuffix(s.ODataID, "/"+systemID) {
+		if s.ID == systemID || s.Name == systemID || strings.HasSuffix(s.ODataID, "/"+systemID) {
 			return s, nil
 		}
 	}
@@ -204,10 +204,13 @@ func (c *client) computerSystem(systemID string) (*gofishredfish.ComputerSystem,
 		if len(systems) == 0 {
 			return nil, fmt.Errorf("redfish: no systems")
 		}
+		if len(systems) > 1 {
+			return nil, fmt.Errorf("redfish: multiple systems; specify system id or name")
+		}
 		return systems[0], nil
 	}
 	for _, s := range systems {
-		if s.ID == systemID || strings.HasSuffix(s.ODataID, "/"+systemID) {
+		if s.ID == systemID || s.Name == systemID || strings.HasSuffix(s.ODataID, "/"+systemID) {
 			return s, nil
 		}
 	}
@@ -448,6 +451,8 @@ func (c *client) Power(ctx context.Context, systemID, resetType string) error {
 }
 
 // CleanupMediaAndBoot ejects all inserted media and clears boot override.
+// Best-effort: continues after individual step failures (powered-off emulators
+// may reject some actions).
 func (c *client) CleanupMediaAndBoot(ctx context.Context, systemID string) error {
 	var firstErr error
 	vms, err := c.ListVirtualMedia(ctx, systemID)

--- a/internal/common/redfish/client.go
+++ b/internal/common/redfish/client.go
@@ -1,0 +1,473 @@
+package redfish
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/stmcginnis/gofish"
+	gofishredfish "github.com/stmcginnis/gofish/redfish"
+)
+
+// client is the gofish-backed BMC implementation.
+type client struct {
+	cfg    Config
+	mu     sync.Mutex
+	api    *gofish.APIClient
+	opened bool
+}
+
+// NewBMC constructs the gofish-backed implementation. Call Open before use.
+func NewBMC(cfg Config) (BMC, error) {
+	if cfg.BaseURL == "" {
+		return nil, fmt.Errorf("redfish: empty BaseURL")
+	}
+	if cfg.MaxConcurrent <= 0 {
+		cfg.MaxConcurrent = 1
+	}
+	if cfg.RequestTimeout <= 0 {
+		cfg.RequestTimeout = 30 * time.Second
+	}
+	if cfg.AuthMode == "" {
+		cfg.AuthMode = "basic"
+	}
+	if cfg.TLSMode == "" {
+		cfg.TLSMode = "off"
+	}
+	return &client{cfg: cfg}, nil
+}
+
+// Open connects to the Redfish service root.
+func (c *client) Open(ctx context.Context) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.opened && c.api != nil {
+		return nil
+	}
+
+	httpClient, err := c.httpClient()
+	if err != nil {
+		return err
+	}
+	httpClient.Timeout = c.cfg.RequestTimeout
+
+	gcfg := gofish.ClientConfig{
+		Endpoint:              c.cfg.BaseURL,
+		Username:              c.cfg.Username,
+		Password:              c.cfg.Password,
+		HTTPClient:            httpClient,
+		BasicAuth:             strings.EqualFold(c.cfg.AuthMode, "basic"),
+		Insecure:              strings.EqualFold(c.cfg.TLSMode, "insecure"),
+		MaxConcurrentRequests: int64(c.cfg.MaxConcurrent),
+		ReuseConnections:      true,
+	}
+
+	api, err := gofish.ConnectContext(ctx, gcfg)
+	if err != nil {
+		return fmt.Errorf("redfish: connect: %w", err)
+	}
+	c.api = api
+	c.opened = true
+	return nil
+}
+
+func (c *client) httpClient() (*http.Client, error) {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	switch strings.ToLower(c.cfg.TLSMode) {
+	case "off":
+		// plain HTTP endpoints; TLS config unused for http://
+	case "insecure":
+		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} //nolint:gosec // explicit lab/BMC self-signed mode
+	case "custom_ca":
+		pem, err := os.ReadFile(c.cfg.CAFile)
+		if err != nil {
+			return nil, fmt.Errorf("redfish: read CA file: %w", err)
+		}
+		pool := x509.NewCertPool()
+		if !pool.AppendCertsFromPEM(pem) {
+			return nil, fmt.Errorf("redfish: no certificates in CA file")
+		}
+		transport.TLSClientConfig = &tls.Config{RootCAs: pool, MinVersion: tls.VersionTLS12}
+	default:
+		return nil, fmt.Errorf("redfish: unknown TLS mode %q", c.cfg.TLSMode)
+	}
+	return &http.Client{Transport: transport}, nil
+}
+
+// Close logs out and releases the client.
+func (c *client) Close(_ context.Context) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.api != nil {
+		c.api.Logout()
+		c.api = nil
+	}
+	c.opened = false
+	return nil
+}
+
+func (c *client) apiClient() (*gofish.APIClient, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if !c.opened || c.api == nil {
+		return nil, fmt.Errorf("redfish: not open")
+	}
+	return c.api, nil
+}
+
+// ServiceRoot returns service root metadata.
+func (c *client) ServiceRoot(_ context.Context) (ServiceRoot, error) {
+	api, err := c.apiClient()
+	if err != nil {
+		return ServiceRoot{}, err
+	}
+	sr := api.Service
+	if sr == nil {
+		return ServiceRoot{}, fmt.Errorf("redfish: nil service root")
+	}
+	return ServiceRoot{
+		Name:           sr.Name,
+		RedfishVersion: sr.RedfishVersion,
+		UUID:           sr.UUID,
+	}, nil
+}
+
+// ListSystems returns all computer systems.
+func (c *client) ListSystems(_ context.Context) ([]SystemInfo, error) {
+	api, err := c.apiClient()
+	if err != nil {
+		return nil, err
+	}
+	systems, err := api.Service.Systems()
+	if err != nil {
+		return nil, fmt.Errorf("redfish: systems: %w", err)
+	}
+	out := make([]SystemInfo, 0, len(systems))
+	for _, s := range systems {
+		out = append(out, mapSystem(s))
+	}
+	return out, nil
+}
+
+// GetSystem returns one system by ID (or first if systemID empty and only one exists).
+func (c *client) GetSystem(ctx context.Context, systemID string) (SystemInfo, error) {
+	systems, err := c.ListSystems(ctx)
+	if err != nil {
+		return SystemInfo{}, err
+	}
+	if systemID == "" {
+		if len(systems) == 0 {
+			return SystemInfo{}, fmt.Errorf("redfish: no systems")
+		}
+		if len(systems) > 1 {
+			return SystemInfo{}, fmt.Errorf("redfish: multiple systems; specify system id")
+		}
+		return systems[0], nil
+	}
+	for _, s := range systems {
+		if s.ID == systemID || strings.HasSuffix(s.ODataID, "/"+systemID) {
+			return s, nil
+		}
+	}
+	return SystemInfo{}, fmt.Errorf("redfish: system %q not found", systemID)
+}
+
+func mapSystem(s *gofishredfish.ComputerSystem) SystemInfo {
+	return SystemInfo{
+		ID:           s.ID,
+		Name:         s.Name,
+		UUID:         s.UUID,
+		Serial:       s.SerialNumber,
+		Model:        s.Model,
+		Manufacturer: s.Manufacturer,
+		PowerState:   string(s.PowerState),
+		ODataID:      s.ODataID,
+	}
+}
+
+func (c *client) computerSystem(systemID string) (*gofishredfish.ComputerSystem, error) {
+	api, err := c.apiClient()
+	if err != nil {
+		return nil, err
+	}
+	systems, err := api.Service.Systems()
+	if err != nil {
+		return nil, fmt.Errorf("redfish: systems: %w", err)
+	}
+	if systemID == "" {
+		if len(systems) == 0 {
+			return nil, fmt.Errorf("redfish: no systems")
+		}
+		return systems[0], nil
+	}
+	for _, s := range systems {
+		if s.ID == systemID || strings.HasSuffix(s.ODataID, "/"+systemID) {
+			return s, nil
+		}
+	}
+	return nil, fmt.Errorf("redfish: system %q not found", systemID)
+}
+
+// GetBoot returns boot override state.
+func (c *client) GetBoot(_ context.Context, systemID string) (BootInfo, error) {
+	sys, err := c.computerSystem(systemID)
+	if err != nil {
+		return BootInfo{}, err
+	}
+	return BootInfo{
+		OverrideEnabled: string(sys.Boot.BootSourceOverrideEnabled),
+		OverrideTarget:  string(sys.Boot.BootSourceOverrideTarget),
+	}, nil
+}
+
+// SetBootOverrideOnceCD sets one-time CD boot (idempotent).
+func (c *client) SetBootOverrideOnceCD(ctx context.Context, systemID string) error {
+	sys, err := c.computerSystem(systemID)
+	if err != nil {
+		return err
+	}
+	cur, err := c.GetBoot(ctx, systemID)
+	if err != nil {
+		return err
+	}
+	if cur.OverrideEnabled == string(gofishredfish.OnceBootSourceOverrideEnabled) &&
+		cur.OverrideTarget == string(gofishredfish.CdBootSourceOverrideTarget) {
+		return nil
+	}
+	boot := sys.Boot
+	boot.BootSourceOverrideEnabled = gofishredfish.OnceBootSourceOverrideEnabled
+	boot.BootSourceOverrideTarget = gofishredfish.CdBootSourceOverrideTarget
+	if err := sys.SetBoot(boot); err != nil {
+		return fmt.Errorf("redfish: set boot override: %w", err)
+	}
+	return nil
+}
+
+// ClearBootOverride disables boot override (idempotent).
+//
+// sushy-tools maps BootSourceOverrideTarget onto libvirt boot devices and
+// rejects target "None" ("Target libvirt device None does not exist"). Prefer
+// Disabled + Hdd as the normal post-provision boot target for lab emulators.
+func (c *client) ClearBootOverride(ctx context.Context, systemID string) error {
+	sys, err := c.computerSystem(systemID)
+	if err != nil {
+		return err
+	}
+	cur, err := c.GetBoot(ctx, systemID)
+	if err != nil {
+		return err
+	}
+	if (cur.OverrideEnabled == string(gofishredfish.DisabledBootSourceOverrideEnabled) ||
+		cur.OverrideEnabled == "" || cur.OverrideEnabled == "Disabled") &&
+		(cur.OverrideTarget == string(gofishredfish.HddBootSourceOverrideTarget) ||
+			cur.OverrideTarget == "Hdd" || cur.OverrideTarget == "") {
+		return nil
+	}
+	boot := sys.Boot
+	boot.BootSourceOverrideEnabled = gofishredfish.DisabledBootSourceOverrideEnabled
+	boot.BootSourceOverrideTarget = gofishredfish.HddBootSourceOverrideTarget
+	if err := sys.SetBoot(boot); err != nil {
+		// Retry with Continuous/Hdd if Disabled is rejected by some firmwares.
+		boot.BootSourceOverrideEnabled = gofishredfish.ContinuousBootSourceOverrideEnabled
+		boot.BootSourceOverrideTarget = gofishredfish.HddBootSourceOverrideTarget
+		if err2 := sys.SetBoot(boot); err2 != nil {
+			return fmt.Errorf("redfish: clear boot override: %w", err)
+		}
+	}
+	return nil
+}
+
+// ListVirtualMedia lists virtual media for a system, falling back to managers.
+func (c *client) ListVirtualMedia(_ context.Context, systemID string) ([]VirtualMedia, error) {
+	api, err := c.apiClient()
+	if err != nil {
+		return nil, err
+	}
+	var out []VirtualMedia
+
+	// Prefer system-attached virtual media.
+	sys, err := c.computerSystem(systemID)
+	if err == nil {
+		vms, vmErr := sys.VirtualMedia()
+		if vmErr == nil {
+			for _, vm := range vms {
+				out = append(out, mapVM(vm))
+			}
+		}
+	}
+
+	// Also check managers (sushy-tools often exposes VM here).
+	managers, err := api.Service.Managers()
+	if err == nil {
+		for _, m := range managers {
+			vms, vmErr := m.VirtualMedia()
+			if vmErr != nil {
+				continue
+			}
+			for _, vm := range vms {
+				mapped := mapVM(vm)
+				// de-dupe by URI
+				dup := false
+				for _, existing := range out {
+					if existing.URI == mapped.URI {
+						dup = true
+						break
+					}
+				}
+				if !dup {
+					out = append(out, mapped)
+				}
+			}
+		}
+	}
+
+	if len(out) == 0 {
+		return nil, fmt.Errorf("redfish: no virtual media found")
+	}
+	return out, nil
+}
+
+func mapVM(vm *gofishredfish.VirtualMedia) VirtualMedia {
+	m := VirtualMedia{
+		URI:      vm.ODataID,
+		Name:     vm.Name,
+		ID:       vm.ID,
+		Image:    vm.Image,
+		Inserted: vm.Inserted,
+	}
+	for _, t := range vm.MediaTypes {
+		m.MediaTypes = append(m.MediaTypes, string(t))
+		if t == gofishredfish.CDMediaType || t == gofishredfish.DVDMediaType {
+			m.SupportsCD = true
+		}
+	}
+	if len(vm.MediaTypes) == 0 {
+		// assume CD-capable when types omitted (some emulators)
+		m.SupportsCD = true
+	}
+	return m
+}
+
+func (c *client) virtualMediaByURI(mediaURI string) (*gofishredfish.VirtualMedia, error) {
+	api, err := c.apiClient()
+	if err != nil {
+		return nil, err
+	}
+	// Search systems
+	systems, err := api.Service.Systems()
+	if err == nil {
+		for _, s := range systems {
+			vms, vmErr := s.VirtualMedia()
+			if vmErr != nil {
+				continue
+			}
+			for _, vm := range vms {
+				if vm.ODataID == mediaURI || vm.ID == mediaURI {
+					return vm, nil
+				}
+			}
+		}
+	}
+	managers, err := api.Service.Managers()
+	if err == nil {
+		for _, m := range managers {
+			vms, vmErr := m.VirtualMedia()
+			if vmErr != nil {
+				continue
+			}
+			for _, vm := range vms {
+				if vm.ODataID == mediaURI || vm.ID == mediaURI {
+					return vm, nil
+				}
+			}
+		}
+	}
+	return nil, fmt.Errorf("redfish: virtual media %q not found", mediaURI)
+}
+
+// InsertVirtualMedia inserts an image URL (idempotent if already inserted with same image).
+func (c *client) InsertVirtualMedia(_ context.Context, mediaURI, imageURL string) error {
+	vm, err := c.virtualMediaByURI(mediaURI)
+	if err != nil {
+		return err
+	}
+	if vm.Inserted && vm.Image == imageURL {
+		return nil
+	}
+	if vm.Inserted {
+		if err := vm.EjectMedia(); err != nil {
+			return fmt.Errorf("redfish: eject before insert: %w", err)
+		}
+	}
+	if err := vm.InsertMedia(imageURL, true, true); err != nil {
+		return fmt.Errorf("redfish: insert media: %w", err)
+	}
+	return nil
+}
+
+// EjectVirtualMedia ejects media (idempotent if already empty).
+func (c *client) EjectVirtualMedia(_ context.Context, mediaURI string) error {
+	vm, err := c.virtualMediaByURI(mediaURI)
+	if err != nil {
+		return err
+	}
+	if !vm.Inserted {
+		return nil
+	}
+	if err := vm.EjectMedia(); err != nil {
+		return fmt.Errorf("redfish: eject media: %w", err)
+	}
+	return nil
+}
+
+// Power performs a reset action (idempotent for On when already on).
+func (c *client) Power(ctx context.Context, systemID, resetType string) error {
+	sys, err := c.computerSystem(systemID)
+	if err != nil {
+		return err
+	}
+	info, err := c.GetSystem(ctx, systemID)
+	if err != nil {
+		return err
+	}
+	rt := gofishredfish.ResetType(resetType)
+	if resetType == "On" && strings.EqualFold(info.PowerState, "On") {
+		// Force restart so one-time media is observed.
+		rt = gofishredfish.ForceRestartResetType
+	}
+	if err := sys.Reset(rt); err != nil {
+		return fmt.Errorf("redfish: power %s: %w", resetType, err)
+	}
+	return nil
+}
+
+// CleanupMediaAndBoot ejects all inserted media and clears boot override.
+func (c *client) CleanupMediaAndBoot(ctx context.Context, systemID string) error {
+	var firstErr error
+	vms, err := c.ListVirtualMedia(ctx, systemID)
+	if err != nil {
+		firstErr = err
+	} else {
+		for _, vm := range vms {
+			if !vm.Inserted {
+				continue
+			}
+			if err := c.EjectVirtualMedia(ctx, vm.URI); err != nil && firstErr == nil {
+				firstErr = err
+			}
+		}
+	}
+	if err := c.ClearBootOverride(ctx, systemID); err != nil && firstErr == nil {
+		firstErr = err
+	}
+	return firstErr
+}
+
+// Ensure client implements BMC.
+var _ BMC = (*client)(nil)

--- a/internal/common/redfish/doc.go
+++ b/internal/common/redfish/doc.go
@@ -1,3 +1,0 @@
-// Package redfish wraps gofish behind Shoal BMC interfaces.
-// gofish types must not leak outside this package. Implementation lands in Phase 2.
-package redfish

--- a/internal/common/redfish/fake.go
+++ b/internal/common/redfish/fake.go
@@ -1,0 +1,190 @@
+package redfish
+
+import (
+	"context"
+	"fmt"
+	"sync"
+)
+
+// Fake is an in-memory BMC for unit tests (no network).
+type Fake struct {
+	mu sync.Mutex
+
+	OpenErr    error
+	Systems    []SystemInfo
+	Boot       map[string]BootInfo     // systemID -> boot
+	Media      map[string]VirtualMedia // URI -> media
+	PowerCalls []string
+	// InsertedImage tracks last insert per media URI.
+	InsertedImage map[string]string
+
+	// FailNextCleanup forces CleanupMediaAndBoot to fail once.
+	FailNextCleanup bool
+}
+
+// NewFake returns a Fake with one system and one CD virtual media slot.
+func NewFake() *Fake {
+	return &Fake{
+		Systems: []SystemInfo{{
+			ID: "1", Name: "System.1", PowerState: "Off", ODataID: "/redfish/v1/Systems/1",
+		}},
+		Boot: map[string]BootInfo{
+			"1": {OverrideEnabled: "Disabled", OverrideTarget: "None"},
+		},
+		Media: map[string]VirtualMedia{
+			"/redfish/v1/Managers/1/VirtualMedia/Cd": {
+				URI: "/redfish/v1/Managers/1/VirtualMedia/Cd", Name: "Cd", ID: "Cd", SupportsCD: true,
+			},
+		},
+		InsertedImage: make(map[string]string),
+	}
+}
+
+func (f *Fake) Open(_ context.Context) error  { return f.OpenErr }
+func (f *Fake) Close(_ context.Context) error { return nil }
+
+func (f *Fake) ServiceRoot(_ context.Context) (ServiceRoot, error) {
+	return ServiceRoot{Name: "Fake", RedfishVersion: "1.0"}, nil
+}
+
+func (f *Fake) ListSystems(_ context.Context) ([]SystemInfo, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]SystemInfo, len(f.Systems))
+	copy(out, f.Systems)
+	return out, nil
+}
+
+func (f *Fake) GetSystem(_ context.Context, systemID string) (SystemInfo, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, s := range f.Systems {
+		if systemID == "" || s.ID == systemID {
+			return s, nil
+		}
+	}
+	return SystemInfo{}, fmt.Errorf("fake: system not found")
+}
+
+func (f *Fake) GetBoot(_ context.Context, systemID string) (BootInfo, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if systemID == "" {
+		systemID = "1"
+	}
+	b, ok := f.Boot[systemID]
+	if !ok {
+		return BootInfo{}, fmt.Errorf("fake: no boot for %s", systemID)
+	}
+	return b, nil
+}
+
+func (f *Fake) SetBootOverrideOnceCD(_ context.Context, systemID string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if systemID == "" {
+		systemID = "1"
+	}
+	f.Boot[systemID] = BootInfo{OverrideEnabled: "Once", OverrideTarget: "Cd"}
+	return nil
+}
+
+func (f *Fake) ClearBootOverride(_ context.Context, systemID string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if systemID == "" {
+		systemID = "1"
+	}
+	f.Boot[systemID] = BootInfo{OverrideEnabled: "Disabled", OverrideTarget: "None"}
+	return nil
+}
+
+func (f *Fake) ListVirtualMedia(_ context.Context, _ string) ([]VirtualMedia, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]VirtualMedia, 0, len(f.Media))
+	for _, m := range f.Media {
+		out = append(out, m)
+	}
+	return out, nil
+}
+
+func (f *Fake) InsertVirtualMedia(_ context.Context, mediaURI, imageURL string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	m, ok := f.Media[mediaURI]
+	if !ok {
+		return fmt.Errorf("fake: media not found")
+	}
+	m.Inserted = true
+	m.Image = imageURL
+	f.Media[mediaURI] = m
+	f.InsertedImage[mediaURI] = imageURL
+	return nil
+}
+
+func (f *Fake) EjectVirtualMedia(_ context.Context, mediaURI string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	m, ok := f.Media[mediaURI]
+	if !ok {
+		return fmt.Errorf("fake: media not found")
+	}
+	m.Inserted = false
+	m.Image = ""
+	f.Media[mediaURI] = m
+	delete(f.InsertedImage, mediaURI)
+	return nil
+}
+
+func (f *Fake) Power(_ context.Context, systemID, resetType string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.PowerCalls = append(f.PowerCalls, resetType)
+	for i, s := range f.Systems {
+		if systemID == "" || s.ID == systemID {
+			s.PowerState = "On"
+			f.Systems[i] = s
+		}
+	}
+	return nil
+}
+
+func (f *Fake) CleanupMediaAndBoot(ctx context.Context, systemID string) error {
+	f.mu.Lock()
+	if f.FailNextCleanup {
+		f.FailNextCleanup = false
+		f.mu.Unlock()
+		return fmt.Errorf("fake: cleanup failed")
+	}
+	f.mu.Unlock()
+	vms, _ := f.ListVirtualMedia(ctx, systemID)
+	for _, vm := range vms {
+		if vm.Inserted {
+			_ = f.EjectVirtualMedia(ctx, vm.URI)
+		}
+	}
+	return f.ClearBootOverride(ctx, systemID)
+}
+
+// MediaInserted reports whether any media is inserted (test helper).
+func (f *Fake) MediaInserted() bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, m := range f.Media {
+		if m.Inserted {
+			return true
+		}
+	}
+	return false
+}
+
+// BootCleared reports whether boot override is disabled on system 1.
+func (f *Fake) BootCleared() bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	b := f.Boot["1"]
+	return b.OverrideEnabled == "Disabled"
+}
+
+var _ BMC = (*Fake)(nil)

--- a/internal/common/redfish/fake.go
+++ b/internal/common/redfish/fake.go
@@ -59,7 +59,7 @@ func (f *Fake) GetSystem(_ context.Context, systemID string) (SystemInfo, error)
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	for _, s := range f.Systems {
-		if systemID == "" || s.ID == systemID {
+		if systemID == "" || s.ID == systemID || s.Name == systemID {
 			return s, nil
 		}
 	}

--- a/internal/common/redfish/lab_integration_test.go
+++ b/internal/common/redfish/lab_integration_test.go
@@ -1,0 +1,120 @@
+//go:build integration
+
+package redfish_test
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/mattcburns/shoal/internal/common/redfish"
+)
+
+// Live lab (VM mode): sushy-tools on shoal_lab_vm_host:8001.
+//
+//	SHOAL_BMC_URL=http://192.168.122.100:8001 \
+//	SHOAL_BMC_USERNAME=... SHOAL_BMC_PASSWORD=... \
+//	go test ./internal/common/redfish -tags=integration -count=1 -v
+func TestLabRedfishVirtualMediaBootCleanup(t *testing.T) {
+	base := envOr("SHOAL_BMC_URL", "http://192.168.122.100:8001")
+	user := os.Getenv("SHOAL_BMC_USERNAME")
+	pass := os.Getenv("SHOAL_BMC_PASSWORD")
+	if user == "" || pass == "" {
+		t.Skip("SHOAL_BMC_USERNAME/PASSWORD required")
+	}
+	iso := envOr("SHOAL_ISO_URL", "http://192.168.124.1:8080/shoal-marker.iso")
+	// Prefer node-1 if present; else first system.
+	wantName := envOr("SHOAL_SYSTEM_NAME", "shoal-node-1")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	bmc, err := redfish.NewBMC(redfish.Config{
+		BaseURL:       base,
+		Username:      user,
+		Password:      pass,
+		AuthMode:      "basic",
+		TLSMode:       "off",
+		MaxConcurrent: 1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := bmc.Open(ctx); err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = bmc.Close(context.Background()) }()
+
+	systems, err := bmc.ListSystems(ctx)
+	if err != nil {
+		t.Fatalf("list systems: %v", err)
+	}
+	if len(systems) == 0 {
+		t.Fatal("no systems")
+	}
+	sysID := systems[0].ID
+	for _, s := range systems {
+		if s.Name == wantName {
+			sysID = s.ID
+			break
+		}
+	}
+	t.Logf("using system id=%s", sysID)
+
+	vms, err := bmc.ListVirtualMedia(ctx, sysID)
+	if err != nil {
+		t.Fatalf("list vm: %v", err)
+	}
+	var mediaURI string
+	for _, vm := range vms {
+		if vm.SupportsCD {
+			mediaURI = vm.URI
+			break
+		}
+	}
+	if mediaURI == "" {
+		t.Fatalf("no CD media in %#v", vms)
+	}
+	t.Logf("media URI=%s iso=%s", mediaURI, iso)
+
+	if err := bmc.InsertVirtualMedia(ctx, mediaURI, iso); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if err := bmc.SetBootOverrideOnceCD(ctx, sysID); err != nil {
+		t.Fatalf("boot override: %v", err)
+	}
+	boot, err := bmc.GetBoot(ctx, sysID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("boot after set: %+v", boot)
+	if boot.OverrideTarget != "Cd" && boot.OverrideTarget != "CD" {
+		// sushy uses "Cd"
+		t.Logf("warning: override target is %q (expected Cd)", boot.OverrideTarget)
+	}
+
+	if err := bmc.Power(ctx, sysID, "On"); err != nil {
+		t.Fatalf("power: %v", err)
+	}
+
+	// Mandatory cleanup
+	if err := bmc.CleanupMediaAndBoot(ctx, sysID); err != nil {
+		t.Fatalf("cleanup: %v", err)
+	}
+	boot, _ = bmc.GetBoot(ctx, sysID)
+	vms, _ = bmc.ListVirtualMedia(ctx, sysID)
+	for _, vm := range vms {
+		if vm.URI == mediaURI && vm.Inserted {
+			t.Fatal("media still inserted after cleanup")
+		}
+	}
+	t.Logf("boot after cleanup: %+v", boot)
+}
+
+func envOr(k, d string) string {
+	if v := os.Getenv(k); v != "" {
+		return v
+	}
+	return d
+}

--- a/internal/common/redfish/types.go
+++ b/internal/common/redfish/types.go
@@ -1,0 +1,57 @@
+// Package redfish wraps gofish behind Shoal BMC interfaces.
+// gofish types must not leak outside this package.
+package redfish
+
+import "time"
+
+// Config configures a BMC connection.
+type Config struct {
+	BaseURL        string
+	Username       string
+	Password       string // never logged
+	AuthMode       string // "basic" | "session" — lab default basic
+	TLSMode        string // "off" | "insecure" | "custom_ca"
+	CAFile         string // when TLSMode=custom_ca
+	MaxConcurrent  int    // default 1–2
+	RequestTimeout time.Duration
+}
+
+// ServiceRoot is a Shoal-domain view of the Redfish service root.
+type ServiceRoot struct {
+	Name           string
+	RedfishVersion string
+	UUID           string
+	SystemsURL     string
+	ManagersURL    string
+}
+
+// SystemInfo is a ComputerSystem snapshot used by Deploy/Discover.
+type SystemInfo struct {
+	ID           string
+	Name         string
+	UUID         string
+	Serial       string
+	Model        string
+	Manufacturer string
+	PowerState   string
+	// ODataID is the system resource URI (for subsequent operations).
+	ODataID string
+}
+
+// BootInfo is the current boot override state.
+type BootInfo struct {
+	OverrideEnabled string // Disabled | Once | Continuous
+	OverrideTarget  string // None | Cd | Pxe | ...
+}
+
+// VirtualMedia describes a virtual media slot.
+type VirtualMedia struct {
+	// URI is the @odata.id used for Insert/Eject.
+	URI        string
+	Name       string
+	ID         string
+	Image      string
+	Inserted   bool
+	MediaTypes []string
+	SupportsCD bool
+}

--- a/internal/common/telemetry/db.go
+++ b/internal/common/telemetry/db.go
@@ -1,0 +1,60 @@
+package telemetry
+
+import (
+	"context"
+	"database/sql"
+	"embed"
+	"fmt"
+	"time"
+
+	_ "github.com/jackc/pgx/v5/stdlib" // Postgres driver (allow-listed)
+)
+
+//go:embed schema.sql
+var schemaFS embed.FS
+
+// Open opens a Postgres database using the allow-listed pgx stdlib driver.
+func Open(dsn string) (*sql.DB, error) {
+	if dsn == "" {
+		return nil, fmt.Errorf("telemetry: empty DSN")
+	}
+	db, err := sql.Open("pgx", dsn)
+	if err != nil {
+		return nil, fmt.Errorf("telemetry: open: %w", err)
+	}
+	db.SetMaxOpenConns(10)
+	db.SetMaxIdleConns(2)
+	db.SetConnMaxLifetime(time.Hour)
+	return db, nil
+}
+
+// Migrate applies the embedded schema (CREATE IF NOT EXISTS).
+func Migrate(ctx context.Context, db *sql.DB) error {
+	sqlBytes, err := schemaFS.ReadFile("schema.sql")
+	if err != nil {
+		return fmt.Errorf("telemetry: read schema: %w", err)
+	}
+	if _, err := db.ExecContext(ctx, string(sqlBytes)); err != nil {
+		return fmt.Errorf("telemetry: migrate: %w", err)
+	}
+	return nil
+}
+
+// OpenAndMigrate opens DSN and runs migrations.
+func OpenAndMigrate(ctx context.Context, dsn string) (*sql.DB, error) {
+	db, err := Open(dsn)
+	if err != nil {
+		return nil, err
+	}
+	pingCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	if err := db.PingContext(pingCtx); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("telemetry: ping: %w", err)
+	}
+	if err := Migrate(ctx, db); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+	return db, nil
+}

--- a/internal/common/telemetry/schema.sql
+++ b/internal/common/telemetry/schema.sql
@@ -1,0 +1,48 @@
+-- Shoal telemetry + jobs schema (Postgres-primary, lab :5433 / shoal_telemetry).
+-- Idempotent: safe to run on every process start.
+
+CREATE TABLE IF NOT EXISTS jobs (
+  id               TEXT PRIMARY KEY,
+  device_id        TEXT NOT NULL,
+  profile_ref      TEXT NOT NULL DEFAULT '',
+  state            TEXT NOT NULL,
+  attempt          INT  NOT NULL DEFAULT 0,
+  phase            TEXT,
+  percent          INT,
+  last_marker_seq  INT  NOT NULL DEFAULT 0,
+  started_at       TIMESTAMPTZ,
+  updated_at       TIMESTAMPTZ NOT NULL,
+  error            TEXT,
+  sol_session_id   TEXT,
+  iso_url          TEXT,
+  bmc_endpoint     TEXT
+);
+
+CREATE TABLE IF NOT EXISTS events (
+  id TEXT PRIMARY KEY,
+  device_id TEXT NOT NULL,
+  ts TIMESTAMPTZ NOT NULL,
+  type TEXT,
+  severity TEXT,
+  component TEXT,
+  message TEXT,
+  raw_ref TEXT
+);
+
+CREATE TABLE IF NOT EXISTS sensor_readings (
+  device_id TEXT NOT NULL,
+  ts TIMESTAMPTZ NOT NULL,
+  sensor TEXT,
+  value DOUBLE PRECISION,
+  unit TEXT
+);
+
+CREATE TABLE IF NOT EXISTS job_log (
+  job_id TEXT NOT NULL,
+  ts TIMESTAMPTZ NOT NULL,
+  line TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS jobs_state_idx ON jobs (state);
+CREATE INDEX IF NOT EXISTS events_device_ts_idx ON events (device_id, ts);
+CREATE INDEX IF NOT EXISTS job_log_job_ts_idx ON job_log (job_id, ts);

--- a/internal/deploy/job/doc.go
+++ b/internal/deploy/job/doc.go
@@ -1,3 +1,0 @@
-// Package job implements the Deploy Orchestrator, HandleTerminal, and jobport adapter.
-// Orchestrator is the sole lifecycle writer. Implementation lands in Phase 2.
-package job

--- a/internal/deploy/job/lab_e2e_test.go
+++ b/internal/deploy/job/lab_e2e_test.go
@@ -1,0 +1,250 @@
+//go:build integration
+
+package job_test
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/mattcburns/shoal/internal/common/models"
+	"github.com/mattcburns/shoal/internal/common/redfish"
+	"github.com/mattcburns/shoal/internal/common/secrets"
+	"github.com/mattcburns/shoal/internal/common/telemetry"
+	"github.com/mattcburns/shoal/internal/deploy/job"
+	"github.com/mattcburns/shoal/internal/deploy/jobstore"
+	"github.com/mattcburns/shoal/internal/observe/sol"
+)
+
+// labE2EEnv holds credentials/endpoints for live lab tests.
+type labE2EEnv struct {
+	base, user, pass, iso, dsn string
+	sshHost, sshUser, sshKey   string
+}
+
+func loadLabE2E(t *testing.T) labE2EEnv {
+	t.Helper()
+	e := labE2EEnv{
+		base:    envOr("SHOAL_BMC_URL", "http://192.168.122.100:8001"),
+		user:    os.Getenv("SHOAL_BMC_USERNAME"),
+		pass:    os.Getenv("SHOAL_BMC_PASSWORD"),
+		iso:     envOr("SHOAL_ISO_URL", "http://192.168.124.1:8080/shoal-marker.iso"),
+		dsn:     os.Getenv("SHOAL_TELEMETRY_DATABASE_URL"),
+		sshHost: os.Getenv("SHOAL_SERIAL_SSH_HOST"),
+		sshUser: envOr("SHOAL_SERIAL_SSH_USER", "lab"),
+		sshKey:  os.Getenv("SHOAL_SERIAL_SSH_KEY"),
+	}
+	if e.user == "" || e.pass == "" {
+		t.Skip("SHOAL_BMC_USERNAME/PASSWORD required")
+	}
+	return e
+}
+
+func labStore(t *testing.T, ctx context.Context, dsn string) (jobstore.Store, func()) {
+	t.Helper()
+	if dsn == "" {
+		return jobstore.NewMemory(), func() {}
+	}
+	db, err := telemetry.OpenAndMigrate(ctx, dsn)
+	if err != nil {
+		t.Fatalf("db: %v", err)
+	}
+	return jobstore.NewPostgres(db), func() { _ = db.Close() }
+}
+
+func labOrch(t *testing.T, e labE2EEnv, store jobstore.Store, watch *sol.WatchService) *job.Orchestrator {
+	t.Helper()
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	orch := job.NewOrchestrator(job.Options{
+		Log:                 log,
+		Store:               store,
+		Secrets:             secrets.NewMemory(),
+		NewBMC:              redfish.NewBMC,
+		Watches:             watch,
+		AuthMode:            "basic",
+		TLSMode:             "off",
+		ReconcileFailOrphan: true,
+	})
+	watch.SetProgress(orch.ProgressPort())
+	return orch
+}
+
+func waitJobState(t *testing.T, store jobstore.Store, id string, want models.LifecycleState, d time.Duration) models.ProvisioningJob {
+	t.Helper()
+	ctx := context.Background()
+	deadline := time.Now().Add(d)
+	var final models.ProvisioningJob
+	var err error
+	for time.Now().Before(deadline) {
+		final, err = store.Get(ctx, id)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if final.State == want {
+			return final
+		}
+		if final.State == models.StateFailed || final.State == models.StateProvisioned {
+			// terminal other than wanted
+			if final.State != want {
+				t.Fatalf("want %s, got %s err=%q phase=%s", want, final.State, final.Error, final.Phase)
+			}
+			return final
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatalf("timeout waiting for %s; last state=%s phase=%s err=%q", want, final.State, final.Phase, final.Error)
+	return final
+}
+
+func mediaInserted(t *testing.T, e labE2EEnv, systemID string) bool {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	bmc, err := redfish.NewBMC(redfish.Config{BaseURL: e.base, Username: e.user, Password: e.pass, AuthMode: "basic", TLSMode: "off"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := bmc.Open(ctx); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = bmc.Close(context.Background()) }()
+	vms, err := bmc.ListVirtualMedia(ctx, systemID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, vm := range vms {
+		if vm.Inserted {
+			return true
+		}
+	}
+	return false
+}
+
+// TestLabDeployCancel starts a live job then cancels; expects FAILED + media ejected.
+func TestLabDeployCancel(t *testing.T) {
+	e := loadLabE2E(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+	store, closer := labStore(t, ctx, e.dsn)
+	defer closer()
+
+	// Injected SOL (pipe stays open so job stays PROVISIONING until cancel).
+	pr, pw := io.Pipe()
+	defer pw.Close()
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	watch := sol.NewWatchService(log, nil)
+	watch.NewTransport = func(models.WatchSession) sol.Transport {
+		return sol.NewReaderTransport(pr)
+	}
+	orch := labOrch(t, e, store, watch)
+	defer orch.Stop()
+
+	j, err := orch.Start(ctx, models.StartJobRequest{
+		DeviceID: "shoal-node-2", BMCEndpoint: e.base, BMCUsername: e.user, BMCPassword: e.pass,
+		SerialTarget: "pipe", ISOURL: e.iso, SystemID: "shoal-node-2",
+		StallTimeout: 5 * time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	if !mediaInserted(t, e, "shoal-node-2") {
+		t.Fatal("expected media inserted before cancel")
+	}
+	if err := orch.Cancel(ctx, j.ID); err != nil {
+		t.Fatalf("cancel: %v", err)
+	}
+	final := waitJobState(t, store, j.ID, models.StateFailed, 90*time.Second)
+	if final.Error != "canceled" {
+		t.Fatalf("error %q", final.Error)
+	}
+	if mediaInserted(t, e, "shoal-node-2") {
+		t.Fatal("media still inserted after cancel cleanup")
+	}
+	t.Logf("cancel job %s OK", j.ID)
+}
+
+// TestLabDeployStall leaves SOL silent with a short stall timeout → FAILED + cleanup.
+func TestLabDeployStall(t *testing.T) {
+	e := loadLabE2E(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	store, closer := labStore(t, ctx, e.dsn)
+	defer closer()
+
+	pr, pw := io.Pipe()
+	defer pw.Close()
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	watch := sol.NewWatchService(log, nil)
+	watch.NewTransport = func(models.WatchSession) sol.Transport {
+		return sol.NewReaderTransport(pr)
+	}
+	orch := labOrch(t, e, store, watch)
+	defer orch.Stop()
+
+	// Use node-3 to avoid colliding with other tests.
+	j, err := orch.Start(ctx, models.StartJobRequest{
+		DeviceID: "shoal-node-3", BMCEndpoint: e.base, BMCUsername: e.user, BMCPassword: e.pass,
+		SerialTarget: "pipe", ISOURL: e.iso, SystemID: "shoal-node-3",
+		StallTimeout: 2 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	final := waitJobState(t, store, j.ID, models.StateFailed, 60*time.Second)
+	if final.Error != "sol stall" {
+		t.Fatalf("error %q", final.Error)
+	}
+	if mediaInserted(t, e, "shoal-node-3") {
+		t.Fatal("media still inserted after stall cleanup")
+	}
+	t.Logf("stall job %s OK", j.ID)
+}
+
+// TestLabDeployRealSOLSSH boots marker ISO and tails nested serial via SSH.
+// Requires SHOAL_SERIAL_SSH_HOST (and usually SHOAL_SERIAL_SSH_KEY).
+func TestLabDeployRealSOLSSH(t *testing.T) {
+	e := loadLabE2E(t)
+	if e.sshHost == "" {
+		t.Skip("SHOAL_SERIAL_SSH_HOST required for real SOL path")
+	}
+	if e.sshKey == "" {
+		if home := os.Getenv("HOME"); home != "" {
+			e.sshKey = home + "/.ssh/shoal_lab_vm"
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Minute)
+	defer cancel()
+	store, closer := labStore(t, ctx, e.dsn)
+	defer closer()
+
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	watch := sol.NewWatchService(log, nil)
+	watch.NewTransport = sol.NewTransportFactory(sol.SSHSerialConfig{
+		Host: e.sshHost, User: e.sshUser, KeyPath: e.sshKey, UseSudo: true,
+	})
+	orch := labOrch(t, e, store, watch)
+	defer orch.Stop()
+
+	// Prefer node-1 for full path (same as CLI spike).
+	j, err := orch.Start(ctx, models.StartJobRequest{
+		DeviceID: "shoal-node-1", BMCEndpoint: e.base, BMCUsername: e.user, BMCPassword: e.pass,
+		SerialTarget: "shoal-node-1", ISOURL: e.iso, SystemID: "shoal-node-1",
+		StallTimeout: 4 * time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	t.Logf("job %s started; waiting for SOL DONE", j.ID)
+	final := waitJobState(t, store, j.ID, models.StateProvisioned, 5*time.Minute)
+	if final.LastMarkerSeq < 1 || final.Phase != "DONE" {
+		t.Fatalf("unexpected progress: phase=%s seq=%d", final.Phase, final.LastMarkerSeq)
+	}
+	if mediaInserted(t, e, "shoal-node-1") {
+		t.Fatal("media still inserted after DONE cleanup")
+	}
+	t.Logf("real SOL job %s provisioned OK (seq=%d)", j.ID, final.LastMarkerSeq)
+}

--- a/internal/deploy/job/lab_integration_test.go
+++ b/internal/deploy/job/lab_integration_test.go
@@ -1,0 +1,183 @@
+//go:build integration
+
+package job_test
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/mattcburns/shoal/internal/common/models"
+	"github.com/mattcburns/shoal/internal/common/redfish"
+	"github.com/mattcburns/shoal/internal/common/secrets"
+	"github.com/mattcburns/shoal/internal/common/telemetry"
+	"github.com/mattcburns/shoal/internal/deploy/job"
+	"github.com/mattcburns/shoal/internal/deploy/jobstore"
+	"github.com/mattcburns/shoal/internal/observe/sol"
+)
+
+// TestLabDeployRealBMCInjectedSOL runs Orchestrator against live sushy-tools
+// Virtual Media + boot + power, while SOL markers are injected via a pipe
+// (nested serial PTY is only on L1; full libvirt SOL is a separate path).
+//
+// ISO must be BMC-reachable (from nested nodes: http://192.168.124.1:8080/...).
+func TestLabDeployRealBMCInjectedSOL(t *testing.T) {
+	base := envOr("SHOAL_BMC_URL", "http://192.168.122.100:8001")
+	user := os.Getenv("SHOAL_BMC_USERNAME")
+	pass := os.Getenv("SHOAL_BMC_PASSWORD")
+	if user == "" || pass == "" {
+		t.Skip("SHOAL_BMC_USERNAME/PASSWORD required")
+	}
+	iso := envOr("SHOAL_ISO_URL", "http://192.168.124.1:8080/shoal-marker.iso")
+	dsn := os.Getenv("SHOAL_TELEMETRY_DATABASE_URL")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+
+	var store jobstore.Store
+	if dsn != "" {
+		db, err := telemetry.OpenAndMigrate(ctx, dsn)
+		if err != nil {
+			t.Fatalf("db: %v", err)
+		}
+		defer db.Close()
+		store = jobstore.NewPostgres(db)
+	} else {
+		store = jobstore.NewMemory()
+	}
+
+	// Resolve shoal-node-1 system id via temporary BMC.
+	sysID := os.Getenv("SHOAL_SYSTEM_ID")
+	if sysID == "" {
+		tmp, err := redfish.NewBMC(redfish.Config{BaseURL: base, Username: user, Password: pass, AuthMode: "basic", TLSMode: "off"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := tmp.Open(ctx); err != nil {
+			t.Fatal(err)
+		}
+		systems, err := tmp.ListSystems(ctx)
+		_ = tmp.Close(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, s := range systems {
+			if s.Name == "shoal-node-1" {
+				sysID = s.ID
+				break
+			}
+		}
+		if sysID == "" && len(systems) > 0 {
+			sysID = systems[0].ID
+		}
+	}
+
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	pr, pw := io.Pipe()
+	watch := sol.NewWatchService(log, nil)
+	watch.NewTransport = func(models.WatchSession) sol.Transport {
+		return sol.NewReaderTransport(pr)
+	}
+
+	orch := job.NewOrchestrator(job.Options{
+		Log:                 log,
+		Store:               store,
+		Secrets:             secrets.NewMemory(),
+		NewBMC:              redfish.NewBMC,
+		Watches:             watch,
+		AuthMode:            "basic",
+		TLSMode:             "off",
+		ReconcileFailOrphan: true,
+	})
+	defer orch.Stop()
+	watch.SetProgress(orch.ProgressPort())
+
+	j, err := orch.Start(ctx, models.StartJobRequest{
+		DeviceID:     "shoal-node-1",
+		BMCEndpoint:  base,
+		BMCUsername:  user,
+		BMCPassword:  pass,
+		SerialTarget: "injected-pipe",
+		ISOURL:       iso,
+		SystemID:     sysID,
+		ProfileRef:   "lab-spike",
+	})
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	t.Logf("job %s started", j.ID)
+
+	// Verify media inserted on live BMC
+	check, err := redfish.NewBMC(redfish.Config{BaseURL: base, Username: user, Password: pass, AuthMode: "basic", TLSMode: "off"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := check.Open(ctx); err != nil {
+		t.Fatal(err)
+	}
+	vms, err := check.ListVirtualMedia(ctx, sysID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	inserted := false
+	for _, vm := range vms {
+		if vm.Inserted {
+			inserted = true
+			t.Logf("inserted media %s image=%s", vm.URI, vm.Image)
+		}
+	}
+	if !inserted {
+		t.Fatal("expected virtual media inserted on lab BMC")
+	}
+
+	// Inject SOL markers → DONE
+	for _, line := range []string{
+		"SHOAL|1|1|2026-07-10T00:00:00Z|BOOT|5|OK|lab boot",
+		"SHOAL|1|2|2026-07-10T00:00:01Z|IMAGE_WRITE|50|OK|lab write",
+		"SHOAL|1|3|2026-07-10T00:00:02Z|DONE|100|OK|lab done",
+	} {
+		if _, err := io.WriteString(pw, line+"\n"); err != nil {
+			t.Fatal(err)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	_ = pw.Close()
+
+	deadline := time.Now().Add(30 * time.Second)
+	var final models.ProvisioningJob
+	for time.Now().Before(deadline) {
+		final, err = store.Get(ctx, j.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if final.State == models.StateProvisioned || final.State == models.StateFailed {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	if final.State != models.StateProvisioned {
+		t.Fatalf("want provisioned, got %s err=%q phase=%s", final.State, final.Error, final.Phase)
+	}
+
+	// Cleanup on BMC
+	vms, _ = check.ListVirtualMedia(ctx, sysID)
+	for _, vm := range vms {
+		if vm.Inserted {
+			t.Fatalf("media still inserted after DONE cleanup: %s", vm.URI)
+		}
+	}
+	boot, _ := check.GetBoot(ctx, sysID)
+	t.Logf("final boot state: %+v", boot)
+	_ = check.Close(context.Background())
+	t.Logf("job %s provisioned OK", final.ID)
+}
+
+func envOr(k, d string) string {
+	if v := os.Getenv(k); v != "" {
+		return v
+	}
+	return d
+}

--- a/internal/deploy/job/orchestrator.go
+++ b/internal/deploy/job/orchestrator.go
@@ -339,7 +339,7 @@ func pickCDMedia(vms []redfish.VirtualMedia) string {
 func (o *Orchestrator) Cancel(ctx context.Context, jobID string) error {
 	job, err := o.store.Get(ctx, jobID)
 	if err != nil {
-		return err
+		return err // includes jobstore.ErrNotFound
 	}
 	if job.State != models.StateProvisioning {
 		return fmt.Errorf("job: cannot cancel job in state %s", job.State)

--- a/internal/deploy/job/orchestrator.go
+++ b/internal/deploy/job/orchestrator.go
@@ -8,7 +8,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"log/slog"
-	"strings"
 	"sync"
 	"time"
 
@@ -253,9 +252,20 @@ func (o *Orchestrator) provision(ctx context.Context, job models.ProvisioningJob
 	}
 	defer func() { _ = bmc.Close(context.Background()) }()
 
-	sys, err := bmc.GetSystem(ctx, req.SystemID)
+	// Prefer explicit SystemID; else match Redfish Name to DeviceID (lab: shoal-node-1).
+	lookup := req.SystemID
+	if lookup == "" {
+		lookup = req.DeviceID
+	}
+	sys, err := bmc.GetSystem(ctx, lookup)
 	if err != nil {
-		return fmt.Errorf("get system: %w", err)
+		// Last resort: if DeviceID lookup failed and SystemID was empty, try empty only when single system.
+		if req.SystemID == "" && req.DeviceID != "" {
+			sys, err = bmc.GetSystem(ctx, "")
+		}
+		if err != nil {
+			return fmt.Errorf("get system: %w", err)
+		}
 	}
 	rs.systemID = sys.ID
 
@@ -279,15 +289,19 @@ func (o *Orchestrator) provision(ctx context.Context, job models.ProvisioningJob
 
 	_ = o.store.UpdateProgress(ctx, job.ID, "WAITING_SOL", nil, 0, "")
 
-	transport := reqSerialTransport(req)
+	stall := req.StallTimeout
+	if stall <= 0 {
+		// Live ISO boot can take well over 90s before the first marker.
+		stall = 3 * time.Minute
+	}
 	session := models.WatchSession{
 		ID:           rs.sessionID,
 		JobID:        job.ID,
 		DeviceID:     req.DeviceID,
-		Transport:    transport,
+		Transport:    "libvirt",
 		Target:       req.SerialTarget,
 		StartedAt:    time.Now().UTC(),
-		StallTimeout: 90 * time.Second,
+		StallTimeout: stall,
 	}
 	// Persist sol session id via progress soft field isn't ideal; update job through transition is wrong.
 	// Use UpdateProgress for phase only; SOLSessionID stored in runState + optional store field via re-insert not available.
@@ -307,13 +321,6 @@ func (o *Orchestrator) provision(ctx context.Context, job models.ProvisioningJob
 		// never log password
 	)
 	return nil
-}
-
-func reqSerialTransport(req models.StartJobRequest) string {
-	if strings.HasPrefix(req.SerialTarget, "/") {
-		return "libvirt" // still file path via libvirt transport
-	}
-	return "libvirt"
 }
 
 func pickCDMedia(vms []redfish.VirtualMedia) string {
@@ -395,9 +402,12 @@ func (o *Orchestrator) handleTerminalOnce(ctx context.Context, jobID string, rea
 		bmcURL = job.BMCEndpoint
 	}
 
-	// Always-run cleanup when we have BMC coordinates.
+	// Always-run cleanup when we have BMC coordinates (hard timeout so we still transition).
 	if bmcURL != "" {
-		if err := o.cleanupBMC(ctx, bmcURL, credRef, systemID); err != nil {
+		cctx, ccancel := context.WithTimeout(context.Background(), 45*time.Second)
+		err := o.cleanupBMC(cctx, bmcURL, credRef, systemID)
+		ccancel()
+		if err != nil {
 			o.log.Error("bmc cleanup failed", "job_id", jobID, "err", err.Error())
 			// still transition
 		}
@@ -452,22 +462,36 @@ func (o *Orchestrator) cleanupBMC(ctx context.Context, bmcURL, credRef, systemID
 			user, pass = c.Username, c.Password
 		}
 	}
-	bmc, err := o.newBMC(redfish.Config{
-		BaseURL:  bmcURL,
-		Username: user,
-		Password: pass,
-		AuthMode: o.authMode,
-		TLSMode:  o.tlsMode,
-		CAFile:   o.caFile,
-	})
-	if err != nil {
+	done := make(chan error, 1)
+	go func() {
+		bmc, err := o.newBMC(redfish.Config{
+			BaseURL:        bmcURL,
+			Username:       user,
+			Password:       pass,
+			AuthMode:       o.authMode,
+			TLSMode:        o.tlsMode,
+			CAFile:         o.caFile,
+			RequestTimeout: 20 * time.Second,
+			MaxConcurrent:  1,
+		})
+		if err != nil {
+			done <- err
+			return
+		}
+		if err := bmc.Open(ctx); err != nil {
+			done <- err
+			return
+		}
+		cerr := bmc.CleanupMediaAndBoot(ctx, systemID)
+		_ = bmc.Close(context.Background())
+		done <- cerr
+	}()
+	select {
+	case err := <-done:
 		return err
+	case <-ctx.Done():
+		return fmt.Errorf("bmc cleanup timed out: %w", ctx.Err())
 	}
-	if err := bmc.Open(ctx); err != nil {
-		return err
-	}
-	defer func() { _ = bmc.Close(context.Background()) }()
-	return bmc.CleanupMediaAndBoot(ctx, systemID)
 }
 
 // ReconcileOrphans fails in-flight PROVISIONING jobs left from a previous process.

--- a/internal/deploy/job/orchestrator.go
+++ b/internal/deploy/job/orchestrator.go
@@ -379,6 +379,7 @@ func (o *Orchestrator) handleTerminalOnce(ctx context.Context, jobID string, rea
 	}
 
 	// Unregister watch first so SOL stops feeding markers.
+	// Bound the wait: a stuck SSH/PTY close must not prevent lifecycle transition.
 	sessionID := ""
 	systemID := ""
 	bmcURL := ""
@@ -390,11 +391,23 @@ func (o *Orchestrator) handleTerminalOnce(ctx context.Context, jobID string, rea
 		credRef = rs.credential
 	}
 	if sessionID != "" && o.watches != nil {
-		_ = o.watches.Unregister(ctx, sessionID)
+		unregDone := make(chan struct{})
+		go func() {
+			_ = o.watches.Unregister(context.Background(), sessionID)
+			close(unregDone)
+		}()
+		select {
+		case <-unregDone:
+		case <-time.After(10 * time.Second):
+			o.log.Warn("watch unregister timed out", "job_id", jobID, "session_id", sessionID)
+		case <-ctx.Done():
+			o.log.Warn("watch unregister aborted by context", "job_id", jobID)
+		}
 	}
 
-	// Load job for BMC endpoint if needed.
-	job, err := o.store.Get(ctx, jobID)
+	// Load job for BMC endpoint if needed. Prefer Background so a cancelled
+	// caller context cannot skip the terminal state write.
+	job, err := o.store.Get(context.Background(), jobID)
 	if err != nil {
 		return err
 	}
@@ -445,9 +458,12 @@ func (o *Orchestrator) handleTerminalOnce(ctx context.Context, jobID string, rea
 		errMsg = string(reason)
 	}
 
-	if err := o.store.Transition(ctx, jobID, to, errMsg); err != nil {
+	// Always commit lifecycle with Background so waiters observe the terminal state
+	// even if the terminalLoop request context already expired.
+	if err := o.store.Transition(context.Background(), jobID, to, errMsg); err != nil {
 		return err
 	}
+	o.log.Info("job terminal", "job_id", jobID, "state", string(to), "reason", string(reason))
 
 	o.mu.Lock()
 	delete(o.running, jobID)
@@ -571,12 +587,19 @@ func (p *progressAdapter) ApplyMarker(ctx context.Context, jobID string, m model
 }
 
 func (p *progressAdapter) ReportStall(ctx context.Context, jobID string, reason string) error {
+	if !p.stillProvisioning(ctx, jobID) {
+		return nil
+	}
 	_ = p.orch.store.UpdateProgress(ctx, jobID, "STALL", nil, 0, reason)
 	p.orch.enqueueTerminal(jobID, ReasonStall)
 	return nil
 }
 
 func (p *progressAdapter) ReportTransportError(ctx context.Context, jobID string, err error) error {
+	// Ignore stream close after DONE/cancel/stall already committed (e.g. guest poweroff).
+	if !p.stillProvisioning(ctx, jobID) {
+		return nil
+	}
 	msg := "transport error"
 	if err != nil {
 		msg = err.Error()
@@ -584,6 +607,14 @@ func (p *progressAdapter) ReportTransportError(ctx context.Context, jobID string
 	_ = p.orch.store.UpdateProgress(ctx, jobID, "TRANSPORT", nil, 0, msg)
 	p.orch.enqueueTerminal(jobID, ReasonTransport)
 	return nil
+}
+
+func (p *progressAdapter) stillProvisioning(ctx context.Context, jobID string) bool {
+	j, err := p.orch.store.Get(ctx, jobID)
+	if err != nil {
+		return true // fail open so real errors still surface
+	}
+	return j.State == models.StateProvisioning
 }
 
 var _ jobport.JobProgress = (*progressAdapter)(nil)

--- a/internal/deploy/job/orchestrator.go
+++ b/internal/deploy/job/orchestrator.go
@@ -1,0 +1,565 @@
+// Package job implements the Deploy Orchestrator, HandleTerminal, and jobport adapter.
+// Orchestrator is the sole lifecycle writer.
+package job
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/mattcburns/shoal/internal/common/jobport"
+	"github.com/mattcburns/shoal/internal/common/models"
+	"github.com/mattcburns/shoal/internal/common/redfish"
+	"github.com/mattcburns/shoal/internal/common/secrets"
+	"github.com/mattcburns/shoal/internal/common/validate"
+	"github.com/mattcburns/shoal/internal/common/watchport"
+	"github.com/mattcburns/shoal/internal/deploy/jobstore"
+	"github.com/mattcburns/shoal/internal/observe/sol"
+)
+
+// TerminalReason classifies why a job is ending.
+type TerminalReason string
+
+const (
+	ReasonDoneOK      TerminalReason = "done_ok"
+	ReasonMarkerError TerminalReason = "marker_error"
+	ReasonStall       TerminalReason = "stall"
+	ReasonTransport   TerminalReason = "transport"
+	ReasonCancel      TerminalReason = "cancel"
+	ReasonBMC         TerminalReason = "bmc"
+	ReasonPanic       TerminalReason = "panic"
+)
+
+// Orchestrator owns lifecycle transitions, BMC actions, and cleanup.
+type Orchestrator struct {
+	log        *slog.Logger
+	store      jobstore.Store
+	secrets    secrets.Backend
+	newBMC     redfish.Factory
+	watches    watchport.WatchRegistrar
+	authMode   string
+	tlsMode    string
+	caFile     string
+	failOrphan bool
+
+	mu       sync.Mutex
+	running  map[string]*runState // jobID -> state
+	terminal chan terminalEvent
+	// closed when Stop is called
+	stopCh chan struct{}
+	wg     sync.WaitGroup
+}
+
+type runState struct {
+	cancel     context.CancelFunc
+	systemID   string
+	sessionID  string
+	credential string
+	bmcURL     string
+	// terminalOnce ensures HandleTerminal runs once
+	terminalOnce sync.Once
+}
+
+type terminalEvent struct {
+	jobID  string
+	reason TerminalReason
+}
+
+// Options configures the Orchestrator.
+type Options struct {
+	Log                 *slog.Logger
+	Store               jobstore.Store
+	Secrets             secrets.Backend
+	NewBMC              redfish.Factory
+	Watches             watchport.WatchRegistrar
+	AuthMode            string
+	TLSMode             string
+	CAFile              string
+	ReconcileFailOrphan bool
+}
+
+// NewOrchestrator constructs an Orchestrator and starts the terminal worker.
+func NewOrchestrator(opts Options) *Orchestrator {
+	log := opts.Log
+	if log == nil {
+		log = slog.Default()
+	}
+	if opts.NewBMC == nil {
+		opts.NewBMC = redfish.NewBMC
+	}
+	auth := opts.AuthMode
+	if auth == "" {
+		auth = "basic"
+	}
+	tlsMode := opts.TLSMode
+	if tlsMode == "" {
+		tlsMode = "off"
+	}
+	o := &Orchestrator{
+		log:        log,
+		store:      opts.Store,
+		secrets:    opts.Secrets,
+		newBMC:     opts.NewBMC,
+		watches:    opts.Watches,
+		authMode:   auth,
+		tlsMode:    tlsMode,
+		caFile:     opts.CAFile,
+		failOrphan: opts.ReconcileFailOrphan, // composition root passes config default true
+		running:    make(map[string]*runState),
+		terminal:   make(chan terminalEvent, 64),
+		stopCh:     make(chan struct{}),
+	}
+	o.wg.Add(1)
+	go o.terminalLoop()
+	return o
+}
+
+// Stop stops the terminal worker.
+func (o *Orchestrator) Stop() {
+	select {
+	case <-o.stopCh:
+	default:
+		close(o.stopCh)
+	}
+	o.wg.Wait()
+}
+
+func (o *Orchestrator) terminalLoop() {
+	defer o.wg.Done()
+	for {
+		select {
+		case <-o.stopCh:
+			return
+		case ev := <-o.terminal:
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+			if err := o.HandleTerminal(ctx, ev.jobID, ev.reason); err != nil {
+				o.log.Error("HandleTerminal failed", "job_id", ev.jobID, "reason", string(ev.reason), "err", err.Error())
+			}
+			cancel()
+		}
+	}
+}
+
+// ProgressPort returns the jobport adapter for Observe injection.
+func (o *Orchestrator) ProgressPort() jobport.JobProgress {
+	return &progressAdapter{orch: o}
+}
+
+// SetWatchRegistrar injects the watch port (composition root).
+func (o *Orchestrator) SetWatchRegistrar(w watchport.WatchRegistrar) {
+	o.watches = w
+}
+
+// Get returns a job from the store.
+func (o *Orchestrator) Get(ctx context.Context, jobID string) (models.ProvisioningJob, error) {
+	return o.store.Get(ctx, jobID)
+}
+
+// Start begins a provisioning job using CLI/API binding fields (no NetBox).
+func (o *Orchestrator) Start(ctx context.Context, req models.StartJobRequest) (models.ProvisioningJob, error) {
+	if err := validate.StartJobRequest(req); err != nil {
+		return models.ProvisioningJob{}, err
+	}
+	if o.watches == nil {
+		return models.ProvisioningJob{}, fmt.Errorf("job: watch registrar not configured")
+	}
+
+	jobID := newID()
+	credRef := req.CredentialRef
+	if credRef == "" {
+		credRef = "job-" + jobID
+		if err := o.secrets.Put(ctx, credRef, secrets.Credential{
+			Username: req.BMCUsername,
+			Password: req.BMCPassword,
+		}); err != nil {
+			return models.ProvisioningJob{}, fmt.Errorf("job: store credentials: %w", err)
+		}
+	}
+	cred, err := o.secrets.Get(ctx, credRef)
+	if err != nil {
+		return models.ProvisioningJob{}, fmt.Errorf("job: resolve credentials: %w", err)
+	}
+
+	profile := req.ProfileRef
+	if profile == "" {
+		profile = "spike"
+	}
+	now := time.Now().UTC()
+	job := models.ProvisioningJob{
+		ID:          jobID,
+		DeviceID:    req.DeviceID,
+		ProfileRef:  profile,
+		State:       models.StateProvisioning,
+		Attempt:     1,
+		Phase:       "STARTING",
+		StartedAt:   &now,
+		UpdatedAt:   &now,
+		ISOURL:      req.ISOURL,
+		BMCEndpoint: req.BMCEndpoint,
+	}
+	if err := o.store.Insert(ctx, job); err != nil {
+		return models.ProvisioningJob{}, err
+	}
+
+	jobCtx, cancel := context.WithCancel(context.Background())
+	rs := &runState{
+		cancel:     cancel,
+		systemID:   req.SystemID,
+		credential: credRef,
+		bmcURL:     req.BMCEndpoint,
+		sessionID:  "sol-" + jobID,
+	}
+	o.mu.Lock()
+	o.running[jobID] = rs
+	o.mu.Unlock()
+
+	if err := o.provision(jobCtx, job, req, cred, rs); err != nil {
+		o.log.Error("provision start failed", "job_id", jobID, "err", err.Error())
+		_ = o.HandleTerminal(ctx, jobID, ReasonBMC)
+		j, _ := o.store.Get(ctx, jobID)
+		if j.ID == "" {
+			return job, err
+		}
+		return j, err
+	}
+
+	out, err := o.store.Get(ctx, jobID)
+	if err != nil {
+		return job, nil
+	}
+	return out, nil
+}
+
+func (o *Orchestrator) provision(ctx context.Context, job models.ProvisioningJob, req models.StartJobRequest, cred secrets.Credential, rs *runState) error {
+	bmc, err := o.newBMC(redfish.Config{
+		BaseURL:       req.BMCEndpoint,
+		Username:      cred.Username,
+		Password:      cred.Password,
+		AuthMode:      o.authMode,
+		TLSMode:       o.tlsMode,
+		CAFile:        o.caFile,
+		MaxConcurrent: 1,
+	})
+	if err != nil {
+		return err
+	}
+	if err := bmc.Open(ctx); err != nil {
+		return fmt.Errorf("bmc open: %w", err)
+	}
+	defer func() { _ = bmc.Close(context.Background()) }()
+
+	sys, err := bmc.GetSystem(ctx, req.SystemID)
+	if err != nil {
+		return fmt.Errorf("get system: %w", err)
+	}
+	rs.systemID = sys.ID
+
+	vms, err := bmc.ListVirtualMedia(ctx, sys.ID)
+	if err != nil {
+		return fmt.Errorf("list virtual media: %w", err)
+	}
+	mediaURI := pickCDMedia(vms)
+	if mediaURI == "" {
+		return fmt.Errorf("no CD-capable virtual media slot")
+	}
+	if err := bmc.InsertVirtualMedia(ctx, mediaURI, req.ISOURL); err != nil {
+		return fmt.Errorf("insert media: %w", err)
+	}
+	if err := bmc.SetBootOverrideOnceCD(ctx, sys.ID); err != nil {
+		return fmt.Errorf("boot override: %w", err)
+	}
+	if err := bmc.Power(ctx, sys.ID, "On"); err != nil {
+		return fmt.Errorf("power on: %w", err)
+	}
+
+	_ = o.store.UpdateProgress(ctx, job.ID, "WAITING_SOL", nil, 0, "")
+
+	transport := reqSerialTransport(req)
+	session := models.WatchSession{
+		ID:           rs.sessionID,
+		JobID:        job.ID,
+		DeviceID:     req.DeviceID,
+		Transport:    transport,
+		Target:       req.SerialTarget,
+		StartedAt:    time.Now().UTC(),
+		StallTimeout: 90 * time.Second,
+	}
+	// Persist sol session id via progress soft field isn't ideal; update job through transition is wrong.
+	// Use UpdateProgress for phase only; SOLSessionID stored in runState + optional store field via re-insert not available.
+	// Patch: store Transition doesn't set sol_session_id. Memory/Postgres need a SetSession helper or we encode in running map only.
+	// For status API, re-read job won't show session — acceptable for Phase 2 if we UpdateProgress detail.
+	_ = o.store.UpdateProgress(ctx, job.ID, "WAITING_SOL", nil, 0, "")
+
+	if err := o.watches.Register(ctx, session); err != nil {
+		_ = bmc.CleanupMediaAndBoot(ctx, sys.ID)
+		return fmt.Errorf("register watch: %w", err)
+	}
+	o.log.Info("job started",
+		"job_id", job.ID,
+		"device_id", job.DeviceID,
+		"bmc", req.BMCEndpoint,
+		"iso_url", req.ISOURL,
+		// never log password
+	)
+	return nil
+}
+
+func reqSerialTransport(req models.StartJobRequest) string {
+	if strings.HasPrefix(req.SerialTarget, "/") {
+		return "libvirt" // still file path via libvirt transport
+	}
+	return "libvirt"
+}
+
+func pickCDMedia(vms []redfish.VirtualMedia) string {
+	for _, vm := range vms {
+		if vm.SupportsCD {
+			return vm.URI
+		}
+	}
+	if len(vms) > 0 {
+		return vms[0].URI
+	}
+	return ""
+}
+
+// Cancel requests terminal handling for a job.
+func (o *Orchestrator) Cancel(ctx context.Context, jobID string) error {
+	job, err := o.store.Get(ctx, jobID)
+	if err != nil {
+		return err
+	}
+	if job.State != models.StateProvisioning {
+		return fmt.Errorf("job: cannot cancel job in state %s", job.State)
+	}
+	o.enqueueTerminal(jobID, ReasonCancel)
+	return nil
+}
+
+// HandleTerminal runs cleanup and commits the terminal lifecycle state.
+// Safe to call multiple times; only the first call performs work.
+func (o *Orchestrator) HandleTerminal(ctx context.Context, jobID string, reason TerminalReason) error {
+	o.mu.Lock()
+	rs, ok := o.running[jobID]
+	o.mu.Unlock()
+
+	runOnce := func(fn func()) {
+		if ok && rs != nil {
+			rs.terminalOnce.Do(fn)
+			return
+		}
+		// orphan path without runState
+		fn()
+	}
+
+	var handleErr error
+	runOnce(func() {
+		handleErr = o.handleTerminalOnce(ctx, jobID, reason, rs)
+	})
+	return handleErr
+}
+
+func (o *Orchestrator) handleTerminalOnce(ctx context.Context, jobID string, reason TerminalReason, rs *runState) error {
+	o.log.Info("HandleTerminal", "job_id", jobID, "reason", string(reason))
+
+	if rs != nil && rs.cancel != nil {
+		rs.cancel()
+	}
+
+	// Unregister watch first so SOL stops feeding markers.
+	sessionID := ""
+	systemID := ""
+	bmcURL := ""
+	credRef := ""
+	if rs != nil {
+		sessionID = rs.sessionID
+		systemID = rs.systemID
+		bmcURL = rs.bmcURL
+		credRef = rs.credential
+	}
+	if sessionID != "" && o.watches != nil {
+		_ = o.watches.Unregister(ctx, sessionID)
+	}
+
+	// Load job for BMC endpoint if needed.
+	job, err := o.store.Get(ctx, jobID)
+	if err != nil {
+		return err
+	}
+	if bmcURL == "" {
+		bmcURL = job.BMCEndpoint
+	}
+
+	// Always-run cleanup when we have BMC coordinates.
+	if bmcURL != "" {
+		if err := o.cleanupBMC(ctx, bmcURL, credRef, systemID); err != nil {
+			o.log.Error("bmc cleanup failed", "job_id", jobID, "err", err.Error())
+			// still transition
+		}
+	}
+
+	var to models.LifecycleState
+	var errMsg string
+	switch reason {
+	case ReasonDoneOK:
+		to = models.StateProvisioned
+		errMsg = ""
+	case ReasonCancel:
+		to = models.StateFailed
+		errMsg = "canceled"
+	case ReasonStall:
+		to = models.StateFailed
+		errMsg = "sol stall"
+	case ReasonTransport:
+		to = models.StateFailed
+		errMsg = "sol transport error"
+	case ReasonMarkerError:
+		to = models.StateFailed
+		errMsg = "marker error"
+		if job.Error != "" {
+			errMsg = job.Error
+		}
+	case ReasonBMC:
+		to = models.StateFailed
+		errMsg = "bmc error"
+		if job.Error != "" {
+			errMsg = job.Error
+		}
+	default:
+		to = models.StateFailed
+		errMsg = string(reason)
+	}
+
+	if err := o.store.Transition(ctx, jobID, to, errMsg); err != nil {
+		return err
+	}
+
+	o.mu.Lock()
+	delete(o.running, jobID)
+	o.mu.Unlock()
+	return nil
+}
+
+func (o *Orchestrator) cleanupBMC(ctx context.Context, bmcURL, credRef, systemID string) error {
+	user, pass := "", ""
+	if credRef != "" && o.secrets != nil {
+		if c, err := o.secrets.Get(ctx, credRef); err == nil {
+			user, pass = c.Username, c.Password
+		}
+	}
+	bmc, err := o.newBMC(redfish.Config{
+		BaseURL:  bmcURL,
+		Username: user,
+		Password: pass,
+		AuthMode: o.authMode,
+		TLSMode:  o.tlsMode,
+		CAFile:   o.caFile,
+	})
+	if err != nil {
+		return err
+	}
+	if err := bmc.Open(ctx); err != nil {
+		return err
+	}
+	defer func() { _ = bmc.Close(context.Background()) }()
+	return bmc.CleanupMediaAndBoot(ctx, systemID)
+}
+
+// ReconcileOrphans fails in-flight PROVISIONING jobs left from a previous process.
+// Default policy (failOrphan=true): cleanup + FAILED for each.
+func (o *Orchestrator) ReconcileOrphans(ctx context.Context) error {
+	jobs, err := o.store.ListByState(ctx, models.StateProvisioning)
+	if err != nil {
+		return err
+	}
+	for _, j := range jobs {
+		o.log.Warn("reconciling orphan job", "job_id", j.ID, "device_id", j.DeviceID, "fail", o.failOrphan)
+		if !o.failOrphan {
+			continue
+		}
+		// Seed runState for cleanup coordinates.
+		o.mu.Lock()
+		if _, ok := o.running[j.ID]; !ok {
+			o.running[j.ID] = &runState{
+				bmcURL:     j.BMCEndpoint,
+				sessionID:  j.SOLSessionID,
+				systemID:   "",
+				credential: "", // may fail cleanup without creds; still transition
+			}
+		}
+		o.mu.Unlock()
+		if err := o.HandleTerminal(ctx, j.ID, ReasonBMC); err != nil {
+			o.log.Error("orphan reconcile failed", "job_id", j.ID, "err", err.Error())
+		}
+	}
+	return nil
+}
+
+func (o *Orchestrator) enqueueTerminal(jobID string, reason TerminalReason) {
+	select {
+	case o.terminal <- terminalEvent{jobID: jobID, reason: reason}:
+	default:
+		// channel full — run async
+		go func() {
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+			defer cancel()
+			_ = o.HandleTerminal(ctx, jobID, reason)
+		}()
+	}
+}
+
+func newID() string {
+	var b [16]byte
+	_, _ = rand.Read(b[:])
+	return hex.EncodeToString(b[:])
+}
+
+// progressAdapter implements jobport.JobProgress.
+type progressAdapter struct {
+	orch *Orchestrator
+}
+
+func (p *progressAdapter) ApplyMarker(ctx context.Context, jobID string, m models.SOLMarker) error {
+	soft := ""
+	if m.State == "ERROR" || m.State == "WARN" {
+		soft = m.Detail
+		if soft == "" {
+			soft = m.State
+		}
+	}
+	phase := m.Phase
+	if m.State == "HEARTBEAT" && phase == "" {
+		phase = "HEARTBEAT"
+	}
+	if err := p.orch.store.UpdateProgress(ctx, jobID, phase, m.Percent, m.Seq, soft); err != nil {
+		return err
+	}
+	if sol.IsTerminal(m) {
+		reason := TerminalReason(sol.TerminalReasonFromMarker(m))
+		p.orch.enqueueTerminal(jobID, reason)
+	}
+	return nil
+}
+
+func (p *progressAdapter) ReportStall(ctx context.Context, jobID string, reason string) error {
+	_ = p.orch.store.UpdateProgress(ctx, jobID, "STALL", nil, 0, reason)
+	p.orch.enqueueTerminal(jobID, ReasonStall)
+	return nil
+}
+
+func (p *progressAdapter) ReportTransportError(ctx context.Context, jobID string, err error) error {
+	msg := "transport error"
+	if err != nil {
+		msg = err.Error()
+	}
+	_ = p.orch.store.UpdateProgress(ctx, jobID, "TRANSPORT", nil, 0, msg)
+	p.orch.enqueueTerminal(jobID, ReasonTransport)
+	return nil
+}
+
+var _ jobport.JobProgress = (*progressAdapter)(nil)

--- a/internal/deploy/job/orchestrator_test.go
+++ b/internal/deploy/job/orchestrator_test.go
@@ -144,6 +144,56 @@ func TestOrchestratorCancelCleansUp(t *testing.T) {
 	t.Fatal("cancel did not fail job in time")
 }
 
+func TestOrchestratorStallFailsAndCleansUp(t *testing.T) {
+	ctx := context.Background()
+	store := jobstore.NewMemory()
+	sec := secrets.NewMemory()
+	fakeBMC := redfish.NewFake()
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	// Open pipe but never write markers → stall.
+	pr, pw := io.Pipe()
+	defer pw.Close()
+	watch := sol.NewWatchService(log, nil)
+	watch.NewTransport = func(session models.WatchSession) sol.Transport {
+		return sol.NewReaderTransport(pr)
+	}
+
+	orch := job.NewOrchestrator(job.Options{
+		Log: log, Store: store, Secrets: sec,
+		NewBMC:              func(cfg redfish.Config) (redfish.BMC, error) { return fakeBMC, nil },
+		Watches:             watch,
+		ReconcileFailOrphan: true,
+	})
+	defer orch.Stop()
+	watch.SetProgress(orch.ProgressPort())
+
+	j, err := orch.Start(ctx, models.StartJobRequest{
+		DeviceID: "n1", BMCEndpoint: "http://bmc", BMCUsername: "u", BMCPassword: "p",
+		SerialTarget: "n1", ISOURL: "http://iso/x.iso",
+		StallTimeout: 80 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		got, _ := store.Get(ctx, j.ID)
+		if got.State == models.StateFailed {
+			if got.Error != "sol stall" {
+				t.Fatalf("error %q", got.Error)
+			}
+			if fakeBMC.MediaInserted() || !fakeBMC.BootCleared() {
+				t.Fatal("cleanup after stall incomplete")
+			}
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatal("stall did not fail job in time")
+}
+
 func TestOrchestratorOrphanReconcile(t *testing.T) {
 	ctx := context.Background()
 	store := jobstore.NewMemory()

--- a/internal/deploy/job/orchestrator_test.go
+++ b/internal/deploy/job/orchestrator_test.go
@@ -1,0 +1,190 @@
+package job_test
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/mattcburns/shoal/internal/common/models"
+	"github.com/mattcburns/shoal/internal/common/redfish"
+	"github.com/mattcburns/shoal/internal/common/secrets"
+	"github.com/mattcburns/shoal/internal/deploy/job"
+	"github.com/mattcburns/shoal/internal/deploy/jobstore"
+	"github.com/mattcburns/shoal/internal/observe/sol"
+)
+
+func TestOrchestratorHappyPathDone(t *testing.T) {
+	ctx := context.Background()
+	store := jobstore.NewMemory()
+	sec := secrets.NewMemory()
+	fakeBMC := redfish.NewFake()
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	// Pipe-based SOL transport: write markers into the watch.
+	pr, pw := io.Pipe()
+	watch := sol.NewWatchService(log, nil)
+	watch.NewTransport = func(session models.WatchSession) sol.Transport {
+		return sol.NewReaderTransport(pr)
+	}
+
+	orch := job.NewOrchestrator(job.Options{
+		Log:     log,
+		Store:   store,
+		Secrets: sec,
+		NewBMC: func(cfg redfish.Config) (redfish.BMC, error) {
+			return fakeBMC, nil
+		},
+		Watches:             watch,
+		AuthMode:            "basic",
+		TLSMode:             "off",
+		ReconcileFailOrphan: true,
+	})
+	defer orch.Stop()
+	watch.SetProgress(orch.ProgressPort())
+
+	j, err := orch.Start(ctx, models.StartJobRequest{
+		DeviceID:     "lab-node-1",
+		BMCEndpoint:  "http://bmc.test",
+		BMCUsername:  "admin",
+		BMCPassword:  "secret",
+		SerialTarget: "lab-node-1",
+		ISOURL:       "http://iso/shoal-marker.iso",
+	})
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	if j.State != models.StateProvisioning {
+		t.Fatalf("state %s", j.State)
+	}
+	if !fakeBMC.MediaInserted() {
+		t.Fatal("expected media inserted")
+	}
+
+	// Emit SOL progress then DONE
+	writeMarker(t, pw, "SHOAL|1|1|2026-06-19T04:10:00Z|BOOT|5|OK|booting")
+	writeMarker(t, pw, "SHOAL|1|2|2026-06-19T04:10:10Z|IMAGE_WRITE|50|OK|writing")
+	writeMarker(t, pw, "SHOAL|1|3|2026-06-19T04:10:20Z|DONE|100|OK|reboot pending")
+	_ = pw.Close()
+
+	deadline := time.Now().Add(3 * time.Second)
+	var final models.ProvisioningJob
+	for time.Now().Before(deadline) {
+		final, err = store.Get(ctx, j.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if final.State == models.StateProvisioned {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if final.State != models.StateProvisioned {
+		t.Fatalf("want provisioned, got %s err=%s phase=%s", final.State, final.Error, final.Phase)
+	}
+	if !fakeBMC.BootCleared() || fakeBMC.MediaInserted() {
+		t.Fatal("cleanup incomplete: media/boot still set")
+	}
+	// password must not appear on job JSON-ish fields
+	if final.BMCEndpoint == "" {
+		t.Fatal("bmc endpoint should persist")
+	}
+}
+
+func TestOrchestratorCancelCleansUp(t *testing.T) {
+	ctx := context.Background()
+	store := jobstore.NewMemory()
+	sec := secrets.NewMemory()
+	fakeBMC := redfish.NewFake()
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	pr, pw := io.Pipe()
+	defer pw.Close()
+	watch := sol.NewWatchService(log, nil)
+	watch.NewTransport = func(session models.WatchSession) sol.Transport {
+		return sol.NewReaderTransport(pr)
+	}
+
+	orch := job.NewOrchestrator(job.Options{
+		Log:                 log,
+		Store:               store,
+		Secrets:             sec,
+		NewBMC:              func(cfg redfish.Config) (redfish.BMC, error) { return fakeBMC, nil },
+		Watches:             watch,
+		ReconcileFailOrphan: true,
+	})
+	defer orch.Stop()
+	watch.SetProgress(orch.ProgressPort())
+
+	j, err := orch.Start(ctx, models.StartJobRequest{
+		DeviceID: "n1", BMCEndpoint: "http://bmc", BMCUsername: "u", BMCPassword: "p",
+		SerialTarget: "n1", ISOURL: "http://iso/x.iso",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := orch.Cancel(ctx, j.ID); err != nil {
+		t.Fatal(err)
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		got, _ := store.Get(ctx, j.ID)
+		if got.State == models.StateFailed {
+			if got.Error != "canceled" {
+				t.Fatalf("error %q", got.Error)
+			}
+			if fakeBMC.MediaInserted() || !fakeBMC.BootCleared() {
+				t.Fatal("cleanup after cancel incomplete")
+			}
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatal("cancel did not fail job in time")
+}
+
+func TestOrchestratorOrphanReconcile(t *testing.T) {
+	ctx := context.Background()
+	store := jobstore.NewMemory()
+	// Pre-seed orphan PROVISIONING job as if process restarted.
+	now := time.Now().UTC()
+	_ = store.Insert(ctx, models.ProvisioningJob{
+		ID: "orphan-1", DeviceID: "d", State: models.StateProvisioning,
+		BMCEndpoint: "http://bmc", StartedAt: &now, UpdatedAt: &now,
+	})
+	fakeBMC := redfish.NewFake()
+	// simulate leftover media from crashed job
+	_ = fakeBMC.InsertVirtualMedia(ctx, "/redfish/v1/Managers/1/VirtualMedia/Cd", "http://iso/x.iso")
+	_ = fakeBMC.SetBootOverrideOnceCD(ctx, "1")
+
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	watch := sol.NewWatchService(log, nil)
+	orch := job.NewOrchestrator(job.Options{
+		Log: log, Store: store, Secrets: secrets.NewMemory(),
+		NewBMC:  func(cfg redfish.Config) (redfish.BMC, error) { return fakeBMC, nil },
+		Watches: watch, ReconcileFailOrphan: true,
+	})
+	defer orch.Stop()
+	watch.SetProgress(orch.ProgressPort())
+
+	if err := orch.ReconcileOrphans(ctx); err != nil {
+		t.Fatal(err)
+	}
+	got, err := store.Get(ctx, "orphan-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.State != models.StateFailed {
+		t.Fatalf("orphan state %s", got.State)
+	}
+}
+
+func writeMarker(t *testing.T, w io.Writer, line string) {
+	t.Helper()
+	if _, err := io.WriteString(w, line+"\n"); err != nil {
+		t.Fatal(err)
+	}
+	// allow apply
+	time.Sleep(30 * time.Millisecond)
+}

--- a/internal/deploy/job/orchestrator_test.go
+++ b/internal/deploy/job/orchestrator_test.go
@@ -194,6 +194,85 @@ func TestOrchestratorStallFailsAndCleansUp(t *testing.T) {
 	t.Fatal("stall did not fail job in time")
 }
 
+// blockingCloseTransport hangs forever in Close — used to prove HandleTerminal
+// still transitions after DONE (regression for happy-path hang).
+type blockingCloseTransport struct {
+	inner   sol.Transport
+	started chan struct{}
+}
+
+func (b *blockingCloseTransport) Open(ctx context.Context, target string) (<-chan string, error) {
+	return b.inner.Open(ctx, target)
+}
+
+func (b *blockingCloseTransport) Close() error {
+	select {
+	case <-b.started:
+	default:
+		close(b.started)
+	}
+	select {} // hang forever
+}
+
+func TestOrchestratorDoneDespiteStuckSOLClose(t *testing.T) {
+	ctx := context.Background()
+	store := jobstore.NewMemory()
+	sec := secrets.NewMemory()
+	fakeBMC := redfish.NewFake()
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	pr, pw := io.Pipe()
+	closeStarted := make(chan struct{})
+	watch := sol.NewWatchService(log, nil)
+	watch.NewTransport = func(session models.WatchSession) sol.Transport {
+		return &blockingCloseTransport{
+			inner:   sol.NewReaderTransport(pr),
+			started: closeStarted,
+		}
+	}
+
+	orch := job.NewOrchestrator(job.Options{
+		Log: log, Store: store, Secrets: sec,
+		NewBMC:              func(cfg redfish.Config) (redfish.BMC, error) { return fakeBMC, nil },
+		Watches:             watch,
+		ReconcileFailOrphan: true,
+	})
+	defer orch.Stop()
+	watch.SetProgress(orch.ProgressPort())
+
+	j, err := orch.Start(ctx, models.StartJobRequest{
+		DeviceID: "n1", BMCEndpoint: "http://bmc", BMCUsername: "u", BMCPassword: "p",
+		SerialTarget: "n1", ISOURL: "http://iso/x.iso",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	writeMarker(t, pw, "SHOAL|1|1|2026-06-19T04:10:00Z|BOOT|5|OK|booting")
+	writeMarker(t, pw, "SHOAL|1|2|2026-06-19T04:10:20Z|DONE|100|OK|reboot pending")
+	_ = pw.Close()
+
+	// Unregister should attempt Close (which hangs); HandleTerminal must still provision.
+	deadline := time.Now().Add(15 * time.Second)
+	var final models.ProvisioningJob
+	for time.Now().Before(deadline) {
+		final, err = store.Get(ctx, j.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if final.State == models.StateProvisioned {
+			select {
+			case <-closeStarted:
+			case <-time.After(time.Second):
+				t.Fatal("expected Close to be attempted")
+			}
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("want provisioned despite stuck Close, got %s phase=%s err=%s", final.State, final.Phase, final.Error)
+}
+
 func TestOrchestratorOrphanReconcile(t *testing.T) {
 	ctx := context.Background()
 	store := jobstore.NewMemory()

--- a/internal/deploy/jobstore/doc.go
+++ b/internal/deploy/jobstore/doc.go
@@ -1,3 +1,0 @@
-// Package jobstore is pure jobs-table persistence (CRUD / progress / transition).
-// No Redfish, no Observe imports, no cleanup side effects. Schema lands in PR3.
-package jobstore

--- a/internal/deploy/jobstore/lab_integration_test.go
+++ b/internal/deploy/jobstore/lab_integration_test.go
@@ -1,0 +1,70 @@
+//go:build integration
+
+package jobstore_test
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/mattcburns/shoal/internal/common/models"
+	"github.com/mattcburns/shoal/internal/common/telemetry"
+	"github.com/mattcburns/shoal/internal/deploy/jobstore"
+)
+
+func TestLabPostgresJobStore(t *testing.T) {
+	dsn := os.Getenv("SHOAL_TELEMETRY_DATABASE_URL")
+	if dsn == "" {
+		dsn = "postgres://shoal:shoal_password@192.168.122.100:5433/shoal_telemetry?sslmode=disable"
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	db, err := telemetry.OpenAndMigrate(ctx, dsn)
+	if err != nil {
+		t.Fatalf("open/migrate: %v", err)
+	}
+	defer db.Close()
+
+	s := jobstore.NewPostgres(db)
+	id := "lab-test-" + time.Now().UTC().Format("20060102T150405")
+	now := time.Now().UTC()
+	job := models.ProvisioningJob{
+		ID: id, DeviceID: "lab-node-1", State: models.StateProvisioning,
+		ProfileRef: "spike", Attempt: 1, StartedAt: &now, UpdatedAt: &now,
+		BMCEndpoint: "http://192.168.122.100:8001",
+		ISOURL:      "http://192.168.124.1:8080/shoal-marker.iso",
+	}
+	if err := s.Insert(ctx, job); err != nil {
+		t.Fatal(err)
+	}
+	p := 40
+	if err := s.UpdateProgress(ctx, id, "IMAGE_WRITE", &p, 7, ""); err != nil {
+		t.Fatal(err)
+	}
+	got, err := s.Get(ctx, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Phase != "IMAGE_WRITE" || got.LastMarkerSeq != 7 {
+		t.Fatalf("got %+v", got)
+	}
+	if err := s.Transition(ctx, id, models.StateFailed, "lab test cleanup"); err != nil {
+		t.Fatal(err)
+	}
+	list, err := s.ListByState(ctx, models.StateFailed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, j := range list {
+		if j.ID == id {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("job not in FAILED list")
+	}
+	t.Logf("postgres jobstore OK for %s", id)
+}

--- a/internal/deploy/jobstore/memory.go
+++ b/internal/deploy/jobstore/memory.go
@@ -1,0 +1,125 @@
+package jobstore
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/mattcburns/shoal/internal/common/models"
+)
+
+// Memory is an in-process Store for unit tests and DSN-less lab spikes.
+type Memory struct {
+	mu   sync.RWMutex
+	jobs map[string]models.ProvisioningJob
+}
+
+// NewMemory returns an empty memory job store.
+func NewMemory() *Memory {
+	return &Memory{jobs: make(map[string]models.ProvisioningJob)}
+}
+
+// Insert stores a new job. Fails if id already exists.
+func (m *Memory) Insert(_ context.Context, job models.ProvisioningJob) error {
+	if job.ID == "" {
+		return fmt.Errorf("jobstore: empty job id")
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, ok := m.jobs[job.ID]; ok {
+		return fmt.Errorf("jobstore: job %s already exists", job.ID)
+	}
+	now := time.Now().UTC()
+	if job.UpdatedAt == nil {
+		job.UpdatedAt = &now
+	}
+	m.jobs[job.ID] = cloneJob(job)
+	return nil
+}
+
+// Get returns a job by id.
+func (m *Memory) Get(_ context.Context, id string) (models.ProvisioningJob, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	j, ok := m.jobs[id]
+	if !ok {
+		return models.ProvisioningJob{}, ErrNotFound
+	}
+	return cloneJob(j), nil
+}
+
+// ListByState returns all jobs in state.
+func (m *Memory) ListByState(_ context.Context, state models.LifecycleState) ([]models.ProvisioningJob, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	var out []models.ProvisioningJob
+	for _, j := range m.jobs {
+		if j.State == state {
+			out = append(out, cloneJob(j))
+		}
+	}
+	return out, nil
+}
+
+// UpdateProgress updates phase/percent/seq/error without changing lifecycle state.
+func (m *Memory) UpdateProgress(_ context.Context, jobID string, phase string, percent *int, seq int, errSoft string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	j, ok := m.jobs[jobID]
+	if !ok {
+		return ErrNotFound
+	}
+	if phase != "" {
+		j.Phase = phase
+	}
+	if percent != nil {
+		p := *percent
+		j.Percent = &p
+	}
+	if seq > j.LastMarkerSeq {
+		j.LastMarkerSeq = seq
+	}
+	if errSoft != "" {
+		j.Error = errSoft
+	}
+	now := time.Now().UTC()
+	j.UpdatedAt = &now
+	m.jobs[jobID] = j
+	return nil
+}
+
+// Transition sets lifecycle state and optional error message.
+func (m *Memory) Transition(_ context.Context, jobID string, to models.LifecycleState, errMsg string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	j, ok := m.jobs[jobID]
+	if !ok {
+		return ErrNotFound
+	}
+	j.State = to
+	if errMsg != "" {
+		j.Error = errMsg
+	}
+	now := time.Now().UTC()
+	j.UpdatedAt = &now
+	m.jobs[jobID] = j
+	return nil
+}
+
+func cloneJob(j models.ProvisioningJob) models.ProvisioningJob {
+	out := j
+	if j.Percent != nil {
+		p := *j.Percent
+		out.Percent = &p
+	}
+	if j.StartedAt != nil {
+		t := *j.StartedAt
+		out.StartedAt = &t
+	}
+	if j.UpdatedAt != nil {
+		t := *j.UpdatedAt
+		out.UpdatedAt = &t
+	}
+	return out
+}

--- a/internal/deploy/jobstore/memory_test.go
+++ b/internal/deploy/jobstore/memory_test.go
@@ -1,0 +1,49 @@
+package jobstore_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/mattcburns/shoal/internal/common/models"
+	"github.com/mattcburns/shoal/internal/deploy/jobstore"
+)
+
+func TestMemoryStoreLifecycle(t *testing.T) {
+	ctx := context.Background()
+	s := jobstore.NewMemory()
+	job := models.ProvisioningJob{
+		ID:       "j1",
+		DeviceID: "d1",
+		State:    models.StateProvisioning,
+	}
+	if err := s.Insert(ctx, job); err != nil {
+		t.Fatal(err)
+	}
+	p := 25
+	if err := s.UpdateProgress(ctx, "j1", "IMAGE_WRITE", &p, 5, ""); err != nil {
+		t.Fatal(err)
+	}
+	got, err := s.Get(ctx, "j1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Phase != "IMAGE_WRITE" || got.LastMarkerSeq != 5 || got.Percent == nil || *got.Percent != 25 {
+		t.Fatalf("progress: %+v", got)
+	}
+	if err := s.Transition(ctx, "j1", models.StateProvisioned, ""); err != nil {
+		t.Fatal(err)
+	}
+	got, _ = s.Get(ctx, "j1")
+	if got.State != models.StateProvisioned {
+		t.Fatalf("state %s", got.State)
+	}
+	list, err := s.ListByState(ctx, models.StateProvisioned)
+	if err != nil || len(list) != 1 {
+		t.Fatalf("list: %v %d", err, len(list))
+	}
+	_, err = s.Get(ctx, "missing")
+	if !errors.Is(err, jobstore.ErrNotFound) {
+		t.Fatalf("want not found: %v", err)
+	}
+}

--- a/internal/deploy/jobstore/postgres.go
+++ b/internal/deploy/jobstore/postgres.go
@@ -1,0 +1,186 @@
+package jobstore
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/mattcburns/shoal/internal/common/models"
+)
+
+// Postgres is a durable Store backed by the jobs table.
+type Postgres struct {
+	db *sql.DB
+}
+
+// NewPostgres wraps an open *sql.DB (already migrated).
+func NewPostgres(db *sql.DB) *Postgres {
+	return &Postgres{db: db}
+}
+
+// Insert inserts a job row.
+func (p *Postgres) Insert(ctx context.Context, job models.ProvisioningJob) error {
+	if job.ID == "" {
+		return fmt.Errorf("jobstore: empty job id")
+	}
+	now := time.Now().UTC()
+	if job.UpdatedAt == nil {
+		job.UpdatedAt = &now
+	}
+	_, err := p.db.ExecContext(ctx, `
+INSERT INTO jobs (
+  id, device_id, profile_ref, state, attempt, phase, percent, last_marker_seq,
+  started_at, updated_at, error, sol_session_id, iso_url, bmc_endpoint
+) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14)`,
+		job.ID, job.DeviceID, job.ProfileRef, string(job.State), job.Attempt,
+		nullString(job.Phase), nullInt(job.Percent), job.LastMarkerSeq,
+		job.StartedAt, job.UpdatedAt, nullString(job.Error), nullString(job.SOLSessionID),
+		nullString(job.ISOURL), nullString(job.BMCEndpoint),
+	)
+	if err != nil {
+		return fmt.Errorf("jobstore: insert: %w", err)
+	}
+	return nil
+}
+
+// Get loads a job by id.
+func (p *Postgres) Get(ctx context.Context, id string) (models.ProvisioningJob, error) {
+	row := p.db.QueryRowContext(ctx, `
+SELECT id, device_id, profile_ref, state, attempt, phase, percent, last_marker_seq,
+       started_at, updated_at, error, sol_session_id, iso_url, bmc_endpoint
+FROM jobs WHERE id = $1`, id)
+	j, err := scanJob(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return models.ProvisioningJob{}, ErrNotFound
+	}
+	if err != nil {
+		return models.ProvisioningJob{}, fmt.Errorf("jobstore: get: %w", err)
+	}
+	return j, nil
+}
+
+// ListByState returns jobs in the given lifecycle state.
+func (p *Postgres) ListByState(ctx context.Context, state models.LifecycleState) ([]models.ProvisioningJob, error) {
+	rows, err := p.db.QueryContext(ctx, `
+SELECT id, device_id, profile_ref, state, attempt, phase, percent, last_marker_seq,
+       started_at, updated_at, error, sol_session_id, iso_url, bmc_endpoint
+FROM jobs WHERE state = $1`, string(state))
+	if err != nil {
+		return nil, fmt.Errorf("jobstore: list: %w", err)
+	}
+	defer rows.Close()
+	var out []models.ProvisioningJob
+	for rows.Next() {
+		j, err := scanJob(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, j)
+	}
+	return out, rows.Err()
+}
+
+// UpdateProgress updates progress fields only.
+func (p *Postgres) UpdateProgress(ctx context.Context, jobID string, phase string, percent *int, seq int, errSoft string) error {
+	now := time.Now().UTC()
+	res, err := p.db.ExecContext(ctx, `
+UPDATE jobs SET
+  phase = CASE WHEN $2 <> '' THEN $2 ELSE phase END,
+  percent = COALESCE($3, percent),
+  last_marker_seq = GREATEST(last_marker_seq, $4),
+  error = CASE WHEN $5 <> '' THEN $5 ELSE error END,
+  updated_at = $6
+WHERE id = $1`, jobID, phase, nullInt(percent), seq, errSoft, now)
+	if err != nil {
+		return fmt.Errorf("jobstore: update progress: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// Transition sets lifecycle state.
+func (p *Postgres) Transition(ctx context.Context, jobID string, to models.LifecycleState, errMsg string) error {
+	now := time.Now().UTC()
+	res, err := p.db.ExecContext(ctx, `
+UPDATE jobs SET
+  state = $2,
+  error = CASE WHEN $3 <> '' THEN $3 ELSE error END,
+  updated_at = $4
+WHERE id = $1`, jobID, string(to), errMsg, now)
+	if err != nil {
+		return fmt.Errorf("jobstore: transition: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+type scannable interface {
+	Scan(dest ...any) error
+}
+
+func scanJob(row scannable) (models.ProvisioningJob, error) {
+	var j models.ProvisioningJob
+	var state string
+	var phase, errMsg, solSess, iso, bmc sql.NullString
+	var percent sql.NullInt64
+	var started, updated sql.NullTime
+	err := row.Scan(
+		&j.ID, &j.DeviceID, &j.ProfileRef, &state, &j.Attempt,
+		&phase, &percent, &j.LastMarkerSeq,
+		&started, &updated, &errMsg, &solSess, &iso, &bmc,
+	)
+	if err != nil {
+		return models.ProvisioningJob{}, err
+	}
+	j.State = models.LifecycleState(state)
+	if phase.Valid {
+		j.Phase = phase.String
+	}
+	if percent.Valid {
+		p := int(percent.Int64)
+		j.Percent = &p
+	}
+	if started.Valid {
+		t := started.Time.UTC()
+		j.StartedAt = &t
+	}
+	if updated.Valid {
+		t := updated.Time.UTC()
+		j.UpdatedAt = &t
+	}
+	if errMsg.Valid {
+		j.Error = errMsg.String
+	}
+	if solSess.Valid {
+		j.SOLSessionID = solSess.String
+	}
+	if iso.Valid {
+		j.ISOURL = iso.String
+	}
+	if bmc.Valid {
+		j.BMCEndpoint = bmc.String
+	}
+	return j, nil
+}
+
+func nullString(s string) any {
+	if s == "" {
+		return nil
+	}
+	return s
+}
+
+func nullInt(p *int) any {
+	if p == nil {
+		return nil
+	}
+	return *p
+}

--- a/internal/deploy/jobstore/store.go
+++ b/internal/deploy/jobstore/store.go
@@ -1,0 +1,22 @@
+// Package jobstore is pure jobs-table persistence (CRUD / progress / transition).
+// No Redfish, no Observe imports, no cleanup side effects.
+package jobstore
+
+import (
+	"context"
+	"errors"
+
+	"github.com/mattcburns/shoal/internal/common/models"
+)
+
+// ErrNotFound is returned when a job id is unknown.
+var ErrNotFound = errors.New("jobstore: job not found")
+
+// Store is pure durable job repository.
+type Store interface {
+	Insert(ctx context.Context, job models.ProvisioningJob) error
+	Get(ctx context.Context, id string) (models.ProvisioningJob, error)
+	ListByState(ctx context.Context, state models.LifecycleState) ([]models.ProvisioningJob, error)
+	UpdateProgress(ctx context.Context, jobID string, phase string, percent *int, seq int, errSoft string) error
+	Transition(ctx context.Context, jobID string, to models.LifecycleState, errMsg string) error
+}

--- a/internal/observe/sol/doc.go
+++ b/internal/observe/sol/doc.go
@@ -1,3 +1,0 @@
-// Package sol implements SOL transports and SHOAL| marker parsing.
-// Parser returns models.SOLMarker. Implementation lands in Phase 2.
-package sol

--- a/internal/observe/sol/parse.go
+++ b/internal/observe/sol/parse.go
@@ -1,0 +1,101 @@
+// Package sol implements SOL transports and SHOAL| marker parsing.
+package sol
+
+import (
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/mattcburns/shoal/internal/common/models"
+)
+
+// Supported schema version for the SHOAL marker protocol.
+const SchemaVersion = 1
+
+// Marker line format:
+//
+//	SHOAL|<schema_ver>|<seq>|<iso8601_utc>|<phase>|<percent>|<state>|<detail>
+//
+// Example:
+//
+//	SHOAL|1|41|2026-06-19T04:10:11Z|IMAGE_WRITE|65|OK|writing rootfs
+func ParseLine(line string) (models.SOLMarker, bool) {
+	line = strings.TrimSpace(line)
+	// Allow noise before the marker on the same line (console prompts).
+	if idx := strings.Index(line, "SHOAL|"); idx >= 0 {
+		line = line[idx:]
+	}
+	if !strings.HasPrefix(line, "SHOAL|") {
+		return models.SOLMarker{}, false
+	}
+	// Split into at most 7 fields so detail may contain '|'.
+	parts := strings.SplitN(line, "|", 7)
+	if len(parts) < 7 {
+		return models.SOLMarker{}, false
+	}
+	ver, err := strconv.Atoi(parts[1])
+	if err != nil || ver != SchemaVersion {
+		return models.SOLMarker{}, false
+	}
+	seq, err := strconv.Atoi(parts[2])
+	if err != nil {
+		return models.SOLMarker{}, false
+	}
+	ts, err := time.Parse(time.RFC3339, parts[3])
+	if err != nil {
+		// try without seconds fraction variants
+		ts, err = time.Parse("2006-01-02T15:04:05Z", parts[3])
+		if err != nil {
+			return models.SOLMarker{}, false
+		}
+	}
+	phase := parts[4]
+	var percent *int
+	if parts[5] != "" && parts[5] != "-" {
+		p, err := strconv.Atoi(parts[5])
+		if err != nil {
+			return models.SOLMarker{}, false
+		}
+		percent = &p
+	}
+	// SplitN(..., 7): parts[6] is "state" or "state|detail..."
+	state, detail, _ := strings.Cut(parts[6], "|")
+
+	switch state {
+	case "OK", "WARN", "ERROR", "HEARTBEAT":
+	default:
+		return models.SOLMarker{}, false
+	}
+
+	return models.SOLMarker{
+		SchemaVer: ver,
+		Seq:       seq,
+		Timestamp: ts.UTC(),
+		Phase:     phase,
+		Percent:   percent,
+		State:     state,
+		Detail:    detail,
+	}, true
+}
+
+// IsTerminal reports whether the marker should end the provisioning job.
+func IsTerminal(m models.SOLMarker) bool {
+	if m.State == "ERROR" {
+		return true
+	}
+	if strings.EqualFold(m.Phase, "ERROR") {
+		return true
+	}
+	if strings.EqualFold(m.Phase, "DONE") && m.State == "OK" {
+		return true
+	}
+	return false
+}
+
+// TerminalReasonFromMarker maps a terminal marker to a reason string used by Deploy.
+func TerminalReasonFromMarker(m models.SOLMarker) string {
+	if strings.EqualFold(m.Phase, "DONE") && m.State == "OK" {
+		return "done_ok"
+	}
+	return "marker_error"
+}

--- a/internal/observe/sol/parse_test.go
+++ b/internal/observe/sol/parse_test.go
@@ -1,0 +1,85 @@
+package sol_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/mattcburns/shoal/internal/observe/sol"
+)
+
+func TestParseLine(t *testing.T) {
+	cases := []struct {
+		name    string
+		line    string
+		ok      bool
+		phase   string
+		state   string
+		percent *int
+		seq     int
+	}{
+		{
+			name: "progress",
+			line: "SHOAL|1|41|2026-06-19T04:10:11Z|IMAGE_WRITE|65|OK|writing rootfs to /dev/nvme0n1",
+			ok:   true, phase: "IMAGE_WRITE", state: "OK", percent: intPtr(65), seq: 41,
+		},
+		{
+			name: "heartbeat",
+			line: "SHOAL|1|42|2026-06-19T04:10:21Z|IMAGE_WRITE|-|HEARTBEAT|",
+			ok:   true, phase: "IMAGE_WRITE", state: "HEARTBEAT", percent: nil, seq: 42,
+		},
+		{
+			name: "done",
+			line: "SHOAL|1|43|2026-06-19T04:11:02Z|DONE|100|OK|reboot pending",
+			ok:   true, phase: "DONE", state: "OK", percent: intPtr(100), seq: 43,
+		},
+		{
+			name: "noise prefix",
+			line: "[    2.1] SHOAL|1|1|2026-06-19T04:10:00Z|BOOT|0|OK|starting",
+			ok:   true, phase: "BOOT", state: "OK", percent: intPtr(0), seq: 1,
+		},
+		{name: "ignore non marker", line: "login:", ok: false},
+		{name: "bad version", line: "SHOAL|2|1|2026-06-19T04:10:00Z|BOOT|0|OK|x", ok: false},
+		{name: "bad state", line: "SHOAL|1|1|2026-06-19T04:10:00Z|BOOT|0|NOPE|x", ok: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m, ok := sol.ParseLine(tc.line)
+			if ok != tc.ok {
+				t.Fatalf("ok=%v want %v", ok, tc.ok)
+			}
+			if !tc.ok {
+				return
+			}
+			if m.Phase != tc.phase || m.State != tc.state || m.Seq != tc.seq {
+				t.Fatalf("got phase=%s state=%s seq=%d", m.Phase, m.State, m.Seq)
+			}
+			if tc.percent == nil {
+				if m.Percent != nil {
+					t.Fatalf("percent want nil got %v", *m.Percent)
+				}
+			} else if m.Percent == nil || *m.Percent != *tc.percent {
+				t.Fatalf("percent mismatch")
+			}
+			if m.Timestamp.IsZero() || m.Timestamp.Location() != time.UTC {
+				// UTC after parse
+			}
+		})
+	}
+}
+
+func TestIsTerminal(t *testing.T) {
+	m, ok := sol.ParseLine("SHOAL|1|1|2026-06-19T04:11:02Z|DONE|100|OK|x")
+	if !ok || !sol.IsTerminal(m) {
+		t.Fatal("DONE/OK should be terminal")
+	}
+	m, ok = sol.ParseLine("SHOAL|1|2|2026-06-19T04:11:02Z|IMAGE_WRITE|10|ERROR|disk full")
+	if !ok || !sol.IsTerminal(m) {
+		t.Fatal("ERROR should be terminal")
+	}
+	m, ok = sol.ParseLine("SHOAL|1|3|2026-06-19T04:11:02Z|IMAGE_WRITE|10|OK|x")
+	if !ok || sol.IsTerminal(m) {
+		t.Fatal("progress should not be terminal")
+	}
+}
+
+func intPtr(v int) *int { return &v }

--- a/internal/observe/sol/ssh_libvirt.go
+++ b/internal/observe/sol/ssh_libvirt.go
@@ -1,0 +1,165 @@
+package sol
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"os/exec"
+	"strings"
+	"sync"
+
+	"github.com/mattcburns/shoal/internal/common/models"
+)
+
+// SSHSerialConfig configures remote libvirt serial access (no runtime state).
+type SSHSerialConfig struct {
+	Host string // e.g. 192.168.122.100
+	User string // e.g. lab
+	// KeyPath is optional private key for ssh -i (BatchMode).
+	KeyPath string
+	// SSH binary (default "ssh").
+	SSH string
+	// RemoteVirsh is the virsh binary on the remote host (default "virsh").
+	RemoteVirsh string
+	// UseSudo prefixes remote commands with sudo -n.
+	UseSudo bool
+}
+
+// SSHLibvirtTransport tails a nested libvirt domain serial console over SSH.
+// Used for VM-hosted lab mode where domains run on L1 and Shoal runs on L0.
+// Target is the libvirt domain name (e.g. shoal-node-1).
+type SSHLibvirtTransport struct {
+	cfg SSHSerialConfig
+
+	mu     sync.Mutex
+	cancel context.CancelFunc
+	cmd    *exec.Cmd
+	stdout io.ReadCloser
+}
+
+// NewSSHLibvirtTransport constructs a transport from config.
+func NewSSHLibvirtTransport(cfg SSHSerialConfig) *SSHLibvirtTransport {
+	return &SSHLibvirtTransport{cfg: cfg}
+}
+
+// Open starts an SSH session that cats the domain console PTY.
+func (t *SSHLibvirtTransport) Open(ctx context.Context, target string) (<-chan string, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if target == "" {
+		return nil, fmt.Errorf("sol: empty serial target")
+	}
+	if t.cfg.Host == "" {
+		return nil, fmt.Errorf("sol: SSH serial host not configured")
+	}
+	user := t.cfg.User
+	if user == "" {
+		user = "lab"
+	}
+	sshBin := t.cfg.SSH
+	if sshBin == "" {
+		sshBin = "ssh"
+	}
+	virsh := t.cfg.RemoteVirsh
+	if virsh == "" {
+		virsh = "virsh"
+	}
+
+	prefix := ""
+	if t.cfg.UseSudo {
+		prefix = "sudo -n "
+	}
+
+	// Resolve tty then cat. stdbuf reduces line buffering when available.
+	remote := fmt.Sprintf(
+		`set -e; PTY=$(%s%s ttyconsole %s); test -n "$PTY"; if command -v stdbuf >/dev/null 2>&1; then %sstdbuf -oL -eL cat "$PTY"; else %scat "$PTY"; fi`,
+		prefix, virsh, shellQuote(target), prefix, prefix,
+	)
+
+	args := []string{
+		"-o", "BatchMode=yes",
+		"-o", "StrictHostKeyChecking=accept-new",
+		"-o", "ConnectTimeout=10",
+	}
+	if t.cfg.KeyPath != "" {
+		args = append(args, "-i", t.cfg.KeyPath)
+	}
+	args = append(args, user+"@"+t.cfg.Host, remote)
+
+	cmd := exec.CommandContext(ctx, sshBin, args...)
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("sol: ssh stdout: %w", err)
+	}
+	cmd.Stderr = io.Discard
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("sol: ssh start: %w", err)
+	}
+	t.cmd = cmd
+	t.stdout = stdout
+
+	ctx, cancel := context.WithCancel(ctx)
+	t.cancel = cancel
+	ch := make(chan string, 32)
+
+	go func() {
+		defer close(ch)
+		sc := bufio.NewScanner(stdout)
+		buf := make([]byte, 0, 64*1024)
+		sc.Buffer(buf, 1024*1024)
+		for sc.Scan() {
+			select {
+			case <-ctx.Done():
+				return
+			case ch <- sc.Text():
+			}
+		}
+		_ = cmd.Wait()
+	}()
+
+	return ch, nil
+}
+
+// Close stops the SSH cat process.
+func (t *SSHLibvirtTransport) Close() error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.cancel != nil {
+		t.cancel()
+		t.cancel = nil
+	}
+	var err error
+	if t.cmd != nil && t.cmd.Process != nil {
+		_ = t.cmd.Process.Kill()
+		err = t.cmd.Wait()
+		t.cmd = nil
+	}
+	if t.stdout != nil {
+		_ = t.stdout.Close()
+		t.stdout = nil
+	}
+	return err
+}
+
+func shellQuote(s string) string {
+	if s == "" {
+		return "''"
+	}
+	return "'" + strings.ReplaceAll(s, "'", `'"'"'`) + "'"
+}
+
+// NewTransportFactory returns a WatchService-compatible factory.
+// When cfg.Host is non-empty, domain-name targets use SSHLibvirtTransport.
+// Absolute path targets always use local LibvirtTransport.
+func NewTransportFactory(cfg SSHSerialConfig) func(session models.WatchSession) Transport {
+	return func(session models.WatchSession) Transport {
+		if strings.HasPrefix(session.Target, "/") {
+			return &LibvirtTransport{}
+		}
+		if cfg.Host != "" {
+			return NewSSHLibvirtTransport(cfg)
+		}
+		return &LibvirtTransport{}
+	}
+}

--- a/internal/observe/sol/ssh_libvirt.go
+++ b/internal/observe/sol/ssh_libvirt.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/mattcburns/shoal/internal/common/models"
 )
@@ -32,10 +33,12 @@ type SSHSerialConfig struct {
 type SSHLibvirtTransport struct {
 	cfg SSHSerialConfig
 
-	mu     sync.Mutex
-	cancel context.CancelFunc
-	cmd    *exec.Cmd
-	stdout io.ReadCloser
+	mu       sync.Mutex
+	cancel   context.CancelFunc
+	cmd      *exec.Cmd
+	stdout   io.ReadCloser
+	waitOnce sync.Once
+	waitErr  error
 }
 
 // NewSSHLibvirtTransport constructs a transport from config.
@@ -87,7 +90,9 @@ func (t *SSHLibvirtTransport) Open(ctx context.Context, target string) (<-chan s
 	}
 	args = append(args, user+"@"+t.cfg.Host, remote)
 
-	cmd := exec.CommandContext(ctx, sshBin, args...)
+	// Detach process lifetime from the watch context: Open/Close own the process.
+	// Tying ssh to watchCtx made cancel races with pipe drain hang cmd.Wait.
+	cmd := exec.Command(sshBin, args...)
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		return nil, fmt.Errorf("sol: ssh stdout: %w", err)
@@ -98,8 +103,10 @@ func (t *SSHLibvirtTransport) Open(ctx context.Context, target string) (<-chan s
 	}
 	t.cmd = cmd
 	t.stdout = stdout
+	t.waitOnce = sync.Once{}
+	t.waitErr = nil
 
-	ctx, cancel := context.WithCancel(ctx)
+	scanCtx, cancel := context.WithCancel(context.Background())
 	t.cancel = cancel
 	ch := make(chan string, 32)
 
@@ -110,36 +117,65 @@ func (t *SSHLibvirtTransport) Open(ctx context.Context, target string) (<-chan s
 		sc.Buffer(buf, 1024*1024)
 		for sc.Scan() {
 			select {
-			case <-ctx.Done():
+			case <-scanCtx.Done():
 				return
 			case ch <- sc.Text():
 			}
 		}
-		_ = cmd.Wait()
+		// Natural EOF: reap process. Close may also reap via waitOnce.
+		_ = t.reap()
 	}()
 
 	return ch, nil
 }
 
-// Close stops the SSH cat process.
+func (t *SSHLibvirtTransport) reap() error {
+	t.waitOnce.Do(func() {
+		t.mu.Lock()
+		cmd := t.cmd
+		t.mu.Unlock()
+		if cmd != nil {
+			t.waitErr = cmd.Wait()
+		}
+	})
+	return t.waitErr
+}
+
+// Close stops the SSH cat process. It never blocks indefinitely.
 func (t *SSHLibvirtTransport) Close() error {
 	t.mu.Lock()
-	defer t.mu.Unlock()
-	if t.cancel != nil {
-		t.cancel()
-		t.cancel = nil
+	cancel := t.cancel
+	t.cancel = nil
+	cmd := t.cmd
+	stdout := t.stdout
+	t.stdout = nil
+	t.mu.Unlock()
+
+	if cancel != nil {
+		cancel()
 	}
-	var err error
-	if t.cmd != nil && t.cmd.Process != nil {
-		_ = t.cmd.Process.Kill()
-		err = t.cmd.Wait()
+	// Unblock Scanner / ssh write side before Wait.
+	if stdout != nil {
+		_ = stdout.Close()
+	}
+	if cmd != nil && cmd.Process != nil {
+		_ = cmd.Process.Kill()
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- t.reap() }()
+	select {
+	case err := <-done:
+		t.mu.Lock()
 		t.cmd = nil
+		t.mu.Unlock()
+		return err
+	case <-time.After(3 * time.Second):
+		t.mu.Lock()
+		t.cmd = nil
+		t.mu.Unlock()
+		return fmt.Errorf("sol: ssh wait timed out after kill")
 	}
-	if t.stdout != nil {
-		_ = t.stdout.Close()
-		t.stdout = nil
-	}
-	return err
 }
 
 func shellQuote(s string) string {

--- a/internal/observe/sol/ssh_libvirt_test.go
+++ b/internal/observe/sol/ssh_libvirt_test.go
@@ -1,0 +1,32 @@
+package sol_test
+
+import (
+	"testing"
+
+	"github.com/mattcburns/shoal/internal/common/models"
+	"github.com/mattcburns/shoal/internal/observe/sol"
+)
+
+func TestNewTransportFactorySSH(t *testing.T) {
+	f := sol.NewTransportFactory(sol.SSHSerialConfig{
+		Host:    "192.168.122.100",
+		User:    "lab",
+		UseSudo: true,
+	})
+	tr := f(models.WatchSession{Transport: "libvirt", Target: "shoal-node-1"})
+	if _, ok := tr.(*sol.SSHLibvirtTransport); !ok {
+		t.Fatalf("want SSHLibvirtTransport, got %T", tr)
+	}
+	tr = f(models.WatchSession{Target: "/dev/pts/0"})
+	if _, ok := tr.(*sol.LibvirtTransport); !ok {
+		t.Fatalf("want LibvirtTransport for path, got %T", tr)
+	}
+}
+
+func TestNewTransportFactoryLocal(t *testing.T) {
+	f := sol.NewTransportFactory(sol.SSHSerialConfig{})
+	tr := f(models.WatchSession{Target: "shoal-node-1"})
+	if _, ok := tr.(*sol.LibvirtTransport); !ok {
+		t.Fatalf("want local LibvirtTransport, got %T", tr)
+	}
+}

--- a/internal/observe/sol/transport.go
+++ b/internal/observe/sol/transport.go
@@ -40,10 +40,11 @@ func (t *ReaderTransport) Open(ctx context.Context, _ string) (<-chan string, er
 	}
 	ctx, cancel := context.WithCancel(ctx)
 	t.cancel = cancel
+	r := t.r
 	ch := make(chan string, 32)
 	go func() {
 		defer close(ch)
-		sc := bufio.NewScanner(t.r)
+		sc := bufio.NewScanner(r)
 		// large lines possible on serial
 		buf := make([]byte, 0, 64*1024)
 		sc.Buffer(buf, 1024*1024)
@@ -68,6 +69,8 @@ func (t *ReaderTransport) Close() error {
 	}
 	if t.r != nil {
 		err := t.r.Close()
+		// keep r set until after Close so a racing Open capture is safe;
+		// callers must not Open again after Close without a new transport.
 		t.r = nil
 		return err
 	}
@@ -118,7 +121,7 @@ func (t *LibvirtTransport) Open(ctx context.Context, target string) (<-chan stri
 	ch := make(chan string, 32)
 	go func() {
 		defer close(ch)
-		sc := bufio.NewScanner(f)
+		sc := bufio.NewScanner(f) // local f, not t.file
 		buf := make([]byte, 0, 64*1024)
 		sc.Buffer(buf, 1024*1024)
 		for sc.Scan() {

--- a/internal/observe/sol/transport.go
+++ b/internal/observe/sol/transport.go
@@ -1,0 +1,149 @@
+package sol
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+)
+
+// Transport opens a line-oriented serial/console stream.
+type Transport interface {
+	// Open starts the stream and returns a channel of lines (without trailing newline).
+	// The channel is closed when the stream ends or Close is called.
+	Open(ctx context.Context, target string) (<-chan string, error)
+	Close() error
+}
+
+// ReaderTransport reads lines from an io.Reader (tests / injected pipes).
+type ReaderTransport struct {
+	mu     sync.Mutex
+	cancel context.CancelFunc
+	r      io.ReadCloser
+}
+
+// NewReaderTransport wraps r as a Transport. Target is ignored on Open.
+func NewReaderTransport(r io.ReadCloser) *ReaderTransport {
+	return &ReaderTransport{r: r}
+}
+
+// Open starts reading lines from the reader.
+func (t *ReaderTransport) Open(ctx context.Context, _ string) (<-chan string, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.r == nil {
+		return nil, fmt.Errorf("sol: nil reader")
+	}
+	ctx, cancel := context.WithCancel(ctx)
+	t.cancel = cancel
+	ch := make(chan string, 32)
+	go func() {
+		defer close(ch)
+		sc := bufio.NewScanner(t.r)
+		// large lines possible on serial
+		buf := make([]byte, 0, 64*1024)
+		sc.Buffer(buf, 1024*1024)
+		for sc.Scan() {
+			select {
+			case <-ctx.Done():
+				return
+			case ch <- sc.Text():
+			}
+		}
+	}()
+	return ch, nil
+}
+
+// Close cancels the reader loop and closes the underlying reader.
+func (t *ReaderTransport) Close() error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.cancel != nil {
+		t.cancel()
+		t.cancel = nil
+	}
+	if t.r != nil {
+		err := t.r.Close()
+		t.r = nil
+		return err
+	}
+	return nil
+}
+
+// LibvirtTransport resolves a domain console via `virsh ttyconsole` and tails the PTY.
+// Target is the libvirt domain name (or an absolute path to a PTY/device).
+type LibvirtTransport struct {
+	mu     sync.Mutex
+	cancel context.CancelFunc
+	file   *os.File
+	// Virsh is the virsh binary (default "virsh").
+	Virsh string
+}
+
+// Open attaches to the domain serial console.
+func (t *LibvirtTransport) Open(ctx context.Context, target string) (<-chan string, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if target == "" {
+		return nil, fmt.Errorf("sol: empty serial target")
+	}
+
+	path := target
+	if !strings.HasPrefix(target, "/") {
+		virsh := t.Virsh
+		if virsh == "" {
+			virsh = "virsh"
+		}
+		out, err := exec.CommandContext(ctx, virsh, "ttyconsole", target).Output()
+		if err != nil {
+			return nil, fmt.Errorf("sol: virsh ttyconsole %s: %w", target, err)
+		}
+		path = strings.TrimSpace(string(out))
+		if path == "" {
+			return nil, fmt.Errorf("sol: empty ttyconsole for %s", target)
+		}
+	}
+
+	f, err := os.OpenFile(path, os.O_RDONLY, 0)
+	if err != nil {
+		return nil, fmt.Errorf("sol: open console %s: %w", path, err)
+	}
+	t.file = f
+	ctx, cancel := context.WithCancel(ctx)
+	t.cancel = cancel
+	ch := make(chan string, 32)
+	go func() {
+		defer close(ch)
+		sc := bufio.NewScanner(f)
+		buf := make([]byte, 0, 64*1024)
+		sc.Buffer(buf, 1024*1024)
+		for sc.Scan() {
+			select {
+			case <-ctx.Done():
+				return
+			case ch <- sc.Text():
+			}
+		}
+	}()
+	return ch, nil
+}
+
+// Close stops the tail and closes the PTY handle.
+func (t *LibvirtTransport) Close() error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.cancel != nil {
+		t.cancel()
+		t.cancel = nil
+	}
+	if t.file != nil {
+		err := t.file.Close()
+		t.file = nil
+		return err
+	}
+	return nil
+}

--- a/internal/observe/sol/watch.go
+++ b/internal/observe/sol/watch.go
@@ -129,6 +129,7 @@ func (w *WatchService) cleanupLocked(session models.WatchSession) {
 }
 
 // Unregister stops the watch for sessionID.
+// Close is bounded so Deploy HandleTerminal cannot hang on a stuck SSH/PTY.
 func (w *WatchService) Unregister(_ context.Context, sessionID string) error {
 	w.mu.Lock()
 	aw, ok := w.active[sessionID]
@@ -141,10 +142,22 @@ func (w *WatchService) Unregister(_ context.Context, sessionID string) error {
 	w.mu.Unlock()
 
 	aw.cancel()
-	_ = aw.trans.Close()
+
+	closeDone := make(chan struct{})
+	go func() {
+		_ = aw.trans.Close()
+		close(closeDone)
+	}()
+	select {
+	case <-closeDone:
+	case <-time.After(5 * time.Second):
+		w.log.Warn("sol transport close timed out", "session_id", sessionID)
+	}
+
 	select {
 	case <-aw.done:
 	case <-time.After(2 * time.Second):
+		w.log.Warn("sol watch run did not exit promptly", "session_id", sessionID)
 	}
 	w.log.Info("sol watch unregistered", "session_id", sessionID)
 	return nil
@@ -176,6 +189,8 @@ func (w *WatchService) run(ctx context.Context, aw *activeWatch, lines <-chan st
 			return
 		case line, ok := <-lines:
 			if !ok {
+				// Stream ended without a terminal marker (or after watch cancel).
+				// Deploy ignores transport errors once the job is no longer PROVISIONING.
 				_ = progress.ReportTransportError(context.Background(), aw.session.JobID, fmt.Errorf("sol stream closed"))
 				return
 			}
@@ -187,8 +202,12 @@ func (w *WatchService) run(ctx context.Context, aw *activeWatch, lines <-chan st
 			if err := progress.ApplyMarker(context.Background(), aw.session.JobID, m); err != nil {
 				w.log.Error("apply marker failed", "job_id", aw.session.JobID, "err", err.Error())
 			}
-			// Terminal markers: progress port notifies orchestrator; we keep
-			// running until Unregister so cleanup can complete.
+			// Terminal markers: orchestrator is notified via jobport; stop the
+			// watch loop so guest poweroff does not race as a transport error and
+			// so Unregister is not stuck draining a dead serial stream.
+			if IsTerminal(m) {
+				return
+			}
 		}
 	}
 }

--- a/internal/observe/sol/watch.go
+++ b/internal/observe/sol/watch.go
@@ -1,0 +1,203 @@
+package sol
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/mattcburns/shoal/internal/common/jobport"
+	"github.com/mattcburns/shoal/internal/common/models"
+	"github.com/mattcburns/shoal/internal/common/watchport"
+)
+
+// DefaultStallTimeout is used when WatchSession.StallTimeout is zero.
+const DefaultStallTimeout = 90 * time.Second
+
+// WatchService implements watchport.WatchRegistrar using a SOL Transport factory.
+type WatchService struct {
+	log      *slog.Logger
+	progress jobport.JobProgress
+	// NewTransport builds a transport for a session (libvirt by default).
+	NewTransport func(session models.WatchSession) Transport
+
+	mu       sync.Mutex
+	active   map[string]*activeWatch // sessionID -> watch
+	byDevice map[string]string       // deviceID -> sessionID (single ownership)
+}
+
+type activeWatch struct {
+	session models.WatchSession
+	cancel  context.CancelFunc
+	trans   Transport
+	done    chan struct{}
+}
+
+// NewWatchService constructs a WatchService. progress must be non-nil before Register.
+func NewWatchService(log *slog.Logger, progress jobport.JobProgress) *WatchService {
+	if log == nil {
+		log = slog.Default()
+	}
+	return &WatchService{
+		log:      log,
+		progress: progress,
+		active:   make(map[string]*activeWatch),
+		byDevice: make(map[string]string),
+		NewTransport: func(session models.WatchSession) Transport {
+			switch session.Transport {
+			case "libvirt", "":
+				return &LibvirtTransport{}
+			default:
+				return &LibvirtTransport{}
+			}
+		},
+	}
+}
+
+// SetProgress injects the job progress port (composition root may wire late).
+func (w *WatchService) SetProgress(p jobport.JobProgress) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.progress = p
+}
+
+// Register starts a SOL tail for the session. Rejects dual ownership of a device.
+func (w *WatchService) Register(ctx context.Context, session models.WatchSession) error {
+	if session.ID == "" || session.JobID == "" || session.DeviceID == "" {
+		return fmt.Errorf("sol: watch session missing id/job/device")
+	}
+	if session.Target == "" {
+		return fmt.Errorf("sol: watch session missing target")
+	}
+	if session.StallTimeout <= 0 {
+		session.StallTimeout = DefaultStallTimeout
+	}
+
+	w.mu.Lock()
+	if w.progress == nil {
+		w.mu.Unlock()
+		return fmt.Errorf("sol: progress port not configured")
+	}
+	if _, ok := w.byDevice[session.DeviceID]; ok {
+		w.mu.Unlock()
+		return fmt.Errorf("sol: device %s already has an active SOL watch", session.DeviceID)
+	}
+	if _, ok := w.active[session.ID]; ok {
+		w.mu.Unlock()
+		return fmt.Errorf("sol: session %s already registered", session.ID)
+	}
+
+	trans := w.NewTransport(session)
+	watchCtx, cancel := context.WithCancel(context.Background())
+	aw := &activeWatch{
+		session: session,
+		cancel:  cancel,
+		trans:   trans,
+		done:    make(chan struct{}),
+	}
+	w.active[session.ID] = aw
+	w.byDevice[session.DeviceID] = session.ID
+	progress := w.progress
+	w.mu.Unlock()
+
+	lines, err := trans.Open(watchCtx, session.Target)
+	if err != nil {
+		w.cleanupLocked(session)
+		return fmt.Errorf("sol: open transport: %w", err)
+	}
+
+	go w.run(watchCtx, aw, lines, progress)
+	w.log.Info("sol watch registered",
+		"session_id", session.ID,
+		"job_id", session.JobID,
+		"device_id", session.DeviceID,
+		"target", session.Target,
+	)
+	return nil
+}
+
+func (w *WatchService) cleanupLocked(session models.WatchSession) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if aw, ok := w.active[session.ID]; ok {
+		aw.cancel()
+		_ = aw.trans.Close()
+		delete(w.active, session.ID)
+	}
+	delete(w.byDevice, session.DeviceID)
+}
+
+// Unregister stops the watch for sessionID.
+func (w *WatchService) Unregister(_ context.Context, sessionID string) error {
+	w.mu.Lock()
+	aw, ok := w.active[sessionID]
+	if !ok {
+		w.mu.Unlock()
+		return nil
+	}
+	delete(w.active, sessionID)
+	delete(w.byDevice, aw.session.DeviceID)
+	w.mu.Unlock()
+
+	aw.cancel()
+	_ = aw.trans.Close()
+	select {
+	case <-aw.done:
+	case <-time.After(2 * time.Second):
+	}
+	w.log.Info("sol watch unregistered", "session_id", sessionID)
+	return nil
+}
+
+func (w *WatchService) run(ctx context.Context, aw *activeWatch, lines <-chan string, progress jobport.JobProgress) {
+	defer close(aw.done)
+	stall := aw.session.StallTimeout
+	timer := time.NewTimer(stall)
+	defer timer.Stop()
+
+	resetStall := func() {
+		if !timer.Stop() {
+			select {
+			case <-timer.C:
+			default:
+			}
+		}
+		timer.Reset(stall)
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-timer.C:
+			w.log.Warn("sol stall detected", "job_id", aw.session.JobID, "timeout", stall.String())
+			_ = progress.ReportStall(context.Background(), aw.session.JobID, fmt.Sprintf("no SOL marker for %s", stall))
+			return
+		case line, ok := <-lines:
+			if !ok {
+				_ = progress.ReportTransportError(context.Background(), aw.session.JobID, fmt.Errorf("sol stream closed"))
+				return
+			}
+			m, ok := ParseLine(line)
+			if !ok {
+				continue
+			}
+			resetStall()
+			if err := progress.ApplyMarker(context.Background(), aw.session.JobID, m); err != nil {
+				w.log.Error("apply marker failed", "job_id", aw.session.JobID, "err", err.Error())
+			}
+			// Terminal markers: progress port notifies orchestrator; we keep
+			// running until Unregister so cleanup can complete.
+		}
+	}
+}
+
+// ActiveCount returns the number of active watches (test helper).
+func (w *WatchService) ActiveCount() int {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return len(w.active)
+}
+
+var _ watchport.WatchRegistrar = (*WatchService)(nil)

--- a/internal/observe/sol/watch_test.go
+++ b/internal/observe/sol/watch_test.go
@@ -1,0 +1,97 @@
+package sol_test
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/mattcburns/shoal/internal/common/models"
+	"github.com/mattcburns/shoal/internal/observe/sol"
+)
+
+type recordingProgress struct {
+	mu      sync.Mutex
+	markers []models.SOLMarker
+	stalls  int
+}
+
+func (r *recordingProgress) ApplyMarker(_ context.Context, _ string, m models.SOLMarker) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.markers = append(r.markers, m)
+	return nil
+}
+func (r *recordingProgress) ReportStall(context.Context, string, string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.stalls++
+	return nil
+}
+func (r *recordingProgress) ReportTransportError(context.Context, string, error) error { return nil }
+
+func TestWatchServiceMarkers(t *testing.T) {
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	prog := &recordingProgress{}
+	w := sol.NewWatchService(log, prog)
+	pr, pw := io.Pipe()
+	w.NewTransport = func(models.WatchSession) sol.Transport {
+		return sol.NewReaderTransport(pr)
+	}
+	err := w.Register(context.Background(), models.WatchSession{
+		ID: "s1", JobID: "j1", DeviceID: "d1", Target: "x",
+		StallTimeout: time.Minute,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// dual ownership rejected
+	if err := w.Register(context.Background(), models.WatchSession{
+		ID: "s2", JobID: "j2", DeviceID: "d1", Target: "y", StallTimeout: time.Minute,
+	}); err == nil {
+		t.Fatal("expected dual ownership error")
+	}
+
+	_, _ = io.WriteString(pw, "noise\n")
+	_, _ = io.WriteString(pw, "SHOAL|1|1|2026-06-19T04:10:00Z|BOOT|1|OK|hi\n")
+	time.Sleep(50 * time.Millisecond)
+	prog.mu.Lock()
+	n := len(prog.markers)
+	prog.mu.Unlock()
+	if n != 1 {
+		t.Fatalf("markers=%d", n)
+	}
+	_ = w.Unregister(context.Background(), "s1")
+	_ = pw.Close()
+}
+
+func TestWatchServiceStall(t *testing.T) {
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	prog := &recordingProgress{}
+	w := sol.NewWatchService(log, prog)
+	pr, pw := io.Pipe()
+	defer pw.Close()
+	w.NewTransport = func(models.WatchSession) sol.Transport {
+		return sol.NewReaderTransport(pr)
+	}
+	err := w.Register(context.Background(), models.WatchSession{
+		ID: "s1", JobID: "j1", DeviceID: "d1", Target: "x",
+		StallTimeout: 50 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		prog.mu.Lock()
+		st := prog.stalls
+		prog.mu.Unlock()
+		if st > 0 {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("stall not reported")
+}

--- a/internal/observe/sol/watch_test.go
+++ b/internal/observe/sol/watch_test.go
@@ -67,6 +67,53 @@ func TestWatchServiceMarkers(t *testing.T) {
 	_ = pw.Close()
 }
 
+func TestWatchServiceStopsOnTerminalMarker(t *testing.T) {
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	prog := &recordingProgress{}
+	w := sol.NewWatchService(log, prog)
+	pr, pw := io.Pipe()
+	w.NewTransport = func(models.WatchSession) sol.Transport {
+		return sol.NewReaderTransport(pr)
+	}
+	ctx := context.Background()
+	if err := w.Register(ctx, models.WatchSession{
+		ID: "s1", JobID: "j1", DeviceID: "d1", Target: "t",
+		StallTimeout: time.Minute,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	_, _ = io.WriteString(pw, "SHOAL|1|1|2026-06-19T04:10:00Z|DONE|100|OK|done\n")
+	// Give run loop time to apply terminal marker without closing the pipe.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		prog.mu.Lock()
+		n := len(prog.markers)
+		prog.mu.Unlock()
+		if n >= 1 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	prog.mu.Lock()
+	n := len(prog.markers)
+	prog.mu.Unlock()
+	if n < 1 {
+		t.Fatal("expected terminal marker applied")
+	}
+	// Unregister should complete quickly even if pipe still open.
+	done := make(chan error, 1)
+	go func() { done <- w.Unregister(ctx, "s1") }()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("Unregister hung after terminal marker")
+	}
+	_ = pw.Close()
+}
+
 func TestWatchServiceStall(t *testing.T) {
 	log := slog.New(slog.NewTextHandler(io.Discard, nil))
 	prog := &recordingProgress{}


### PR DESCRIPTION
## Summary
Implements **Phase 2 thesis spike** (design v2.0.3 / PR4–PR8): BMC-only provisioning with Virtual Media, SOL marker feedback, Orchestrator lifecycle, and lab E2E — **without AI or Discover/NetBox**.

- **Redfish** (gofish behind `internal/common/redfish`): VM insert/eject, boot override, power, cleanup
- **SOL observe**: marker parser, watch service, SSH→libvirt serial for VM lab mode
- **Deploy**: pure JobStore (memory + Postgres), Orchestrator + `HandleTerminal`, cancel, orphan reconcile
- **CLI/API**: `shoal deploy run|status|cancel` with Phase 2 binding flags; `GET/POST /v1/jobs/...`
- **Live image**: Ansible marker ISO build/publish to lab nginx `:8080`
- **Hang fix**: DONE no longer leaves jobs stuck in `provisioning` when SSH SOL `Close`/`Wait` stalls

## Acceptance criteria
- [x] CLI flags only (no NetBox device required)
- [x] Boot marker ISO via Virtual Media from `http://…:8080/….iso`; phase/percent → DONE via SOL; media ejected + override cleared
- [x] Heartbeat kill → stall → FAILED + cleanup
- [x] Cancel → cleanup + FAILED
- [x] Orphan PROVISIONING reconcile (fail + cleanup default)
- [x] Validated on lab; no LLM/Discover required

## Test plan
- [x] `gofmt` / `go vet ./...` / `go test ./...`
- [x] `go test ./internal/deploy/job ./internal/common/redfish ./internal/deploy/jobstore -tags=integration -count=1`
  - cancel, stall, real SOL SSH (seq=7 → provisioned), injected SOL, Redfish VM cleanup, Postgres JobStore
- [x] CLI: `go run ./cmd/shoal deploy run -device-id shoal-node-1 …` → `provisioned OK`
- [x] Regression: `TestOrchestratorDoneDespiteStuckSOLClose`

## Notes for reviewers
- Branch is **4 commits** ahead of `master` (full Phase 2 + hang fix).
- Known non-blocker: `internal/deploy/job` imports `internal/observe/sol` for `IsTerminal` (boundary cleanup can be a follow-up).
- sushy-tools boot clear may report `Continuous/Hdd` rather than `Disabled`; media eject is verified.