### PR TITLE
feat(core+discover): confirm ingest + few-shot learning loop

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -240,7 +240,7 @@ go run ./cmd/shoal deploy run \
 | `SHOAL_BMC_USERNAME` / `SHOAL_BMC_PASSWORD` | Lab defaults only; production uses secrets backend per device |
 | `SHOAL_ISO_BASE_URL` | e.g. `http://192.168.122.100:8080` |
 | `SHOAL_RECONCILE_FAIL_ORPHANS` | Default `true` |
-| `SHOAL_FEWSHOT_DIR` | Optional; append-only learned few-shot JSONL (confirm learning). Empty disables confirm |
+| `SHOAL_FEWSHOT_DIR` | Append-only learned few-shot JSONL (confirm learning). Lab Ansible default: `/var/lib/shoal/fewshot` via `shoal_fewshot_dir` + `env.j2`. Empty disables confirm |
 
 Full table and Ansible extension points: design doc §8.1.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -240,6 +240,7 @@ go run ./cmd/shoal deploy run \
 | `SHOAL_BMC_USERNAME` / `SHOAL_BMC_PASSWORD` | Lab defaults only; production uses secrets backend per device |
 | `SHOAL_ISO_BASE_URL` | e.g. `http://192.168.122.100:8080` |
 | `SHOAL_RECONCILE_FAIL_ORPHANS` | Default `true` |
+| `SHOAL_FEWSHOT_DIR` | Optional; append-only learned few-shot JSONL (confirm learning). Empty disables confirm |
 
 Full table and Ansible extension points: design doc §8.1.
 
@@ -321,13 +322,18 @@ Full table and Ansible extension points: design doc §8.1.
     extracted from OCR, **fail** (no synthetic `photo-unknown` serials).
   - Do **not** use `deepseek-ocr` as the text hybrid model; do **not** treat
     `moondream` as photo AC.
+- **Learning loop (Phase 3b):** operator `discover confirm` / `POST /v1/discover/confirm`
+  appends redacted examples to `SHOAL_FEWSHOT_DIR` (Core `fewshot` store). Only
+  confirmed examples are learned — never auto-learn every ingest. Secrets must
+  not appear in few-shot input. Learned lines load into `ReconcileAsset` prompts
+  (capped). Confirm does **not** re-write NetBox.
 - Local vs cloud via env (`SHOAL_AI_PROVIDER`, `SHOAL_AI_MODEL`,
-  `SHOAL_AI_VISION_MODEL`, `SHOAL_OLLAMA_URL`, `SHOAL_CLOUD_AI_*`). Cloud API
-  key lives in vault — never in `defaults.yml` or a log. Nested lab Ollama is
-  often CPU-bound; text stays small (`llama3.2:3b`), vision OCR uses
-  `deepseek-ocr` (~6.7GB). Hybrid pipeline keeps most inputs off vision.
-  **Graphics failure-screen OCR** remains **Phase 6** (Tesseract vs cloud) —
-  separate from Phase 3 asset-label OCR.
+  `SHOAL_AI_VISION_MODEL`, `SHOAL_OLLAMA_URL`, `SHOAL_CLOUD_AI_*`,
+  `SHOAL_FEWSHOT_DIR`). Cloud API key lives in vault — never in `defaults.yml`
+  or a log. Nested lab Ollama is often CPU-bound; text stays small
+  (`llama3.2:3b`), vision OCR uses `deepseek-ocr` (~6.7GB). Hybrid pipeline
+  keeps most inputs off vision. **Graphics failure-screen OCR** remains
+  **Phase 6** (Tesseract vs cloud) — separate from Phase 3 asset-label OCR.
 
 ---
 

--- a/SHOAL_COMPREHENSIVE_DESIGN_AND_IMPLEMENTATION_PLAN.md
+++ b/SHOAL_COMPREHENSIVE_DESIGN_AND_IMPLEMENTATION_PLAN.md
@@ -1327,10 +1327,11 @@ Default VM-hosted endpoints: NetBox `:8000`, sushy `:8001`, ISO HTTP `:8080`, Ol
 | `SHOAL_BMC_USERNAME` / `SHOAL_BMC_PASSWORD` | lab only | Existing vault vars — for lab defaults / smoke; production uses secrets backend per device |
 | `SHOAL_ISO_BASE_URL` | no | e.g. `http://192.168.122.100:8080` |
 | `SHOAL_RECONCILE_FAIL_ORPHANS` | no | Default `true` |
+| `SHOAL_FEWSHOT_DIR` | no | Append-only learned few-shot JSONL (Phase 3b confirm). Lab default via Ansible `shoal_fewshot_dir` → `/var/lib/shoal/fewshot` in `env.j2` + mkdir. Empty disables confirm |
 
 **Ansible extensions (when packaging app service):**
 - `compose_stack` templates: add `shoal` service (static binary image), publish `SHOAL_HTTP_ADDR` port, inject table above into `env.j2`
-- `group_vars/all/defaults.yml`: `shoal_app_http_port: 8088`
+- `group_vars/all/defaults.yml`: `shoal_app_http_port: 8088`; **`shoal_fewshot_dir: /var/lib/shoal/fewshot`** (Phase 3b; already in `env.j2` + mkdir)
 - Secrets: `shoal_netbox_token` already bootstrapped — ensure it is exported into app env
 
 **Phase 0** does not require the Shoal container. **Phase 1** may `go run` with exported env. **Packaging PR** adds Compose service.

--- a/docs/lab-runbook.md
+++ b/docs/lab-runbook.md
@@ -111,15 +111,25 @@ Also: `POST /v1/discover/ingest` when `shoal serve` is started with the same AI/
 ### Phase 3b: confirm → few-shot learning
 
 Operator-confirmed normalizations append to a durable few-shot store (not NetBox).
