### PR TITLE
feat(lab): pull text + vision Ollama models for Phase 3 AI contract

### DIFF
--- a/docs/lab-runbook.md
+++ b/docs/lab-runbook.md
@@ -58,6 +58,34 @@ go run ./cmd/shoal deploy run \
 
 See also [phase2-live-image.md](./phase2-live-image.md).
 
+### Ollama models (design §6 / v2.0.4 dual-model contract)
+
+`up.yml` / `compose_stack` pulls configured Ollama models into the `shoal-ollama`
+container after the stack is healthy:
+
+| Ansible var | App env | Lab default | Role |
+|-------------|---------|-------------|------|
+| `shoal_ai_model` | `SHOAL_AI_MODEL` | `llama3.2:3b` | Text / hybrid JSON (required) |
+| `shoal_ai_vision_model` | `SHOAL_AI_VISION_MODEL` | `moondream` | Photo / `CompleteVision` (optional; empty skips pull + smoke) |
+
+`smoke.yml` asserts `/api/tags` includes the text model, and the vision model when
+`shoal_ai_vision_model` is non-empty. First vision pull can take several minutes.
+
+Re-pull without full stack rebuild (on L1 / lab VM):
+
+```bash
+ssh -i ~/.ssh/shoal_lab_vm lab@192.168.122.100 \
+  'docker exec shoal-ollama ollama pull llama3.2:3b &&
+   docker exec shoal-ollama ollama pull moondream'
+curl -s http://192.168.122.100:11434/api/tags | jq '.models[].name'
+```
+
+To skip vision in a constrained lab, set `shoal_ai_vision_model: ""` in
+`defaults.yml` (or inventory override) and re-run the compose/ollama portion of
+`up.yml`.
+
+Phase 3 app smoke will use these env vars once the hybrid Discover PR lands.
+
 ## 2) Fast stop (teardown / clean slate)
 ```bash
 ansible-playbook -i infra/ansible/inventory/lab-vm.yml infra/ansible/playbooks/down.yml

--- a/infra/ansible/inventory/group_vars/all/defaults.yml
+++ b/infra/ansible/inventory/group_vars/all/defaults.yml
@@ -44,15 +44,21 @@ shoal_ollama_port: 11434
 shoal_telemetry_db_port: 5433
 shoal_redis_port: 6379
 
-# --- AI provider (see design doc §6) ---
+# --- AI provider (see design doc §6 / v2.0.4 dual-model contract) ---
 # Provider is "ollama" (local, served by the shoal-ollama container) or "cloud".
 # The Ollama base URL is mode-specific (see vm_mode.yml / direct_mode.yml).
 # Cloud provider base URL is only used when shoal_ai_provider == "cloud"; leave
 # empty for local Ollama. Common cloud values:
 #   Groq   https://api.groq.com/openai/v1
 #   OpenAI https://api.openai.com/v1
+#
+# Text model (SHOAL_AI_MODEL): required; always pulled into the Ollama container.
+# Vision model (SHOAL_AI_VISION_MODEL): optional; empty skips pull/smoke for vision.
+# Lab default uses moondream (~1.8B) for Phase 3 photo path readiness. Nested lab
+# Ollama is often CPU-bound — keep ≤3B-class models.
 shoal_ai_provider: ollama
 shoal_ai_model: llama3.2:3b
+shoal_ai_vision_model: moondream
 shoal_cloud_ai_base_url: ""
 
 # --- Paths on the target host (where the lab stack runs) ---

--- a/infra/ansible/playbooks/smoke.yml
+++ b/infra/ansible/playbooks/smoke.yml
@@ -60,6 +60,47 @@
       failed_when: false
       changed_when: false
 
+    # Ollama /api/tags returns { "models": [ { "name": "llama3.2:3b", ... }, ... ] }.
+    # Match configured model as a prefix of the reported name (tag may add digests later).
+    - name: Assert Ollama text model is present
+      ansible.builtin.assert:
+        that:
+          - smoke_ollama.status == 200
+          - smoke_ollama.json.models is defined
+          - >
+            smoke_ollama.json.models
+            | map(attribute='name')
+            | select('search', '^' + (shoal_ai_model | regex_escape))
+            | list
+            | length > 0
+        fail_msg: >-
+          Ollama text model {{ shoal_ai_model }} not found in /api/tags.
+          Models: {{ smoke_ollama.json.models | default([]) | map(attribute='name') | list }}.
+          Pull with: docker exec shoal-ollama ollama pull {{ shoal_ai_model }}
+        success_msg: "Ollama text model present: {{ shoal_ai_model }}"
+      when: smoke_ollama.status == 200
+
+    - name: Assert Ollama vision model is present
+      ansible.builtin.assert:
+        that:
+          - smoke_ollama.status == 200
+          - smoke_ollama.json.models is defined
+          - >
+            smoke_ollama.json.models
+            | map(attribute='name')
+            | select('search', '^' + (shoal_ai_vision_model | regex_escape))
+            | list
+            | length > 0
+        fail_msg: >-
+          Ollama vision model {{ shoal_ai_vision_model }} not found in /api/tags.
+          Models: {{ smoke_ollama.json.models | default([]) | map(attribute='name') | list }}.
+          Pull with: docker exec shoal-ollama ollama pull {{ shoal_ai_vision_model }}
+          (or set shoal_ai_vision_model: "" to skip vision in this lab).
+        success_msg: "Ollama vision model present: {{ shoal_ai_vision_model }}"
+      when:
+        - smoke_ollama.status == 200
+        - (shoal_ai_vision_model | default('') | length) > 0
+
     - name: Check ISO HTTP server
       ansible.builtin.uri:
         url: "http://{{ shoal_service_host }}:{{ shoal_iso_server_port }}/"

--- a/infra/ansible/roles/compose_stack/tasks/main.yml
+++ b/infra/ansible/roles/compose_stack/tasks/main.yml
@@ -149,24 +149,42 @@
   delay: 3
   tags: [wait]
 
-- name: Pull Ollama model
-  shell: |
-    docker exec shoal-ollama ollama pull {{ shoal_ai_model }}
+# Text model is required; vision model is optional (empty string skips pull).
+# Sequential pulls keep nested-lab Ollama memory pressure lower than parallel.
+- name: Build Ollama model pull list
+  set_fact:
+    shoal_ollama_models_to_pull: >-
+      {{
+        ([shoal_ai_model] + ([shoal_ai_vision_model] if (shoal_ai_vision_model | default('') | length) > 0 else []))
+        | unique
+        | list
+      }}
+  tags: [ollama]
+
+- name: Pull Ollama models (text + optional vision)
+  ansible.builtin.command:
+    cmd: docker exec shoal-ollama ollama pull {{ item }}
+  loop: "{{ shoal_ollama_models_to_pull }}"
+  loop_control:
+    label: "{{ item }}"
   register: model_pull
-  changed_when: "'already exists' not in model_pull.stdout"
-  failed_when: false
+  # Pulls are slow and may be no-ops if the model is already present; always report changed=false
+  # would hide real work — mark changed on success so operators see which models were processed.
+  changed_when: model_pull.rc == 0
+  failed_when: model_pull.rc != 0
   tags: [ollama]
 
 - name: Display Compose stack status
   debug:
     msg: |
       Docker Compose stack is running.
-      
+
       Services:
       - NetBox: {{ shoal_netbox_url }}
       - PostgreSQL: localhost:5432 (netbox)
       - Redis: localhost:6379
       - Ollama: {{ shoal_ollama_url }}
+        models: {{ shoal_ollama_models_to_pull | join(', ') }}
       - HTTP Server: http://{{ ansible_host }}:{{ shoal_iso_server_port }}
       - Telemetry DB: localhost:5433 (shoal_telemetry)
   tags: [status]

--- a/infra/ansible/roles/compose_stack/templates/env.j2
+++ b/infra/ansible/roles/compose_stack/templates/env.j2
@@ -3,11 +3,13 @@ SHOAL_NETBOX_POSTGRES_PASSWORD={{ shoal_netbox_postgres_password }}
 SHOAL_REDIS_PASSWORD={{ shoal_redis_password }}
 SHOAL_ISO_SERVER_PORT={{ shoal_iso_server_port }}
 SHOAL_ISO_SERVER_DIR={{ shoal_iso_server_dir }}
-# AI provider (see design doc §6). Provider is "ollama" (local, in the lab VM)
-# or "cloud". SHOAL_OLLAMA_URL is the base URL for the local Ollama container;
-# the cloud vars are only used when SHOAL_AI_PROVIDER=cloud.
+# AI provider (see design doc §6 / v2.0.4). Provider is "ollama" (local, in the
+# lab VM) or "cloud". SHOAL_OLLAMA_URL is the base URL for the local Ollama
+# container; cloud vars are only used when SHOAL_AI_PROVIDER=cloud.
+# SHOAL_AI_MODEL = text/default; SHOAL_AI_VISION_MODEL = CompleteVision (optional).
 SHOAL_AI_PROVIDER={{ shoal_ai_provider }}
 SHOAL_AI_MODEL={{ shoal_ai_model }}
+SHOAL_AI_VISION_MODEL={{ shoal_ai_vision_model | default('') }}
 SHOAL_OLLAMA_URL={{ shoal_ollama_url | default('') }}
 SHOAL_CLOUD_AI_BASE_URL={{ shoal_cloud_ai_base_url | default('') }}
 SHOAL_CLOUD_AI_API_KEY={{ shoal_cloud_ai_api_key | default('') }}


### PR DESCRIPTION
## Summary
Implements the **v2.0.4 dual-model AI contract** in the lab stack (follow-up to #4).

- `shoal_ai_vision_model: moondream` (default; set `""` to skip)
- `env.j2` exports `SHOAL_AI_VISION_MODEL`
- `compose_stack` pulls text + non-empty vision models sequentially
- `smoke.yml` asserts `/api/tags` includes configured model names
- Runbook documents dual models and re-pull commands

## Test plan
- [x] `lab_up.yml --tags config,ollama` on live VM lab → env updated; pulls `llama3.2:3b` + `moondream`
- [x] `curl …:11434/api/tags` → both models present
- [x] Smoke: **Ollama text/vision model asserts pass**
- [ ] Full `down.yml` → `up.yml` → `smoke.yml` (optional full lifecycle; serial console smoke can fail when nested nodes are powered off from Phase 2 testing — unrelated to this PR)

## Out of scope
Phase 3 hybrid Discover / Go AI client (next PR after merge).