### PR TITLE
feat(common): telemetry Store + Redfish SEL/sensor reads

### DIFF
--- a/SHOAL_COMPREHENSIVE_DESIGN_AND_IMPLEMENTATION_PLAN.md
+++ b/SHOAL_COMPREHENSIVE_DESIGN_AND_IMPLEMENTATION_PLAN.md
@@ -1590,7 +1590,7 @@ go test ./...
 
 ## Open Questions
 
-**All previously open product decisions are resolved through v2.0.5.** Phase 0–2 are on `master`; Phase 3 follows the AI contract below.
+**All previously open product decisions are resolved through v2.0.5.** Phase 0–3 are on `master`; Phase 4 (Observe broaden) is next.
 
 | Topic | Resolution |
 |-------|------------|
@@ -1629,9 +1629,9 @@ go test ./...
 
 ---
 
-**This document (v2.0.5) is the SoT for agents.** Phase 0–2 and dual-model lab wiring are on `master`.
+**This document (v2.0.5) is the SoT for agents.** Phase 0–3 (incl. dual-model lab + hybrid Discover + few-shot learning) are on `master`.
 
 Next actions:
-1. Phase 3 hybrid Discover PR (honors §6: text `llama3.2:3b`, vision `deepseek-ocr` Free OCR)
-2. Later phases: Observe broaden, Deploy harden, packaging
+1. Phase 4 Observe broaden: telemetry Store, Redfish SEL/sensors, poll, device status CLI/API
+2. Later: Phase 5 Deploy harden, packaging
 3. At Phase 6: choose graphics failure-screen OCR approach before implementing

--- a/internal/common/models/models.go
+++ b/internal/common/models/models.go
@@ -30,6 +30,8 @@ type NormalizationResult struct {
 
 // NormalizedEvent is a telemetry/event record correlated to a device.
 type NormalizedEvent struct {
+	// ID is the durable events.id primary key. Empty on write → Store assigns one.
+	ID        string    `json:"id,omitempty"`
 	DeviceID  string    `json:"device_id"` // required for telemetry.events.device_id correlation
 	EventType string    `json:"event_type"`
 	Severity  string    `json:"severity"`
@@ -37,6 +39,7 @@ type NormalizedEvent struct {
 	Message   string    `json:"message"`
 	Timestamp time.Time `json:"timestamp"`
 	// Raw must be redacted before any LLM call; may be empty in API responses.
+	// Telemetry Store does not persist Raw by default (use raw_ref only if needed later).
 	Raw map[string]any `json:"raw,omitempty"`
 }
 

--- a/internal/common/redfish/bmc.go
+++ b/internal/common/redfish/bmc.go
@@ -22,6 +22,12 @@ type BMC interface {
 	Power(ctx context.Context, systemID, resetType string) error
 	// CleanupMediaAndBoot ejects all inserted media for the system and clears boot override.
 	CleanupMediaAndBoot(ctx context.Context, systemID string) error
+	// ListSEL returns log entries (SEL/event logs) for the system, managers, and chassis.
+	// Best-effort: missing LogServices yield an empty slice, not an error.
+	ListSEL(ctx context.Context, systemID string, opts SELOptions) ([]SELEntry, error)
+	// ListSensors returns thermal/power sensor samples for chassis related to systemID.
+	// Best-effort: missing Thermal/Power yield empty slice or partial results.
+	ListSensors(ctx context.Context, systemID string) ([]SensorSample, error)
 }
 
 // Factory constructs a BMC from config (composition root injects this).

--- a/internal/common/redfish/fake.go
+++ b/internal/common/redfish/fake.go
@@ -20,6 +20,13 @@ type Fake struct {
 
 	// FailNextCleanup forces CleanupMediaAndBoot to fail once.
 	FailNextCleanup bool
+
+	// SEL and Sensors are returned by ListSEL / ListSensors (Phase 4 Observe).
+	SEL     []SELEntry
+	Sensors []SensorSample
+	// ListSELErr / ListSensorsErr force errors when set.
+	ListSELErr     error
+	ListSensorsErr error
 }
 
 // NewFake returns a Fake with one system and one CD virtual media slot.
@@ -165,6 +172,40 @@ func (f *Fake) CleanupMediaAndBoot(ctx context.Context, systemID string) error {
 		}
 	}
 	return f.ClearBootOverride(ctx, systemID)
+}
+
+func (f *Fake) ListSEL(_ context.Context, _ string, opts SELOptions) ([]SELEntry, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.ListSELErr != nil {
+		return nil, f.ListSELErr
+	}
+	out := make([]SELEntry, 0, len(f.SEL))
+	for _, e := range f.SEL {
+		if !opts.Since.IsZero() && !e.Created.IsZero() && e.Created.Before(opts.Since) {
+			continue
+		}
+		out = append(out, e)
+	}
+	max := opts.MaxEntries
+	if max <= 0 {
+		max = 200
+	}
+	if len(out) > max {
+		out = out[:max]
+	}
+	return out, nil
+}
+
+func (f *Fake) ListSensors(_ context.Context, _ string) ([]SensorSample, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.ListSensorsErr != nil {
+		return nil, f.ListSensorsErr
+	}
+	out := make([]SensorSample, len(f.Sensors))
+	copy(out, f.Sensors)
+	return out, nil
 }
 
 // MediaInserted reports whether any media is inserted (test helper).