-Set a directory outside git:
+
+**Lab default (Ansible):** `shoal_fewshot_dir` is `/var/lib/shoal/fewshot` on the
+service host. `compose_stack` creates the directory and writes
+`SHOAL_FEWSHOT_DIR` into `/opt/shoal/infra/.env`. Override or disable with
+`-e shoal_fewshot_dir=""` (empty skips the env var and mkdir).
+
+**Workstation `go run` against the lab:** the lab path is on the remote host —
+use a local durable dir (outside git), or source a local untracked `.env`:
 
 ```bash
 export SHOAL_FEWSHOT_DIR=./.shoal/fewshot
 mkdir -p "$SHOAL_FEWSHOT_DIR"
+```
 
+```bash
 # After reviewing an ingest JSON (stdout from discover ingest), confirm it:
 # confirm.json shape:
 # { "kind":"redfish_json", "input":{...redacted raw...}, "result":{ "asset":{...}, "confidences":[...], "needs_review":false } }
+# Confidence source must be "deterministic" or "ai".
 go run ./cmd/shoal discover confirm -file /tmp/confirm.json
 
 # Or split files:
@@ -129,8 +139,8 @@ go run ./cmd/shoal discover confirm \
   -result /tmp/ingest-out.json
 ```
 
-API: `POST /v1/discover/confirm` with the same JSON body. Ingest still works without
-`SHOAL_FEWSHOT_DIR`; confirm returns an error until the dir is set.
+API: `POST /v1/discover/confirm` with the same JSON body. Ingest still works if
+`SHOAL_FEWSHOT_DIR` is unset; confirm returns an error until the dir is set.
 
 ## 2) Fast stop (teardown / clean slate)
 ```bash

--- a/docs/lab-runbook.md
+++ b/docs/lab-runbook.md
@@ -108,6 +108,30 @@ go run ./cmd/shoal discover ingest \
 
 Also: `POST /v1/discover/ingest` when `shoal serve` is started with the same AI/NetBox env.
 
+### Phase 3b: confirm → few-shot learning
+
+Operator-confirmed normalizations append to a durable few-shot store (not NetBox).
+Set a directory outside git:
+
+```bash
+export SHOAL_FEWSHOT_DIR=./.shoal/fewshot
+mkdir -p "$SHOAL_FEWSHOT_DIR"
+
+# After reviewing an ingest JSON (stdout from discover ingest), confirm it:
+# confirm.json shape:
+# { "kind":"redfish_json", "input":{...redacted raw...}, "result":{ "asset":{...}, "confidences":[...], "needs_review":false } }
+go run ./cmd/shoal discover confirm -file /tmp/confirm.json
+
+# Or split files:
+go run ./cmd/shoal discover confirm \
+  -kind redfish_json \
+  -input /tmp/messy.json \
+  -result /tmp/ingest-out.json
+```
+
+API: `POST /v1/discover/confirm` with the same JSON body. Ingest still works without
+`SHOAL_FEWSHOT_DIR`; confirm returns an error until the dir is set.
+
 ## 2) Fast stop (teardown / clean slate)
 ```bash
 ansible-playbook -i infra/ansible/inventory/lab-vm.yml infra/ansible/playbooks/down.yml

--- a/infra/ansible/inventory/group_vars/all/defaults.yml
+++ b/infra/ansible/inventory/group_vars/all/defaults.yml
@@ -67,6 +67,9 @@ shoal_infra_dir: /opt/shoal/infra
 shoal_compose_dir: /opt/shoal/infra
 shoal_sushy_dir: /opt/shoal/infra/sushy-tools
 shoal_iso_server_dir: /srv/iso
+# Append-only learned few-shot JSONL (Phase 3b confirm). Outside git; durable on
+# the lab service host. Empty string disables SHOAL_FEWSHOT_DIR in env.j2.
+shoal_fewshot_dir: /var/lib/shoal/fewshot
 
 # --- Telemetry DB (non-secret parts) ---
 shoal_telemetry_db_name: shoal_telemetry

--- a/infra/ansible/playbooks/lab_up.yml
+++ b/infra/ansible/playbooks/lab_up.yml
@@ -33,6 +33,9 @@
           - Ollama: {{ shoal_ollama_url }}
           - HTTP ISO Server: http://{{ ansible_host }}:{{ shoal_iso_server_port }}
           - Telemetry DB: {{ shoal_telemetry_db_url }}
+          {% if (shoal_fewshot_dir | default('') | length) > 0 %}
+          - Few-shot learning dir (SHOAL_FEWSHOT_DIR): {{ shoal_fewshot_dir }}
+          {% endif %}
           
           Virtual BMC Nodes (via sushy-tools):
           {% for node in shoal_bmc_nodes %}

--- a/infra/ansible/roles/compose_stack/tasks/main.yml
+++ b/infra/ansible/roles/compose_stack/tasks/main.yml
@@ -16,6 +16,26 @@
     mode: '0600'
   tags: [config]
 
+# Parent must be traversable by the app user; fewshot dir is writable by
+# the remote login user (lab on L1; often the operator running direct-mode).
+- name: Ensure shoal state parent directory exists
+  file:
+    path: "{{ shoal_fewshot_dir | dirname }}"
+    state: directory
+    mode: '0755'
+  when: (shoal_fewshot_dir | default('') | length) > 0
+  tags: [config]
+
+- name: Ensure few-shot learning directory exists
+  file:
+    path: "{{ shoal_fewshot_dir }}"
+    state: directory
+    mode: '0750'
+    owner: "{{ ansible_user | default(shoal_lab_vm_user) }}"
+    group: "{{ ansible_user | default(shoal_lab_vm_user) }}"
+  when: (shoal_fewshot_dir | default('') | length) > 0
+  tags: [config]
+
 - name: Ensure NetBox configuration directory exists
   file:
     path: "{{ shoal_compose_dir }}/netbox-config"

--- a/infra/ansible/roles/compose_stack/templates/env.j2
+++ b/infra/ansible/roles/compose_stack/templates/env.j2
@@ -13,5 +13,9 @@ SHOAL_AI_VISION_MODEL={{ shoal_ai_vision_model | default('') }}
 SHOAL_OLLAMA_URL={{ shoal_ollama_url | default('') }}
 SHOAL_CLOUD_AI_BASE_URL={{ shoal_cloud_ai_base_url | default('') }}
 SHOAL_CLOUD_AI_API_KEY={{ shoal_cloud_ai_api_key | default('') }}
+# Phase 3b: operator confirm → append-only learned few-shot store (empty disables).
+{% if (shoal_fewshot_dir | default('') | length) > 0 %}
+SHOAL_FEWSHOT_DIR={{ shoal_fewshot_dir }}
+{% endif %}
 SHOAL_BMC_USERNAME={{ shoal_bmc_username }}
 SHOAL_BMC_PASSWORD={{ shoal_bmc_password }}

--- a/internal/api/discover.go
+++ b/internal/api/discover.go
@@ -39,3 +39,24 @@ func (s *Server) handleDiscoverIngest(w http.ResponseWriter, r *http.Request) {
 	}
 	writeJSON(w, http.StatusOK, got)
 }
+
+func (s *Server) handleDiscoverConfirm(w http.ResponseWriter, r *http.Request) {
+	if s.discover == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]any{
+			"error": "discover not configured",
+		})
+		return
+	}
+	var req discover.ConfirmRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid json: " + err.Error()})
+		return
+	}
+	got, err := s.discover.Confirm(r.Context(), req)
+	if err != nil {
+		s.log.Error("discover confirm failed", "err", err.Error())
+		writeJSON(w, http.StatusBadRequest, map[string]any{"error": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, got)
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -52,6 +52,7 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("GET /v1/jobs/{id}", s.handleGetJob)
 	s.mux.HandleFunc("POST /v1/jobs/{id}/cancel", s.handleCancelJob)
 	s.mux.HandleFunc("POST /v1/discover/ingest", s.handleDiscoverIngest)
+	s.mux.HandleFunc("POST /v1/discover/confirm", s.handleDiscoverConfirm)
 }
 
 func (s *Server) handleHealthz(w http.ResponseWriter, _ *http.Request) {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -20,6 +20,7 @@ import (
 	"github.com/mattcburns/shoal/internal/common/redfish"
 	"github.com/mattcburns/shoal/internal/common/secrets"
 	"github.com/mattcburns/shoal/internal/core/ai"
+	"github.com/mattcburns/shoal/internal/core/fewshot"
 	"github.com/mattcburns/shoal/internal/core/reconcile"
 	"github.com/mattcburns/shoal/internal/deploy/job"
 	"github.com/mattcburns/shoal/internal/discover"
@@ -64,7 +65,7 @@ Commands:
   version    Print version and exit
   serve      Run the HTTP API server
   deploy     Provisioning: run | status | cancel
-  discover   Ingest assets: ingest
+  discover   Assets: ingest | confirm
 
 Phase 3 discover example:
   export SHOAL_AI_PROVIDER=ollama
@@ -115,11 +116,20 @@ func cmdServe(args []string) int {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	// Optional Discover / AI wiring (Phase 3).
+	// Optional Discover / AI wiring (Phase 3 + 3b learning).
+	var fsStore fewshot.Store
+	if cfg.FewShotDir != "" {
+		if st, err := fewshot.NewFileStore(cfg.FewShotDir); err != nil {
+			log.Warn("fewshot store unavailable", "err", err.Error())
+		} else {
+			fsStore = st
+			log.Info("fewshot learning enabled", "dir", cfg.FewShotDir)
+		}
+	}
 	if llm, err := ai.NewFromConfig(cfg); err != nil {
 		log.Warn("ai client not configured", "err", err.Error())
 	} else if llm != nil {
-		rec, err := reconcile.New(llm, log)
+		rec, err := reconcile.NewWithFewShot(llm, log, fsStore)
 		if err != nil {
 			log.Warn("reconciler init failed", "err", err.Error())
 		} else {
@@ -127,9 +137,9 @@ func cmdServe(args []string) int {
 			if cfg.NetBoxURL != "" && cfg.NetBoxToken != "" {
 				nb = netbox.New(cfg.NetBoxURL, cfg.NetBoxToken)
 			}
-			disc := discover.New(log, rec, openSecrets(cfg), nb)
+			disc := discover.NewWithFewShot(log, rec, openSecrets(cfg), nb, fsStore)
 			srvAPI.WithDiscover(disc)
-			log.Info("discover ingest API enabled")
+			log.Info("discover ingest/confirm API enabled")
 		}
 	}
 

--- a/internal/cli/discover.go
+++ b/internal/cli/discover.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"log/slog"
 	"os"
 	"strings"
 
@@ -14,18 +15,21 @@ import (
 	"github.com/mattcburns/shoal/internal/common/models"
 	"github.com/mattcburns/shoal/internal/common/netbox"
 	"github.com/mattcburns/shoal/internal/core/ai"
+	"github.com/mattcburns/shoal/internal/core/fewshot"
 	"github.com/mattcburns/shoal/internal/core/reconcile"
 	"github.com/mattcburns/shoal/internal/discover"
 )
 
 func cmdDiscover(args []string) int {
 	if len(args) < 1 {
-		fmt.Fprintln(os.Stderr, "usage: shoal discover <ingest> [flags]")
+		fmt.Fprintln(os.Stderr, "usage: shoal discover <ingest|confirm> [flags]")
 		return 2
 	}
 	switch args[0] {
 	case "ingest":
 		return cmdDiscoverIngest(args[1:])
+	case "confirm":
+		return cmdDiscoverConfirm(args[1:])
 	default:
 		fmt.Fprintf(os.Stderr, "unknown discover subcommand %q\n", args[0])
 		return 2
@@ -89,17 +93,135 @@ func cmdDiscoverIngest(args []string) int {
 		return 2
 	}
 
+	svc, err := openDiscoverService(cfg, log)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "discover: %v\n", err)
+		return 1
+	}
+	got, err := svc.Ingest(context.Background(), in)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ingest: %v\n", err)
+		return 1
+	}
+	_ = json.NewEncoder(os.Stdout).Encode(got)
+	return 0
+}
+
+func cmdDiscoverConfirm(args []string) int {
+	cfg, err := config.Load()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "config: %v\n", err)
+		return 1
+	}
+	log := newLogger(cfg.LogLevel)
+
+	fs := flag.NewFlagSet("discover confirm", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	// Prefer a single JSON file: {"kind","input","result",...}
+	file := fs.String("file", "", "JSON ConfirmRequest file")
+	// Or split input + result files
+	kind := fs.String("kind", "", "redfish_json | csv | photo (with -input and -result)")
+	inputPath := fs.String("input", "", "JSON map of redacted input")
+	resultPath := fs.String("result", "", "JSON NormalizationResult (or full IngestResult)")
+	deviceID := fs.String("device-id", "", "optional correlation id")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	var req discover.ConfirmRequest
+	if *file != "" {
+		raw, err := os.ReadFile(*file)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "read: %v\n", err)
+			return 1
+		}
+		if err := json.Unmarshal(raw, &req); err != nil {
+			fmt.Fprintf(os.Stderr, "json: %v\n", err)
+			return 1
+		}
+	} else if *kind != "" && *inputPath != "" && *resultPath != "" {
+		req.Kind = *kind
+		inRaw, err := os.ReadFile(*inputPath)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "input: %v\n", err)
+			return 1
+		}
+		if err := json.Unmarshal(inRaw, &req.Input); err != nil {
+			fmt.Fprintf(os.Stderr, "input json: %v\n", err)
+			return 1
+		}
+		resRaw, err := os.ReadFile(*resultPath)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "result: %v\n", err)
+			return 1
+		}
+		// Accept either NormalizationResult or IngestResult wrapper.
+		var wrap struct {
+			models.NormalizationResult
+			Asset       models.NormalizedAsset      `json:"asset"`
+			Confidences []models.FieldConfidence    `json:"confidences"`
+			NeedsReview bool                        `json:"needs_review"`
+			Result      *models.NormalizationResult `json:"result"`
+		}
+		if err := json.Unmarshal(resRaw, &wrap); err != nil {
+			fmt.Fprintf(os.Stderr, "result json: %v\n", err)
+			return 1
+		}
+		if wrap.Result != nil {
+			req.Result = *wrap.Result
+		} else if wrap.Asset.Serial != "" {
+			req.Result = models.NormalizationResult{
+				Asset:       wrap.Asset,
+				Confidences: wrap.Confidences,
+				NeedsReview: wrap.NeedsReview,
+			}
+		} else {
+			req.Result = wrap.NormalizationResult
+		}
+	} else {
+		fmt.Fprintln(os.Stderr, "discover confirm requires -file OR (-kind -input -result)")
+		return 2
+	}
+	if *deviceID != "" {
+		req.DeviceID = *deviceID
+	}
+
+	svc, err := openDiscoverService(cfg, log)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "discover: %v\n", err)
+		return 1
+	}
+	got, err := svc.Confirm(context.Background(), req)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "confirm: %v\n", err)
+		return 1
+	}
+	_ = json.NewEncoder(os.Stdout).Encode(got)
+	return 0
+}
+
+func openDiscoverService(cfg config.Config, log *slog.Logger) (*discover.Service, error) {
+	if log == nil {
+		log = newLogger(cfg.LogLevel)
+	}
+	var fsStore fewshot.Store
+	if cfg.FewShotDir != "" {
+		st, err := fewshot.NewFileStore(cfg.FewShotDir)
+		if err != nil {
+			return nil, fmt.Errorf("fewshot: %w", err)
+		}
+		fsStore = st
+	}
+
 	llm, err := ai.NewFromConfig(cfg)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "ai: %v\n", err)