--- a/internal/common/redfish/lab_integration_test.go
+++ b/internal/common/redfish/lab_integration_test.go
@@ -112,6 +112,49 @@ func TestLabRedfishVirtualMediaBootCleanup(t *testing.T) {
 	t.Logf("boot after cleanup: %+v", boot)
 }
 
+// TestLabListSELAndSensors exercises Phase 4 Redfish reads. sushy-tools often
+// has empty logs/sensors — empty results are OK; hard errors are not.
+func TestLabListSELAndSensors(t *testing.T) {
+	base := envOr("SHOAL_BMC_URL", "http://192.168.122.100:8001")
+	user := os.Getenv("SHOAL_BMC_USERNAME")
+	pass := os.Getenv("SHOAL_BMC_PASSWORD")
+	if user == "" || pass == "" {
+		t.Skip("SHOAL_BMC_USERNAME/PASSWORD required")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	bmc, err := redfish.NewBMC(redfish.Config{
+		BaseURL: base, Username: user, Password: pass,
+		AuthMode: "basic", TLSMode: "off", MaxConcurrent: 1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := bmc.Open(ctx); err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = bmc.Close(context.Background()) }()
+
+	systems, err := bmc.ListSystems(ctx)
+	if err != nil || len(systems) == 0 {
+		t.Fatalf("systems: %v n=%d", err, len(systems))
+	}
+	sysID := systems[0].ID
+
+	sel, err := bmc.ListSEL(ctx, sysID, redfish.SELOptions{MaxEntries: 50})
+	if err != nil {
+		t.Fatalf("ListSEL: %v", err)
+	}
+	t.Logf("SEL entries: %d", len(sel))
+
+	sensors, err := bmc.ListSensors(ctx, sysID)
+	if err != nil {
+		t.Fatalf("ListSensors: %v", err)
+	}
+	t.Logf("sensors: %d", len(sensors))
+}
+
 func envOr(k, d string) string {
 	if v := os.Getenv(k); v != "" {
 		return v

--- a/internal/common/redfish/sel_sensors.go
+++ b/internal/common/redfish/sel_sensors.go
@@ -1,0 +1,251 @@
+package redfish
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	gofishredfish "github.com/stmcginnis/gofish/redfish"
+)
+
+// ListSEL collects log entries from the computer system, managers, and chassis.
+// Missing log services are skipped; returns empty slice when none are present.
+func (c *client) ListSEL(ctx context.Context, systemID string, opts SELOptions) ([]SELEntry, error) {
+	_ = ctx
+	api, err := c.apiClient()
+	if err != nil {
+		return nil, err
+	}
+	max := opts.MaxEntries
+	if max <= 0 {
+		max = 200
+	}
+
+	seen := make(map[string]struct{})
+	var out []SELEntry
+
+	appendEntries := func(logName string, entries []*gofishredfish.LogEntry) {
+		for _, e := range entries {
+			if e == nil {
+				continue
+			}
+			se := mapLogEntry(logName, e)
+			key := se.ODataID
+			if key == "" {
+				key = se.ID + "|" + se.Message + "|" + se.Created.String()
+			}
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			if !opts.Since.IsZero() && !se.Created.IsZero() && se.Created.Before(opts.Since) {
+				continue
+			}
+			seen[key] = struct{}{}
+			out = append(out, se)
+			if len(out) >= max {
+				return
+			}
+		}
+	}
+
+	// System log services
+	if sys, err := c.computerSystem(systemID); err == nil && sys != nil {
+		if services, err := sys.LogServices(); err == nil {
+			for _, ls := range services {
+				if ls == nil {
+					continue
+				}
+				entries, err := ls.Entries()
+				if err != nil {
+					continue
+				}
+				appendEntries(ls.Name, entries)
+				if len(out) >= max {
+					return out, nil
+				}
+			}
+		}
+	}
+
+	// Managers
+	if managers, err := api.Service.Managers(); err == nil {
+		for _, m := range managers {
+			if m == nil {
+				continue
+			}
+			services, err := m.LogServices()
+			if err != nil {
+				continue
+			}
+			for _, ls := range services {
+				if ls == nil {
+					continue
+				}
+				entries, err := ls.Entries()
+				if err != nil {
+					continue
+				}
+				appendEntries(ls.Name, entries)
+				if len(out) >= max {
+					return out, nil
+				}
+			}
+		}
+	}
+
+	// Chassis
+	if chassis, err := api.Service.Chassis(); err == nil {
+		for _, ch := range chassis {
+			if ch == nil {
+				continue
+			}
+			services, err := ch.LogServices()
+			if err != nil {
+				continue
+			}
+			for _, ls := range services {
+				if ls == nil {
+					continue
+				}
+				entries, err := ls.Entries()
+				if err != nil {
+					continue
+				}
+				appendEntries(ls.Name, entries)
+				if len(out) >= max {
+					return out, nil
+				}
+			}
+		}
+	}
+
+	return out, nil
+}
+
+func mapLogEntry(logName string, e *gofishredfish.LogEntry) SELEntry {
+	msg := strings.TrimSpace(e.Message)
+	if msg == "" {
+		msg = strings.TrimSpace(e.Description)
+	}
+	if msg == "" {
+		msg = e.MessageID
+	}
+	if msg == "" {
+		msg = e.ID
+	}
+	created := parseRedfishTime(e.Created)
+	if created.IsZero() {
+		created = parseRedfishTime(e.EventTimestamp)
+	}
+	return SELEntry{
+		ID:         e.ID,
+		Message:    msg,
+		Severity:   string(e.Severity),
+		EntryType:  string(e.EntryType),
+		Created:    created,
+		SensorType: string(e.SensorType),
+		SensorNum:  e.SensorNumber,
+		ODataID:    e.ODataID,
+		LogService: logName,
+	}
+}
+
+func parseRedfishTime(s string) time.Time {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return time.Time{}
+	}
+	// Common Redfish formats
+	layouts := []string{
+		time.RFC3339Nano,
+		time.RFC3339,
+		"2006-01-02T15:04:05Z",
+		"2006-01-02T15:04:05-07:00",
+		"2006-01-02 15:04:05",
+	}
+	for _, layout := range layouts {
+		if t, err := time.Parse(layout, s); err == nil {
+			return t.UTC()
+		}
+	}
+	return time.Time{}
+}
+
+// ListSensors collects temperature, fan, and voltage samples from chassis Thermal/Power.
+// Best-effort: skips chassis/subresources that are missing or error.
+func (c *client) ListSensors(ctx context.Context, systemID string) ([]SensorSample, error) {
+	_ = ctx
+	_ = systemID // chassis list is global for multi-node sushy; filter later if needed
+	api, err := c.apiClient()
+	if err != nil {
+		return nil, err
+	}
+	chassis, err := api.Service.Chassis()
+	if err != nil {
+		// No chassis collection → empty sensors, not hard failure for Observe poll.
+		return nil, nil
+	}
+	var out []SensorSample
+	for _, ch := range chassis {
+		if ch == nil {
+			continue
+		}
+		if thermal, err := ch.Thermal(); err == nil && thermal != nil {
+			for _, t := range thermal.Temperatures {
+				name := t.Name
+				if name == "" {
+					name = t.MemberID
+				}
+				if name == "" {
+					name = t.ID
+				}
+				out = append(out, SensorSample{
+					Name:            name,
+					Reading:         float64(t.ReadingCelsius),
+					Units:           "Cel",
+					PhysicalContext: string(t.PhysicalContext),
+					Kind:            "temperature",
+				})
+			}
+			for _, f := range thermal.Fans {
+				name := f.Name
+				if name == "" {
+					name = f.MemberID
+				}
+				if name == "" {
+					name = f.ID
+				}
+				units := string(f.ReadingUnits)
+				if units == "" {
+					units = "RPM"
+				}
+				out = append(out, SensorSample{
+					Name:            name,
+					Reading:         float64(f.Reading),
+					Units:           units,
+					PhysicalContext: string(f.PhysicalContext),
+					Kind:            "fan",
+				})
+			}
+		}
+		if power, err := ch.Power(); err == nil && power != nil {
+			for _, v := range power.Voltages {
+				name := v.Name
+				if name == "" {
+					name = v.MemberID
+				}
+				if name == "" {
+					name = v.ID
+				}
+				out = append(out, SensorSample{
+					Name:            name,
+					Reading:         float64(v.ReadingVolts),
+					Units:           "V",
+					PhysicalContext: string(v.PhysicalContext),
+					Kind:            "voltage",
+				})
+			}
+		}
+	}
+	return out, nil
+}

--- a/internal/common/redfish/sel_sensors_test.go
+++ b/internal/common/redfish/sel_sensors_test.go
@@ -1,0 +1,55 @@
+package redfish_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/mattcburns/shoal/internal/common/redfish"
+)
+
+func TestFakeListSELAndSensors(t *testing.T) {
+	f := redfish.NewFake()
+	ts := time.Date(2026, 7, 13, 10, 0, 0, 0, time.UTC)
+	f.SEL = []redfish.SELEntry{
+		{ID: "1", Message: "old", Created: ts.Add(-2 * time.Hour), Severity: "OK"},
+		{ID: "2", Message: "new thermal", Created: ts, Severity: "Warning", SensorType: "Temperature"},
+	}
+	f.Sensors = []redfish.SensorSample{
+		{Name: "Inlet", Reading: 22, Units: "Cel", Kind: "temperature"},
+	}
+
+	got, err := f.ListSEL(context.Background(), "1", redfish.SELOptions{Since: ts.Add(-time.Hour)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].ID != "2" {
+		t.Fatalf("sel filter: %+v", got)
+	}
+
+	sensors, err := f.ListSensors(context.Background(), "1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sensors) != 1 || sensors[0].Name != "Inlet" {
+		t.Fatalf("%+v", sensors)
+	}
+}
+
+func TestFakeListSELMaxEntries(t *testing.T) {
+	f := redfish.NewFake()
+	for i := 0; i < 5; i++ {
+		f.SEL = append(f.SEL, redfish.SELEntry{ID: string(rune('a' + i)), Message: "m"})
+	}
+	got, err := f.ListSEL(context.Background(), "", redfish.SELOptions{MaxEntries: 2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len=%d", len(got))
+	}
+}
+
+func TestFakeImplementsBMC(t *testing.T) {
+	var _ redfish.BMC = redfish.NewFake()
+}

--- a/internal/common/redfish/types.go
+++ b/internal/common/redfish/types.go
@@ -55,3 +55,34 @@ type VirtualMedia struct {
 	MediaTypes []string
 	SupportsCD bool
 }
+
+// SELOptions filters ListSEL results.
+type SELOptions struct {
+	// MaxEntries caps returned entries (0 = default 200).
+	MaxEntries int
+	// Since, when non-zero, keeps entries at or after this time (Created/EventTimestamp).
+	Since time.Time
+}
+
+// SELEntry is a Shoal-domain log/SEL record (no gofish types).
+type SELEntry struct {
+	ID         string // Log entry ID
+	Message    string
+	Severity   string    // OK | Warning | Critical | …
+	EntryType  string    // Event | SEL | Oem
+	Created    time.Time // zero if unknown
+	SensorType string
+	SensorNum  int // 0 when unset / not SEL
+	ODataID    string
+	LogService string // parent log service name or URI fragment
+}
+
+// SensorSample is one thermal/power sensor reading from Redfish.
+type SensorSample struct {
+	Name            string
+	Reading         float64
+	Units           string
+	PhysicalContext string
+	Status          string // Health / State summary when available
+	Kind            string // "temperature" | "fan" | "voltage" | "power" | …
+}

--- a/internal/common/telemetry/memory.go
+++ b/internal/common/telemetry/memory.go
@@ -1,0 +1,173 @@
+package telemetry
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/mattcburns/shoal/internal/common/models"
+	"github.com/mattcburns/shoal/internal/common/validate"
+)
+
+// Memory is an in-process Store for unit tests.
+type Memory struct {
+	mu      sync.RWMutex
+	events  []models.NormalizedEvent
+	sensors []SensorReading
+	jobLogs []jobLogLine
+}
+
+type jobLogLine struct {
+	JobID string
+	TS    time.Time
+	Line  string
+}
+
+// NewMemory returns an empty memory telemetry store.
+func NewMemory() *Memory {
+	return &Memory{}
+}
+
+// WriteEvent validates and appends an event (assigns ID if empty).
+func (m *Memory) WriteEvent(_ context.Context, e models.NormalizedEvent) error {
+	if err := validate.NormalizedEvent(e); err != nil {
+		return err
+	}
+	if e.Timestamp.IsZero() {
+		e.Timestamp = time.Now().UTC()
+	} else {
+		e.Timestamp = e.Timestamp.UTC()
+	}
+	if e.ID == "" {
+		e.ID = newID()
+	}
+	// Do not retain Raw in durable form for MVP.
+	e.Raw = nil
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.events = append(m.events, e)
+	return nil
+}
+
+// WriteSensor appends a sensor reading.
+func (m *Memory) WriteSensor(_ context.Context, r SensorReading) error {
+	if r.DeviceID == "" {
+		return fmt.Errorf("telemetry: sensor device_id required")
+	}
+	if r.Sensor == "" {
+		return fmt.Errorf("telemetry: sensor name required")
+	}
+	if r.TS.IsZero() {
+		r.TS = time.Now().UTC()
+	} else {
+		r.TS = r.TS.UTC()
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.sensors = append(m.sensors, r)
+	return nil
+}
+
+// WriteJobLog appends a job log line.
+func (m *Memory) WriteJobLog(_ context.Context, jobID string, ts time.Time, line string) error {
+	if jobID == "" {
+		return fmt.Errorf("telemetry: job_id required")
+	}
+	if line == "" {
+		return fmt.Errorf("telemetry: log line required")
+	}
+	if ts.IsZero() {
+		ts = time.Now().UTC()
+	} else {
+		ts = ts.UTC()
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.jobLogs = append(m.jobLogs, jobLogLine{JobID: jobID, TS: ts, Line: line})
+	return nil
+}
+
+// ListEvents returns events for deviceID at or after since, newest first, capped at limit.
+func (m *Memory) ListEvents(_ context.Context, deviceID string, since time.Time, limit int) ([]models.NormalizedEvent, error) {
+	if deviceID == "" {
+		return nil, fmt.Errorf("telemetry: device_id required")
+	}
+	if limit <= 0 {
+		limit = 100
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	var out []models.NormalizedEvent
+	for _, e := range m.events {
+		if e.DeviceID != deviceID {
+			continue
+		}
+		if !since.IsZero() && e.Timestamp.Before(since) {
+			continue
+		}
+		out = append(out, e)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].Timestamp.After(out[j].Timestamp)
+	})
+	if len(out) > limit {
+		out = out[:limit]
+	}
+	return out, nil
+}
+
+// ListSensors returns sensor rows for deviceID at or after since, newest first.
+func (m *Memory) ListSensors(_ context.Context, deviceID string, since time.Time, limit int) ([]SensorReading, error) {
+	if deviceID == "" {
+		return nil, fmt.Errorf("telemetry: device_id required")
+	}
+	if limit <= 0 {
+		limit = 100
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	var out []SensorReading
+	for _, r := range m.sensors {
+		if r.DeviceID != deviceID {
+			continue
+		}
+		if !since.IsZero() && r.TS.Before(since) {
+			continue
+		}
+		out = append(out, r)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].TS.After(out[j].TS)
+	})
+	if len(out) > limit {
+		out = out[:limit]
+	}
+	return out, nil
+}
+
+// JobLogCount returns lines for a job (test helper).
+func (m *Memory) JobLogCount(jobID string) int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	n := 0
+	for _, l := range m.jobLogs {
+		if l.JobID == jobID {
+			n++
+		}
+	}
+	return n
+}
+
+func newID() string {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return fmt.Sprintf("evt-%d", time.Now().UnixNano())
+	}
+	return hex.EncodeToString(b[:])
+}
+
+var _ Store = (*Memory)(nil)