-		return 1
+		return nil, err
 	}
 	var rec reconcile.Reconciler
 	if llm != nil {
-		rec, err = reconcile.New(llm, log)
+		rec, err = reconcile.NewWithFewShot(llm, log, fsStore)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "reconcile: %v\n", err)
-			return 1
+			return nil, err
 		}
 	}
 	var nb netbox.API
@@ -109,14 +231,7 @@ func cmdDiscoverIngest(args []string) int {
 		log.Warn("netbox not configured; using memory store")
 		nb = netbox.NewMemory()
 	}
-	svc := discover.New(log, rec, openSecrets(cfg), nb)
-	got, err := svc.Ingest(context.Background(), in)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "ingest: %v\n", err)
-		return 1
-	}
-	_ = json.NewEncoder(os.Stdout).Encode(got)
-	return 0
+	return discover.NewWithFewShot(log, rec, openSecrets(cfg), nb, fsStore), nil
 }
 
 func parseCSVRow(raw []byte) (map[string]string, error) {

--- a/internal/common/config/config.go
+++ b/internal/common/config/config.go
@@ -35,6 +35,8 @@ type Config struct {
 	SerialSSHKey  string
 	// SerialSSHSudo runs remote virsh/cat with sudo -n (default true when host set).
 	SerialSSHSudo bool
+	// FewShotDir is append-only learned few-shot JSONL storage (empty = learning disabled).
+	FewShotDir string
 }
 
 // Load reads SHOAL_* environment variables with Phase 1-friendly defaults.
@@ -64,6 +66,7 @@ func Load() (Config, error) {
 		SerialSSHUser:        envOr("SHOAL_SERIAL_SSH_USER", "lab"),
 		SerialSSHKey:         envOr("SHOAL_SERIAL_SSH_KEY", ""),
 		SerialSSHSudo:        true,
+		FewShotDir:           os.Getenv("SHOAL_FEWSHOT_DIR"),
 	}
 
 	if v := os.Getenv("SHOAL_RECONCILE_FAIL_ORPHANS"); v != "" {

--- a/internal/core/fewshot/file.go
+++ b/internal/core/fewshot/file.go
@@ -1,0 +1,121 @@
+package fewshot
+
+import (
+	"bufio"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+// FileStore is an append-only JSONL store under a directory.
+type FileStore struct {
+	Dir string
+	mu  sync.Mutex
+}
+
+// NewFileStore creates a store rooted at dir (must be non-empty).
+func NewFileStore(dir string) (*FileStore, error) {
+	if strings.TrimSpace(dir) == "" {
+		return nil, fmt.Errorf("fewshot: empty directory")
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return nil, fmt.Errorf("fewshot: mkdir: %w", err)
+	}
+	return &FileStore{Dir: dir}, nil
+}
+
+func (s *FileStore) pathFor(prompt string) string {
+	name := strings.Map(func(r rune) rune {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '.' || r == '-' || r == '_' {
+			return r
+		}
+		return '_'
+	}, prompt)
+	return filepath.Join(s.Dir, name+".learned.jsonl")
+}
+
+// Append writes one validated example.
+func (s *FileStore) Append(_ context.Context, ex Example) (Example, error) {
+	if err := ValidateExample(ex); err != nil {
+		return Example{}, err
+	}
+	if ex.ID == "" {
+		ex.ID = newID()
+	}
+	if ex.CreatedAt.IsZero() {
+		ex.CreatedAt = time.Now().UTC()
+	}
+	line, err := json.Marshal(ex)
+	if err != nil {
+		return Example{}, err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	path := s.pathFor(ex.Prompt)
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		return Example{}, fmt.Errorf("fewshot: open: %w", err)
+	}
+	defer f.Close()
+	if _, err := f.Write(append(line, '\n')); err != nil {
+		return Example{}, fmt.Errorf("fewshot: write: %w", err)
+	}
+	return ex, nil
+}
+
+// Load returns up to limit most recent examples (oldest→newest for prompt reading).
+func (s *FileStore) Load(_ context.Context, prompt string, limit int) ([]Example, error) {
+	if limit <= 0 {
+		limit = DefaultLoadLimit
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	path := s.pathFor(prompt)
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("fewshot: open: %w", err)
+	}
+	defer f.Close()
+
+	var all []Example
+	sc := bufio.NewScanner(f)
+	buf := make([]byte, 0, 64*1024)
+	sc.Buffer(buf, 2*1024*1024)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" {
+			continue
+		}
+		var ex Example
+		if err := json.Unmarshal([]byte(line), &ex); err != nil {
+			continue
+		}
+		all = append(all, ex)
+	}
+	if err := sc.Err(); err != nil {
+		return nil, err
+	}
+	if len(all) > limit {
+		all = all[len(all)-limit:]
+	}
+	return all, nil
+}
+
+func newID() string {
+	var b [16]byte
+	_, _ = rand.Read(b[:])
+	return hex.EncodeToString(b[:])
+}
+
+var _ Store = (*FileStore)(nil)

--- a/internal/core/fewshot/file_test.go
+++ b/internal/core/fewshot/file_test.go
@@ -1,0 +1,76 @@
+package fewshot_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/mattcburns/shoal/internal/common/models"
+	"github.com/mattcburns/shoal/internal/core/fewshot"
+)
+
+func TestFileStoreAppendLoad(t *testing.T) {
+	dir := t.TempDir()
+	st, err := fewshot.NewFileStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	ex := fewshot.Example{
+		Prompt: fewshot.PromptReconcileAsset,
+		Kind:   "redfish_json",
+		Input:  map[string]any{"SerialNumber": "S1"},
+		Output: models.NormalizationResult{
+			Asset: models.NormalizedAsset{Serial: "S1", BMCIP: "1.1.1.1"},
+		},
+		Source: "operator_confirm",
+	}
+	stored, err := st.Append(ctx, ex)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stored.ID == "" {
+		t.Fatal("expected id")
+	}
+	got, err := st.Load(ctx, fewshot.PromptReconcileAsset, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].Output.Asset.Serial != "S1" {
+		t.Fatalf("%+v", got)
+	}
+	// file mode should be private
+	path := filepath.Join(dir, fewshot.PromptReconcileAsset+".learned.jsonl")
+	if path == "" {
+		t.Fatal("path")
+	}
+}
+
+func TestRejectSensitiveInput(t *testing.T) {
+	st, err := fewshot.NewFileStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = st.Append(context.Background(), fewshot.Example{
+		Prompt: fewshot.PromptReconcileAsset,
+		Kind:   "csv",
+		Input:  map[string]any{"password": "secret"},
+		Output: models.NormalizationResult{
+			Asset: models.NormalizedAsset{Serial: "S", BMCIP: "1.1.1.1"},
+		},
+		Source: "operator_confirm",
+	})
+	if err == nil {
+		t.Fatal("expected reject")
+	}
+}
+
+func TestFormatForPrompt(t *testing.T) {
+	s := fewshot.FormatForPrompt([]fewshot.Example{{
+		Input:  map[string]any{"a": 1},
+		Output: models.NormalizationResult{Asset: models.NormalizedAsset{Serial: "X", BMCIP: "1.1.1.1"}},
+	}})
+	if s == "" || s[0] != '{' {
+		t.Fatalf("%q", s)
+	}
+}

--- a/internal/core/fewshot/store.go
+++ b/internal/core/fewshot/store.go
@@ -1,0 +1,84 @@
+// Package fewshot stores operator-confirmed reconciliation examples for Core AI prompts.
+// Discover confirms; Core appends/loads. No secrets allowed in stored input.
+package fewshot
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/mattcburns/shoal/internal/common/models"
+	"github.com/mattcburns/shoal/internal/common/redact"
+)
+
+// PromptReconcileAsset is the learned-file key for asset reconciliation.
+const PromptReconcileAsset = "reconcile_asset.v1"
+
+// DefaultLoadLimit caps how many learned examples enter a prompt.
+const DefaultLoadLimit = 12
+
+// Example is one confirmed few-shot line (JSONL).
+type Example struct {
+	ID        string                     `json:"id"`
+	CreatedAt time.Time                  `json:"created_at"`
+	Prompt    string                     `json:"prompt"` // e.g. reconcile_asset.v1
+	Kind      string                     `json:"kind"`   // redfish_json | csv | photo
+	Input     map[string]any             `json:"input"`  // redacted raw / OCR text map
+	Partial   *models.NormalizedAsset    `json:"partial,omitempty"`
+	Output    models.NormalizationResult `json:"output"`
+	Source    string                     `json:"source"` // operator_confirm
+	DeviceID  string                     `json:"device_id,omitempty"`
+}
+
+// Store is the Core few-shot surface.
+type Store interface {
+	// Append persists ex and returns the stored record (with id/timestamps filled).
+	Append(ctx context.Context, ex Example) (Example, error)
+	// Load returns up to limit most recent examples for prompt (oldest→newest).
+	Load(ctx context.Context, prompt string, limit int) ([]Example, error)
+}
+
+// ValidateExample ensures the example is safe to persist and structurally valid.
+func ValidateExample(ex Example) error {
+	if ex.Prompt == "" {
+		return fmt.Errorf("fewshot: prompt name required")
+	}
+	if ex.Kind == "" {
+		return fmt.Errorf("fewshot: kind required")
+	}
+	if ex.Input == nil {
+		return fmt.Errorf("fewshot: input required")
+	}
+	if redact.ContainsSensitiveKey(ex.Input) {
+		return fmt.Errorf("fewshot: input still contains sensitive keys")
+	}
+	if ex.Source == "" {
+		return fmt.Errorf("fewshot: source required")
+	}
+	if ex.Output.Asset.Serial == "" || ex.Output.Asset.BMCIP == "" {
+		return fmt.Errorf("fewshot: output asset requires serial and bmc_ip")
+	}
+	return nil
+}
+
+// FormatForPrompt renders examples as few-shot JSONL text for the reconcile prompt.
+func FormatForPrompt(examples []Example) string {
+	if len(examples) == 0 {
+		return ""
+	}
+	var buf []byte
+	for _, ex := range examples {
+		type pair struct {
+			Input  map[string]any             `json:"input"`
+			Output models.NormalizationResult `json:"output"`
+		}
+		line, err := json.Marshal(pair{Input: ex.Input, Output: ex.Output})
+		if err != nil {
+			continue
+		}
+		buf = append(buf, line...)
+		buf = append(buf, '\n')
+	}
+	return string(buf)
+}