--- a/internal/common/telemetry/postgres.go
+++ b/internal/common/telemetry/postgres.go
@@ -1,0 +1,201 @@
+package telemetry
+
+import (
+	"context"
+	"crypto/rand"
+	"database/sql"
+	"encoding/hex"
+	"fmt"
+	"time"
+
+	"github.com/mattcburns/shoal/internal/common/models"
+	"github.com/mattcburns/shoal/internal/common/validate"
+)
+
+// Postgres implements Store on the lab telemetry DB (events / sensor_readings / job_log).
+type Postgres struct {
+	db *sql.DB
+}
+
+// NewPostgres wraps an open, migrated *sql.DB.
+func NewPostgres(db *sql.DB) *Postgres {
+	return &Postgres{db: db}
+}
+
+// WriteEvent inserts one events row. Assigns ID when empty. Does not persist Raw.
+func (p *Postgres) WriteEvent(ctx context.Context, e models.NormalizedEvent) error {
+	if err := validate.NormalizedEvent(e); err != nil {
+		return err
+	}
+	if e.Timestamp.IsZero() {
+		e.Timestamp = time.Now().UTC()
+	} else {
+		e.Timestamp = e.Timestamp.UTC()
+	}
+	if e.ID == "" {
+		e.ID = newEventID()
+	}
+	_, err := p.db.ExecContext(ctx, `
+INSERT INTO events (id, device_id, ts, type, severity, component, message, raw_ref)
+VALUES ($1,$2,$3,$4,$5,$6,$7,$8)`,
+		e.ID, e.DeviceID, e.Timestamp,
+		nullStr(e.EventType), nullStr(e.Severity), nullStr(e.Component),
+		e.Message, nil,
+	)
+	if err != nil {
+		return fmt.Errorf("telemetry: write event: %w", err)
+	}
+	return nil
+}
+
+// WriteSensor inserts one sensor_readings row.
+func (p *Postgres) WriteSensor(ctx context.Context, r SensorReading) error {
+	if r.DeviceID == "" {
+		return fmt.Errorf("telemetry: sensor device_id required")
+	}
+	if r.Sensor == "" {
+		return fmt.Errorf("telemetry: sensor name required")
+	}
+	if r.TS.IsZero() {
+		r.TS = time.Now().UTC()
+	} else {
+		r.TS = r.TS.UTC()
+	}
+	_, err := p.db.ExecContext(ctx, `
+INSERT INTO sensor_readings (device_id, ts, sensor, value, unit)
+VALUES ($1,$2,$3,$4,$5)`,
+		r.DeviceID, r.TS, r.Sensor, r.Value, nullStr(r.Unit),
+	)
+	if err != nil {
+		return fmt.Errorf("telemetry: write sensor: %w", err)
+	}
+	return nil
+}
+
+// WriteJobLog inserts one job_log row.
+func (p *Postgres) WriteJobLog(ctx context.Context, jobID string, ts time.Time, line string) error {
+	if jobID == "" {
+		return fmt.Errorf("telemetry: job_id required")
+	}
+	if line == "" {
+		return fmt.Errorf("telemetry: log line required")
+	}
+	if ts.IsZero() {
+		ts = time.Now().UTC()
+	} else {
+		ts = ts.UTC()
+	}
+	_, err := p.db.ExecContext(ctx, `
+INSERT INTO job_log (job_id, ts, line) VALUES ($1,$2,$3)`,
+		jobID, ts, line,
+	)
+	if err != nil {
+		return fmt.Errorf("telemetry: write job log: %w", err)
+	}
+	return nil
+}
+
+// ListEvents returns newest-first events for a device since the given time.
+func (p *Postgres) ListEvents(ctx context.Context, deviceID string, since time.Time, limit int) ([]models.NormalizedEvent, error) {
+	if deviceID == "" {
+		return nil, fmt.Errorf("telemetry: device_id required")
+	}
+	if limit <= 0 {
+		limit = 100
+	}
+	var (
+		rows *sql.Rows
+		err  error
+	)
+	if since.IsZero() {
+		rows, err = p.db.QueryContext(ctx, `
+SELECT id, device_id, ts, type, severity, component, message
+FROM events WHERE device_id = $1
+ORDER BY ts DESC LIMIT $2`, deviceID, limit)
+	} else {
+		rows, err = p.db.QueryContext(ctx, `
+SELECT id, device_id, ts, type, severity, component, message
+FROM events WHERE device_id = $1 AND ts >= $2
+ORDER BY ts DESC LIMIT $3`, deviceID, since.UTC(), limit)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("telemetry: list events: %w", err)
+	}
+	defer rows.Close()
+
+	var out []models.NormalizedEvent
+	for rows.Next() {
+		var e models.NormalizedEvent
+		var typ, sev, comp sql.NullString
+		if err := rows.Scan(&e.ID, &e.DeviceID, &e.Timestamp, &typ, &sev, &comp, &e.Message); err != nil {
+			return nil, fmt.Errorf("telemetry: scan event: %w", err)
+		}
+		e.EventType = typ.String
+		e.Severity = sev.String
+		e.Component = comp.String
+		out = append(out, e)
+	}
+	return out, rows.Err()
+}
+
+// ListSensors returns newest-first sensor rows for a device.
+func (p *Postgres) ListSensors(ctx context.Context, deviceID string, since time.Time, limit int) ([]SensorReading, error) {
+	if deviceID == "" {
+		return nil, fmt.Errorf("telemetry: device_id required")
+	}
+	if limit <= 0 {
+		limit = 100
+	}
+	var (
+		rows *sql.Rows
+		err  error
+	)
+	if since.IsZero() {
+		rows, err = p.db.QueryContext(ctx, `
+SELECT device_id, ts, sensor, value, unit
+FROM sensor_readings WHERE device_id = $1
+ORDER BY ts DESC LIMIT $2`, deviceID, limit)
+	} else {
+		rows, err = p.db.QueryContext(ctx, `
+SELECT device_id, ts, sensor, value, unit
+FROM sensor_readings WHERE device_id = $1 AND ts >= $2
+ORDER BY ts DESC LIMIT $3`, deviceID, since.UTC(), limit)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("telemetry: list sensors: %w", err)
+	}
+	defer rows.Close()
+
+	var out []SensorReading
+	for rows.Next() {
+		var r SensorReading
+		var unit sql.NullString
+		var val sql.NullFloat64
+		if err := rows.Scan(&r.DeviceID, &r.TS, &r.Sensor, &val, &unit); err != nil {
+			return nil, fmt.Errorf("telemetry: scan sensor: %w", err)
+		}
+		if val.Valid {
+			r.Value = val.Float64
+		}
+		r.Unit = unit.String
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+func nullStr(s string) any {
+	if s == "" {
+		return nil
+	}
+	return s
+}
+
+func newEventID() string {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return fmt.Sprintf("evt-%d", time.Now().UnixNano())
+	}
+	return hex.EncodeToString(b[:])
+}
+
+var _ Store = (*Postgres)(nil)

--- a/internal/common/telemetry/postgres_integration_test.go
+++ b/internal/common/telemetry/postgres_integration_test.go
@@ -1,0 +1,76 @@
+//go:build integration
+
+package telemetry_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/mattcburns/shoal/internal/common/models"
+	"github.com/mattcburns/shoal/internal/common/telemetry"
+)
+
+// Lab: SHOAL_TELEMETRY_DATABASE_URL=postgres://shoal:…@192.168.122.100:5433/shoal_telemetry?sslmode=disable
+func TestLabPostgresStoreWriteList(t *testing.T) {
+	dsn := os.Getenv("SHOAL_TELEMETRY_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("SHOAL_TELEMETRY_DATABASE_URL required")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	db, err := telemetry.OpenAndMigrate(ctx, dsn)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer db.Close()
+
+	st := telemetry.NewPostgres(db)
+	device := fmt.Sprintf("lab-p4a-%d", time.Now().UnixNano())
+	ts := time.Now().UTC()
+
+	if err := st.WriteEvent(ctx, models.NormalizedEvent{
+		DeviceID:  device,
+		EventType: "sel",
+		Severity:  "info",
+		Message:   "phase4a lab store probe",
+		Timestamp: ts,
+	}); err != nil {
+		t.Fatalf("write event: %v", err)
+	}
+	if err := st.WriteSensor(ctx, telemetry.SensorReading{
+		DeviceID: device,
+		TS:       ts,
+		Sensor:   "probe-temp",
+		Value:    21.5,
+		Unit:     "Cel",
+	}); err != nil {
+		t.Fatalf("write sensor: %v", err)
+	}
+	if err := st.WriteJobLog(ctx, "job-p4a-probe", ts, "phase4a probe line"); err != nil {
+		t.Fatalf("write job log: %v", err)
+	}
+
+	evs, err := st.ListEvents(ctx, device, time.Time{}, 10)
+	if err != nil {
+		t.Fatalf("list events: %v", err)
+	}
+	if len(evs) == 0 || evs[0].Message != "phase4a lab store probe" {
+		t.Fatalf("events: %+v", evs)
+	}
+	if evs[0].ID == "" {
+		t.Fatal("expected event id")
+	}
+
+	sens, err := st.ListSensors(ctx, device, time.Time{}, 10)
+	if err != nil {
+		t.Fatalf("list sensors: %v", err)
+	}
+	if len(sens) == 0 || sens[0].Value != 21.5 {
+		t.Fatalf("sensors: %+v", sens)
+	}
+	t.Logf("ok device=%s event_id=%s sensors=%d", device, evs[0].ID, len(sens))
+}

--- a/internal/common/telemetry/store.go
+++ b/internal/common/telemetry/store.go
@@ -1,0 +1,28 @@
+// Package telemetry is the Postgres-primary events/sensors/job_log store.
+package telemetry
+
+import (
+	"context"
+	"time"
+
+	"github.com/mattcburns/shoal/internal/common/models"
+)
+
+// SensorReading is one numeric sensor sample for sensor_readings.
+type SensorReading struct {
+	DeviceID string
+	TS       time.Time
+	Sensor   string
+	Value    float64
+	Unit     string
+}
+
+// Store is the durable telemetry surface (events, sensors, job log lines).
+// Job rows live in deploy/jobstore on the same DB.
+type Store interface {
+	WriteEvent(ctx context.Context, e models.NormalizedEvent) error
+	WriteSensor(ctx context.Context, r SensorReading) error
+	WriteJobLog(ctx context.Context, jobID string, ts time.Time, line string) error
+	ListEvents(ctx context.Context, deviceID string, since time.Time, limit int) ([]models.NormalizedEvent, error)
+	ListSensors(ctx context.Context, deviceID string, since time.Time, limit int) ([]SensorReading, error)
+}

--- a/internal/common/telemetry/store_test.go
+++ b/internal/common/telemetry/store_test.go
@@ -1,0 +1,96 @@
+package telemetry_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/mattcburns/shoal/internal/common/models"
+	"github.com/mattcburns/shoal/internal/common/telemetry"
+)
+
+func TestMemoryWriteListEvents(t *testing.T) {
+	st := telemetry.NewMemory()
+	ctx := context.Background()
+	ts := time.Date(2026, 7, 13, 12, 0, 0, 0, time.UTC)
+	err := st.WriteEvent(ctx, models.NormalizedEvent{
+		DeviceID:  "dev-1",
+		EventType: "sel",
+		Severity:  "warning",
+		Component: "cpu",
+		Message:   "thermal trip",
+		Timestamp: ts,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// older event
+	err = st.WriteEvent(ctx, models.NormalizedEvent{
+		DeviceID:  "dev-1",
+		Message:   "older",
+		Timestamp: ts.Add(-time.Hour),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = st.WriteEvent(ctx, models.NormalizedEvent{
+		DeviceID:  "other",
+		Message:   "skip",
+		Timestamp: ts,
+	})
+
+	got, err := st.ListEvents(ctx, "dev-1", time.Time{}, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len=%d", len(got))
+	}
+	if got[0].Message != "thermal trip" {
+		t.Fatalf("want newest first, got %q", got[0].Message)
+	}
+	if got[0].ID == "" {
+		t.Fatal("expected assigned id")
+	}
+
+	since := ts.Add(-30 * time.Minute)
+	got, err = st.ListEvents(ctx, "dev-1", since, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].Message != "thermal trip" {
+		t.Fatalf("since filter: %+v", got)
+	}
+}
+
+func TestMemoryWriteEventRejectsEmptyDevice(t *testing.T) {
+	st := telemetry.NewMemory()
+	err := st.WriteEvent(context.Background(), models.NormalizedEvent{Message: "x"})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestMemorySensorsAndJobLog(t *testing.T) {
+	st := telemetry.NewMemory()
+	ctx := context.Background()
+	ts := time.Now().UTC()
+	if err := st.WriteSensor(ctx, telemetry.SensorReading{
+		DeviceID: "d1", TS: ts, Sensor: "Inlet Temp", Value: 24.5, Unit: "Cel",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.WriteJobLog(ctx, "job-1", ts, "line1"); err != nil {
+		t.Fatal(err)
+	}
+	sensors, err := st.ListSensors(ctx, "d1", time.Time{}, 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sensors) != 1 || sensors[0].Value != 24.5 {
+		t.Fatalf("%+v", sensors)
+	}
+	if st.JobLogCount("job-1") != 1 {
+		t.Fatal("job log")
+	}
+}


### PR DESCRIPTION
## Summary

Phase **4a** foundations for Observe broaden:

- **`telemetry.Store`** — `WriteEvent` / `WriteSensor` / `WriteJobLog` + list APIs; Postgres + memory implementations
- **Redfish `ListSEL` / `ListSensors`** — Shoal domain types only; gofish-backed best-effort (system/manager/chassis logs; chassis thermal/power); Fake for unit tests
- Optional `NormalizedEvent.ID` for durable event keys
- Design next-actions hygiene: Phase 0–3 done; Phase 4 next (stale Phase 3 “next actions” cleared)

## Test plan

- [x] `go test ./...` (unit)
- [x] `staticcheck` on touched packages
- [x] Lab Redfish: `TestLabListSELAndSensors` (empty SEL/sensors on sushy is OK)
- [x] Lab Redfish: existing VM/boot/cleanup still passes
- [x] Lab Postgres: `TestLabPostgresStoreWriteList` against `:5433` (`SHOAL_TELEMETRY_DATABASE_URL`)

## Out of scope (Phase 4b)

Poller loops, device status CLI/API, event AI normalize, watch-mode poll rates.