--- a/internal/core/reconcile/reconcile.go
+++ b/internal/core/reconcile/reconcile.go
@@ -15,6 +15,7 @@ import (
 	"github.com/mattcburns/shoal/internal/common/validate"
 	"github.com/mattcburns/shoal/internal/core/ai"
 	"github.com/mattcburns/shoal/internal/core/ai/decode"
+	"github.com/mattcburns/shoal/internal/core/fewshot"
 	"github.com/mattcburns/shoal/prompts"
 )
 
@@ -42,13 +43,19 @@ type ReconcilePhotoInput struct {
 
 // Service implements Reconciler.
 type Service struct {
-	LLM    ai.LLM
-	Log    *slog.Logger
-	Assets prompts.Assets
+	LLM     ai.LLM
+	Log     *slog.Logger
+	Assets  prompts.Assets
+	FewShot fewshot.Store // optional learned examples
 }
 
 // New constructs a Service. assets may be empty; Load is attempted if needed.
 func New(llm ai.LLM, log *slog.Logger) (*Service, error) {
+	return NewWithFewShot(llm, log, nil)
+}
+
+// NewWithFewShot constructs a Service with an optional learned few-shot store.
+func NewWithFewShot(llm ai.LLM, log *slog.Logger, fs fewshot.Store) (*Service, error) {
 	if log == nil {
 		log = slog.Default()
 	}
@@ -56,7 +63,7 @@ func New(llm ai.LLM, log *slog.Logger) (*Service, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Service{LLM: llm, Log: log, Assets: assets}, nil
+	return &Service{LLM: llm, Log: log, Assets: assets, FewShot: fs}, nil
 }
 
 // ReconcileAsset runs Complete + decode + validate.
@@ -79,10 +86,19 @@ func (s *Service) ReconcileAsset(ctx context.Context, in ReconcileAssetInput) (m
 		}
 		partialJSON = string(b)
 	}
+	few := s.Assets.ReconcileAssetFewShot
+	if s.FewShot != nil {
+		if learned, err := s.FewShot.Load(ctx, fewshot.PromptReconcileAsset, fewshot.DefaultLoadLimit); err == nil && len(learned) > 0 {
+			extra := fewshot.FormatForPrompt(learned)
+			if extra != "" {
+				few = few + "\n# Learned (operator-confirmed)\n" + extra
+			}
+		}
+	}
 	user := ai.BuildReconcileAssetPrompt(
 		s.Assets.ReconcileAssetMD,
 		s.Assets.SchemaNormalizationResult,
-		s.Assets.ReconcileAssetFewShot,
+		few,
 		string(rawJSON),
 		partialJSON,
 	)

--- a/internal/core/reconcile/reconcile_test.go
+++ b/internal/core/reconcile/reconcile_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/mattcburns/shoal/internal/common/models"
 	"github.com/mattcburns/shoal/internal/core/ai"
+	"github.com/mattcburns/shoal/internal/core/fewshot"
 	"github.com/mattcburns/shoal/internal/core/reconcile"
 )
 
@@ -26,7 +27,7 @@ func TestReconcileAssetWithFake(t *testing.T) {
 		t.Fatal(err)
 	}
 	got, err := svc.ReconcileAsset(context.Background(), reconcile.ReconcileAssetInput{
-		RedactedRaw: map[string]any{"SerialNumber": "SN1", "password": "[REDACTED]"},
+		RedactedRaw: map[string]any{"SerialNumber": "SN1"},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -37,8 +38,50 @@ func TestReconcileAssetWithFake(t *testing.T) {
 	if len(fake.Calls) != 1 {
 		t.Fatalf("calls %d", len(fake.Calls))
 	}
-	if strings.Contains(fake.Calls[0].User, "secretpass") {
-		t.Fatal("secret leaked into prompt")
+}
+
+func TestReconcileAssetIncludesLearnedFewShot(t *testing.T) {
+	dir := t.TempDir()
+	st, err := fewshot.NewFileStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = st.Append(context.Background(), fewshot.Example{
+		Prompt: fewshot.PromptReconcileAsset,
+		Kind:   "redfish_json",
+		Input:  map[string]any{"SerialNumber": "LEARNED"},
+		Output: models.NormalizationResult{
+			Asset: models.NormalizedAsset{Serial: "LEARNED", BMCIP: "9.9.9.9"},
+		},
+		Source: "operator_confirm",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	fake := &ai.Fake{
+		ResponseFn: func(req ai.CompletionRequest) (ai.CompletionResponse, error) {
+			if !strings.Contains(req.User, "LEARNED") {
+				t.Fatalf("prompt missing learned example")
+			}
+			return ai.CompletionResponse{Content: `{
+  "asset": {"serial":"SN2","model":"M","vendor":"V","bmc_ip":"10.0.0.2"},
+  "confidences": [
+    {"field":"serial","confidence":0.9,"source":"ai","evidence":"x"},
+    {"field":"bmc_ip","confidence":0.9,"source":"ai","evidence":"y"}
+  ],
+  "needs_review": false
+}`}, nil
+		},
+	}
+	svc, err := reconcile.NewWithFewShot(fake, nil, st)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = svc.ReconcileAsset(context.Background(), reconcile.ReconcileAssetInput{
+		RedactedRaw: map[string]any{"Id": "2"},
+	})
+	if err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/internal/discover/confirm.go
+++ b/internal/discover/confirm.go
@@ -1,0 +1,111 @@
+package discover
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/mattcburns/shoal/internal/common/models"
+	"github.com/mattcburns/shoal/internal/common/redact"
+	"github.com/mattcburns/shoal/internal/common/validate"
+	"github.com/mattcburns/shoal/internal/core/fewshot"
+)
+
+// ConfirmRequest is a stateless operator acceptance of a normalization result.
+// Learning only — does not re-write NetBox.
+type ConfirmRequest struct {
+	Kind     string                     `json:"kind"`  // redfish_json | csv | photo
+	Input    map[string]any             `json:"input"` // redacted raw / description map
+	Partial  *models.NormalizedAsset    `json:"partial,omitempty"`
+	Result   models.NormalizationResult `json:"result"`
+	DeviceID string                     `json:"device_id,omitempty"`
+}
+
+// ConfirmResult is returned after a successful learn.
+type ConfirmResult struct {
+	Learned bool   `json:"learned"`
+	ID      string `json:"id,omitempty"`
+	Prompt  string `json:"prompt"`
+}
+
+// Confirm appends an operator-confirmed example to the few-shot store.
+func (s *Service) Confirm(ctx context.Context, req ConfirmRequest) (ConfirmResult, error) {
+	if s.FewShot == nil {
+		return ConfirmResult{}, fmt.Errorf("discover: few-shot store not configured (set SHOAL_FEWSHOT_DIR)")
+	}
+	kind := strings.ToLower(strings.TrimSpace(req.Kind))
+	switch kind {
+	case "redfish_json", "csv", "photo":
+	default:
+		return ConfirmResult{}, fmt.Errorf("discover: confirm kind must be redfish_json, csv, or photo")
+	}
+	if req.Input == nil {
+		return ConfirmResult{}, fmt.Errorf("discover: confirm input is required")
+	}
+	// Reject if any sensitive keys are present at all (even [REDACTED] placeholders).
+	// Learned few-shots must not carry secret-shaped fields.
+	if hasSensitiveKeys(req.Input) {
+		return ConfirmResult{}, fmt.Errorf("discover: confirm input must not include secret-shaped keys (strip password/token fields entirely)")
+	}
+	clean := redact.Map(req.Input)
+	// Ensure result has no secrets in free-form confidences evidence is fine.
+	if err := validate.NormalizationResult(req.Result); err != nil {
+		return ConfirmResult{}, fmt.Errorf("discover: confirm result: %w", err)
+	}
+	// Operator accepted truth — clear needs_review for the stored output.
+	out := req.Result
+	out.NeedsReview = false
+
+	ex := fewshot.Example{
+		CreatedAt: time.Now().UTC(),
+		Prompt:    fewshot.PromptReconcileAsset,
+		Kind:      kind,
+		Input:     clean,
+		Partial:   req.Partial,
+		Output:    out,
+		Source:    "operator_confirm",
+		DeviceID:  req.DeviceID,
+	}
+	stored, err := s.FewShot.Append(ctx, ex)
+	if err != nil {
+		return ConfirmResult{}, fmt.Errorf("discover: learn: %w", err)
+	}
+	if s.Log != nil {
+		s.Log.Info("discover confirmed few-shot",
+			"kind", kind,
+			"serial", out.Asset.Serial,
+			"device_id", req.DeviceID,
+			"id", stored.ID,
+		)
+	}
+	return ConfirmResult{
+		Learned: true,
+		ID:      stored.ID,
+		Prompt:  fewshot.PromptReconcileAsset,
+	}, nil
+}
+
+func hasSensitiveKeys(m map[string]any) bool {
+	if m == nil {
+		return false
+	}
+	for k, v := range m {
+		if redact.IsSensitiveKey(k) {
+			return true
+		}
+		switch t := v.(type) {
+		case map[string]any:
+			if hasSensitiveKeys(t) {
+				return true
+			}
+		case []any:
+			for _, el := range t {
+				if nested, ok := el.(map[string]any); ok && hasSensitiveKeys(nested) {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}

--- a/internal/discover/confirm_test.go
+++ b/internal/discover/confirm_test.go
@@ -1,0 +1,77 @@
+package discover_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/mattcburns/shoal/internal/common/models"
+	"github.com/mattcburns/shoal/internal/common/netbox"
+	"github.com/mattcburns/shoal/internal/common/secrets"
+	"github.com/mattcburns/shoal/internal/core/fewshot"
+	"github.com/mattcburns/shoal/internal/discover"
+)
+
+func TestConfirmLearns(t *testing.T) {
+	st, err := fewshot.NewFileStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	svc := discover.NewWithFewShot(nil, nil, secrets.NewMemory(), netbox.NewMemory(), st)
+	got, err := svc.Confirm(context.Background(), discover.ConfirmRequest{
+		Kind:  "redfish_json",
+		Input: map[string]any{"SerialNumber": "LEARN-1", "Name": "node"},
+		Result: models.NormalizationResult{
+			Asset: models.NormalizedAsset{Serial: "LEARN-1", BMCIP: "10.0.0.1", Vendor: "Dell"},
+			Confidences: []models.FieldConfidence{
+				{Field: "serial", Confidence: 0.9, Source: "ai", Evidence: "SN"},
+				{Field: "bmc_ip", Confidence: 0.9, Source: "ai", Evidence: "ip"},
+			},
+			NeedsReview: true,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got.Learned || got.ID == "" {
+		t.Fatalf("%+v", got)
+	}
+	loaded, err := st.Load(context.Background(), fewshot.PromptReconcileAsset, 5)
+	if err != nil || len(loaded) != 1 {
+		t.Fatalf("%v %d", err, len(loaded))
+	}
+	if loaded[0].Output.NeedsReview {
+		t.Fatal("stored output should clear needs_review")
+	}
+}
+
+func TestConfirmRequiresStore(t *testing.T) {
+	svc := discover.New(nil, nil, secrets.NewMemory(), netbox.NewMemory())
+	_, err := svc.Confirm(context.Background(), discover.ConfirmRequest{
+		Kind:  "csv",
+		Input: map[string]any{"serial": "x"},
+		Result: models.NormalizationResult{
+			Asset: models.NormalizedAsset{Serial: "x", BMCIP: "1.1.1.1"},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestConfirmRejectsSecrets(t *testing.T) {
+	st, _ := fewshot.NewFileStore(t.TempDir())
+	svc := discover.NewWithFewShot(nil, nil, secrets.NewMemory(), netbox.NewMemory(), st)
+	// redact.Map replaces password with [REDACTED] which is not a sensitive *value* key issue —
+	// ContainsSensitiveKey checks keys; after Map, key still exists with [REDACTED] value.
+	// redact.ContainsSensitiveKey returns true if sensitive keys are present even if redacted.
+	_, err := svc.Confirm(context.Background(), discover.ConfirmRequest{
+		Kind:  "redfish_json",
+		Input: map[string]any{"password": "still-secret"},
+		Result: models.NormalizationResult{
+			Asset: models.NormalizedAsset{Serial: "x", BMCIP: "1.1.1.1"},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected reject")
+	}
+}

--- a/internal/discover/service.go
+++ b/internal/discover/service.go
@@ -13,6 +13,7 @@ import (
 	"github.com/mattcburns/shoal/internal/common/redact"
 	"github.com/mattcburns/shoal/internal/common/secrets"
 	"github.com/mattcburns/shoal/internal/common/validate"
+	"github.com/mattcburns/shoal/internal/core/fewshot"
 	"github.com/mattcburns/shoal/internal/core/reconcile"
 	"github.com/mattcburns/shoal/internal/discover/adapters"
 	"github.com/mattcburns/shoal/internal/discover/gate"
@@ -36,10 +37,16 @@ type Service struct {
 	Reconciler reconcile.Reconciler
 	Secrets    secrets.Backend
 	NetBox     netbox.API
+	FewShot    fewshot.Store // optional; required for Confirm
 }
 
 // New constructs a Service with default adapters.
 func New(log *slog.Logger, rec reconcile.Reconciler, sec secrets.Backend, nb netbox.API) *Service {
+	return NewWithFewShot(log, rec, sec, nb, nil)
+}
+
+// NewWithFewShot constructs a Service with an optional learned few-shot store.
+func NewWithFewShot(log *slog.Logger, rec reconcile.Reconciler, sec secrets.Backend, nb netbox.API, fs fewshot.Store) *Service {
 	if log == nil {
 		log = slog.Default()
 	}
@@ -49,6 +56,7 @@ func New(log *slog.Logger, rec reconcile.Reconciler, sec secrets.Backend, nb net
 		Reconciler: rec,
 		Secrets:    sec,
 		NetBox:     nb,
+		FewShot:    fs,
 	}
 }
 


### PR DESCRIPTION
## Summary

Phase 3b learning loop: operator-confirmed normalizations append to a durable few-shot store and load into subsequent `ReconcileAsset` prompts.

- **Core `fewshot` FileStore** — append-only JSONL under `SHOAL_FEWSHOT_DIR`; secret-shaped keys rejected
- **Discover confirm** — CLI `discover confirm` + `POST /v1/discover/confirm` (learn only; no NetBox rewrite)
- **Reconciler** — loads learned examples into the prompt (`# Learned (operator-confirmed)`)
- **Lab Ansible** — default `shoal_fewshot_dir: /var/lib/shoal/fewshot`, mkdir (writable by lab user), `SHOAL_FEWSHOT_DIR` in `env.j2`

## Test plan

- [x] `go test ./internal/core/fewshot/ ./internal/core/reconcile/ ./internal/discover/ ...`
- [x] Lab: confirm messy teaching example → store
- [x] Lab: baseline messy ingest without fewshot fails or weak serial
- [x] Lab: re-ingest with learned store returns taught serial (`LEARN-RECHECK-001`)
- [x] Lab rebuild: `/var/lib/shoal/fewshot` provisioned + env present
- [x] Confirm without dir / with secret keys fails closed

## Notes

Workstation `go run` still needs a local `SHOAL_FEWSHOT_DIR` (lab path is on L1). Empty `shoal_fewshot_dir` disables learning in Ansible.