### PR TITLE
feat(observe): SEL/sensor poll, device status CLI/API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -227,7 +227,7 @@ go run ./cmd/shoal deploy run \
 |---------|--------|
 | `SHOAL_HTTP_ADDR` | Default `:8088`; bind management interface in lab |
 | `SHOAL_LOG_LEVEL` | `debug` \| `info` \| `warn` \| `error` (default `info`) |
-| `SHOAL_TELEMETRY_DATABASE_URL` | Lab Postgres `…:5433/shoal_telemetry` (jobs + events) |
+| `SHOAL_TELEMETRY_DATABASE_URL` | Lab Postgres `…:5433/shoal_telemetry` (jobs + events/sensors; Observe poll) |
 | `SHOAL_NETBOX_URL` / `SHOAL_NETBOX_TOKEN` | Identity store |
 | `SHOAL_AI_PROVIDER` | `ollama` \| `cloud` |
 | `SHOAL_AI_MODEL` | Text / default model (lab: `llama3.2:3b`) |
@@ -243,6 +243,10 @@ go run ./cmd/shoal deploy run \
 | `SHOAL_FEWSHOT_DIR` | Append-only learned few-shot JSONL (confirm learning). Lab Ansible default: `/var/lib/shoal/fewshot` via `shoal_fewshot_dir` + `env.j2`. Empty disables confirm |
 
 Full table and Ansible extension points: design doc §8.1.
+
+**Phase 4 Observe:** `shoal observe status|poll`, `GET /v1/devices/{id}/status` and
+`…/events`. Poll uses Redfish `ListSEL`/`ListSensors` → `telemetry.Store`.
+Observe never imports Deploy (job reads via `jobport.JobQuery`).
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -245,8 +245,10 @@ go run ./cmd/shoal deploy run \
 Full table and Ansible extension points: design doc §8.1.
 
 **Phase 4 Observe:** `shoal observe status|poll`, `GET /v1/devices/{id}/status` and
-`…/events`. Poll uses Redfish `ListSEL`/`ListSensors` → `telemetry.Store`.
-Observe never imports Deploy (job reads via `jobport.JobQuery`).
+`…/events`. Poll uses Redfish `ListSEL`/`ListSensors` → durable `telemetry.Store`
+only (no silent memory fallback). Empty SEL/sensors with exit 0 is valid when the
+BMC has no logs; write failures and Redfish errors fail the poll. Observe never
+imports Deploy (job reads via `jobport.JobQuery`).
 
 ---
 

--- a/SHOAL_COMPREHENSIVE_DESIGN_AND_IMPLEMENTATION_PLAN.md
+++ b/SHOAL_COMPREHENSIVE_DESIGN_AND_IMPLEMENTATION_PLAN.md
@@ -1632,6 +1632,6 @@ go test ./...
 **This document (v2.0.5) is the SoT for agents.** Phase 0–3 (incl. dual-model lab + hybrid Discover + few-shot learning) are on `master`.
 
 Next actions:
-1. Phase 4 Observe broaden: telemetry Store, Redfish SEL/sensors, poll, device status CLI/API
+1. Phase 4 Observe broaden (4a Store+SEL landed; 4b poll/status CLI/API)
 2. Later: Phase 5 Deploy harden, packaging
 3. At Phase 6: choose graphics failure-screen OCR approach before implementing

--- a/docs/lab-runbook.md
+++ b/docs/lab-runbook.md
@@ -142,6 +142,32 @@ go run ./cmd/shoal discover confirm \
 API: `POST /v1/discover/confirm` with the same JSON body. Ingest still works if
 `SHOAL_FEWSHOT_DIR` is unset; confirm returns an error until the dir is set.
 
+### Phase 4: Observe status + SEL/sensor poll
+
+Telemetry events/sensors go to Postgres (`SHOAL_TELEMETRY_DATABASE_URL`, lab
+`:5433/shoal_telemetry`) — **not** NetBox.
+
+```bash
+export SHOAL_TELEMETRY_DATABASE_URL="postgres://shoal:…@192.168.122.100:5433/shoal_telemetry?sslmode=disable"
+export SHOAL_BMC_USERNAME=… SHOAL_BMC_PASSWORD=…
+
+# Aggregate device status (job phase + last event)
+go run ./cmd/shoal observe status -device-id shoal-node-1
+go run ./cmd/shoal observe status -device-id shoal-node-1 -events 10
+
+# One-shot Redfish SEL + sensor poll → telemetry store
+go run ./cmd/shoal observe poll \
+  -device-id shoal-node-1 \
+  -bmc-url http://192.168.122.100:8001
+
+# With serve: GET /v1/devices/{id}/status and /v1/devices/{id}/events
+# Background poller seeds targets from jobs that have bmc_endpoint set;
+# interval elevates while a SOL watch is active (15s vs 60s idle).
+```
+
+**Lab fidelity:** sushy-tools often returns **empty** SEL/sensors — poll still
+succeeds (0 new entries). Rich SEL requires real BMC hardware.
+
 ## 2) Fast stop (teardown / clean slate)
 ```bash
 ansible-playbook -i infra/ansible/inventory/lab-vm.yml infra/ansible/playbooks/down.yml

--- a/docs/lab-runbook.md
+++ b/docs/lab-runbook.md
@@ -145,7 +145,9 @@ API: `POST /v1/discover/confirm` with the same JSON body. Ingest still works if
 ### Phase 4: Observe status + SEL/sensor poll
 
 Telemetry events/sensors go to Postgres (`SHOAL_TELEMETRY_DATABASE_URL`, lab
-`:5433/shoal_telemetry`) — **not** NetBox.
+`:5433/shoal_telemetry`) — **not** NetBox. **No silent memory fallback:** poll
+and `-events` require a working DSN; if the DSN is set but open fails, commands
+error out.
 
 ```bash
 export SHOAL_TELEMETRY_DATABASE_URL="postgres://shoal:…@192.168.122.100:5433/shoal_telemetry?sslmode=disable"
@@ -155,18 +157,29 @@ export SHOAL_BMC_USERNAME=… SHOAL_BMC_PASSWORD=…
 go run ./cmd/shoal observe status -device-id shoal-node-1
 go run ./cmd/shoal observe status -device-id shoal-node-1 -events 10
 
-# One-shot Redfish SEL + sensor poll → telemetry store
+# One-shot Redfish SEL + sensor poll → durable telemetry only
 go run ./cmd/shoal observe poll \
   -device-id shoal-node-1 \
   -bmc-url http://192.168.122.100:8001
 
+# Multi-system sushy: pass -system-id when using -bmc-url for power state
+go run ./cmd/shoal observe status -device-id shoal-node-1 \
+  -bmc-url http://192.168.122.100:8001 -system-id <uuid-or-name>
+
 # With serve: GET /v1/devices/{id}/status and /v1/devices/{id}/events
-# Background poller seeds targets from jobs that have bmc_endpoint set;
+# Background poller runs only when DSN is healthy; seeds jobs with bmc_endpoint;
 # interval elevates while a SOL watch is active (15s vs 60s idle).
 ```
 
-**Lab fidelity:** sushy-tools often returns **empty** SEL/sensors — poll still
-succeeds (0 new entries). Rich SEL requires real BMC hardware.
+**What “pass” means on lab:**
+- Poll exit 0 with `sel_new:0, sensors_written:0` is **valid** on sushy (no logs)
+  — it means Redfish open + list succeeded with empty data, **not** that rich SEL
+  was ingested. Write/dedup is covered by unit tests with Fake BMC.
+- Poll exit non-zero if Redfish fails or any normalize/write fails.
+- `ActiveJobID` is only set for `provisioning` jobs (failed jobs expose lifecycle
+  + error, not an “active” id).
+
+**Lab fidelity:** rich SEL/sensors need real BMC hardware.
 
 ## 2) Fast stop (teardown / clean slate)
 ```bash

--- a/internal/api/devices.go
+++ b/internal/api/devices.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/mattcburns/shoal/internal/common/models"
 	"github.com/mattcburns/shoal/internal/observe"
 )
 
@@ -63,6 +64,9 @@ func (s *Server) handleDeviceEvents(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		writeJSON(w, http.StatusServiceUnavailable, map[string]any{"error": err.Error()})
 		return
+	}
+	if evs == nil {
+		evs = []models.NormalizedEvent{}
 	}
 	writeJSON(w, http.StatusOK, map[string]any{
 		"device_id": id,

--- a/internal/api/devices.go
+++ b/internal/api/devices.go
@@ -1,0 +1,71 @@
+package api
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/mattcburns/shoal/internal/observe"
+)
+
+// WithObserve attaches the Observe service for device status/events.
+func (s *Server) WithObserve(obs *observe.Service) *Server {
+	s.observe = obs
+	return s
+}
+
+func (s *Server) handleDeviceStatus(w http.ResponseWriter, r *http.Request) {
+	if s.observe == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]any{
+			"error": "observe not configured",
+		})
+		return
+	}
+	id := r.PathValue("id")
+	if id == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "missing device id"})
+		return
+	}
+	st, err := s.observe.Status(r.Context(), id)
+	if err != nil {
+		s.log.Error("device status", "err", err.Error())
+		writeJSON(w, http.StatusInternalServerError, map[string]any{"error": "internal error"})
+		return
+	}
+	writeJSON(w, http.StatusOK, st)
+}
+
+func (s *Server) handleDeviceEvents(w http.ResponseWriter, r *http.Request) {
+	if s.observe == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]any{
+			"error": "observe not configured",
+		})
+		return
+	}
+	id := r.PathValue("id")
+	if id == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "missing device id"})
+		return
+	}
+	limit := 50
+	if v := r.URL.Query().Get("limit"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			limit = n
+		}
+	}
+	var since time.Time
+	if v := r.URL.Query().Get("since"); v != "" {
+		if t, err := time.Parse(time.RFC3339, v); err == nil {
+			since = t
+		}
+	}
+	evs, err := s.observe.ListEvents(r.Context(), id, since, limit)
+	if err != nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]any{"error": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"device_id": id,
+		"events":    evs,
+	})
+}

--- a/internal/api/devices_test.go
+++ b/internal/api/devices_test.go
@@ -1,0 +1,53 @@
+package api_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/mattcburns/shoal/internal/api"
+	"github.com/mattcburns/shoal/internal/common/config"
+	"github.com/mattcburns/shoal/internal/common/models"
+	"github.com/mattcburns/shoal/internal/common/telemetry"
+	"github.com/mattcburns/shoal/internal/deploy/jobstore"
+	"github.com/mattcburns/shoal/internal/observe"
+)
+
+func TestDeviceStatusAndEvents(t *testing.T) {
+	jobs := jobstore.NewMemory()
+	store := telemetry.NewMemory()
+	ctx := context.Background()
+	now := time.Now().UTC()
+	_ = jobs.Insert(ctx, models.ProvisioningJob{
+		ID: "j1", DeviceID: "n1", State: models.StateProvisioning, Phase: "BOOT", UpdatedAt: &now,
+	})
+	_ = store.WriteEvent(ctx, models.NormalizedEvent{
+		DeviceID: "n1", Message: "hello", Severity: "info", Timestamp: now,
+	})
+	obs := observe.New(nil, jobs, store, nil)
+	s := api.New(config.Config{}, nil).WithObserve(obs)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/devices/n1/status", nil)
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status %d body=%s", rr.Code, rr.Body.String())
+	}
+	var st models.DeviceStatus
+	if err := json.Unmarshal(rr.Body.Bytes(), &st); err != nil {
+		t.Fatal(err)
+	}
+	if st.ActiveJobID != "j1" {
+		t.Fatalf("%+v", st)
+	}
+
+	rr = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/v1/devices/n1/events?limit=5", nil)
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("events %d %s", rr.Code, rr.Body.String())
+	}
+}

--- a/internal/api/devices_test.go
+++ b/internal/api/devices_test.go
@@ -50,4 +50,22 @@ func TestDeviceStatusAndEvents(t *testing.T) {
 	if rr.Code != http.StatusOK {
 		t.Fatalf("events %d %s", rr.Code, rr.Body.String())
 	}
+	var body map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if body["events"] == nil {
+		t.Fatal("events must be [] not null")
+	}
+}
+
+func TestDeviceEventsWithoutTelemetry(t *testing.T) {
+	obs := observe.New(nil, jobstore.NewMemory(), nil, nil)
+	s := api.New(config.Config{}, nil).WithObserve(obs)
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/devices/x/events", nil)
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status %d", rr.Code)
+	}
 }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -12,9 +12,10 @@ import (
 	"github.com/mattcburns/shoal/internal/common/telemetry"
 	"github.com/mattcburns/shoal/internal/deploy/jobstore"
 	"github.com/mattcburns/shoal/internal/discover"
+	"github.com/mattcburns/shoal/internal/observe"
 )
 
-// Server is the HTTP API surface (health + jobs + discover).
+// Server is the HTTP API surface (health + jobs + discover + observe).
 type Server struct {
 	cfg config.Config
 	log *slog.Logger
@@ -24,6 +25,7 @@ type Server struct {
 	jobs     jobstore.Store
 	cancel   JobCanceler
 	discover *discover.Service
+	observe  *observe.Service
 }
 
 // New constructs a Server with routes registered.
@@ -53,6 +55,8 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("POST /v1/jobs/{id}/cancel", s.handleCancelJob)
 	s.mux.HandleFunc("POST /v1/discover/ingest", s.handleDiscoverIngest)
 	s.mux.HandleFunc("POST /v1/discover/confirm", s.handleDiscoverConfirm)
+	s.mux.HandleFunc("GET /v1/devices/{id}/status", s.handleDeviceStatus)
+	s.mux.HandleFunc("GET /v1/devices/{id}/events", s.handleDeviceEvents)
 }
 
 func (s *Server) handleHealthz(w http.ResponseWriter, _ *http.Request) {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -15,20 +15,25 @@ import (
 
 	"github.com/mattcburns/shoal/internal/api"
 	"github.com/mattcburns/shoal/internal/common/config"
+	"github.com/mattcburns/shoal/internal/common/models"
 	"github.com/mattcburns/shoal/internal/common/netbox"
 	"github.com/mattcburns/shoal/internal/common/redact"
 	"github.com/mattcburns/shoal/internal/common/redfish"
 	"github.com/mattcburns/shoal/internal/common/secrets"
+	"github.com/mattcburns/shoal/internal/common/telemetry"
 	"github.com/mattcburns/shoal/internal/core/ai"
 	"github.com/mattcburns/shoal/internal/core/fewshot"
 	"github.com/mattcburns/shoal/internal/core/reconcile"
 	"github.com/mattcburns/shoal/internal/deploy/job"
+	"github.com/mattcburns/shoal/internal/deploy/jobstore"
 	"github.com/mattcburns/shoal/internal/discover"
+	"github.com/mattcburns/shoal/internal/observe"
+	"github.com/mattcburns/shoal/internal/observe/poll"
 	"github.com/mattcburns/shoal/internal/observe/sol"
 )
 
 // Version is the application version string (overridable via -ldflags).
-var Version = "0.3.0-phase3"
+var Version = "0.4.0-phase4"
 
 // Run dispatches subcommands. args should be os.Args[1:].
 func Run(args []string) int {
@@ -45,6 +50,8 @@ func Run(args []string) int {
 		return cmdDeploy(args[1:])
 	case "discover":
 		return cmdDiscover(args[1:])
+	case "observe":
+		return cmdObserve(args[1:])
 	case "help", "-h", "--help":
 		printUsage(os.Stdout)
 		return 0
@@ -66,6 +73,12 @@ Commands:
   serve      Run the HTTP API server
   deploy     Provisioning: run | status | cancel
   discover   Assets: ingest | confirm
+  observe    Status / poll: status | poll
+
+Phase 4 observe example:
+  export SHOAL_TELEMETRY_DATABASE_URL=postgres://…@192.168.122.100:5433/shoal_telemetry
+  shoal observe status -device-id shoal-node-1
+  shoal observe poll -device-id shoal-node-1 -bmc-url http://192.168.122.100:8001
 
 Phase 3 discover example:
   export SHOAL_AI_PROVIDER=ollama
@@ -118,6 +131,7 @@ func cmdServe(args []string) int {
 
 	// Optional Discover / AI wiring (Phase 3 + 3b learning).
 	var fsStore fewshot.Store
+	var rec reconcile.Reconciler
 	if cfg.FewShotDir != "" {
 		if st, err := fewshot.NewFileStore(cfg.FewShotDir); err != nil {
 			log.Warn("fewshot store unavailable", "err", err.Error())
@@ -129,10 +143,11 @@ func cmdServe(args []string) int {
 	if llm, err := ai.NewFromConfig(cfg); err != nil {
 		log.Warn("ai client not configured", "err", err.Error())
 	} else if llm != nil {
-		rec, err := reconcile.NewWithFewShot(llm, log, fsStore)
+		r, err := reconcile.NewWithFewShot(llm, log, fsStore)
 		if err != nil {
 			log.Warn("reconciler init failed", "err", err.Error())
 		} else {
+			rec = r
 			var nb netbox.API
 			if cfg.NetBoxURL != "" && cfg.NetBoxToken != "" {
 				nb = netbox.New(cfg.NetBoxURL, cfg.NetBoxToken)
@@ -140,6 +155,12 @@ func cmdServe(args []string) int {
 			disc := discover.NewWithFewShot(log, rec, openSecrets(cfg), nb, fsStore)
 			srvAPI.WithDiscover(disc)
 			log.Info("discover ingest/confirm API enabled")
+		}
+	}
+	// Deterministic event normalize when AI unavailable (Observe poll still works).
+	if rec == nil {
+		if r, err := reconcile.New(&ai.Fake{Content: `{}`}, log); err == nil {
+			rec = r
 		}
 	}
 
@@ -177,6 +198,46 @@ func cmdServe(args []string) int {
 		if err := orch.ReconcileOrphans(ctx); err != nil {
 			log.Warn("orphan reconcile", "err", err.Error())
 		}
+
+		// Phase 4: Observe status + background SEL/sensor poll for jobs with BMC endpoints.
+		var telemStore telemetry.Store
+		if cfg.TelemetryDatabaseURL != "" {
+			db, err := telemetry.OpenAndMigrate(ctx, cfg.TelemetryDatabaseURL)
+			if err != nil {
+				log.Warn("telemetry store for observe", "err", err.Error())
+			} else {
+				defer db.Close()
+				telemStore = telemetry.NewPostgres(db)
+			}
+		}
+		if telemStore == nil {
+			telemStore = telemetry.NewMemory()
+		}
+		obsSvc := observe.New(log, store, telemStore, watchSvc)
+		srvAPI.WithObserve(obsSvc)
+		log.Info("observe device status API enabled")
+
+		poller := poll.New(log, telemStore, redfish.NewBMC)
+		poller.Watching = watchSvc
+		poller.Events = rec
+		seedPollTargets(ctx, poller, store, cfg)
+		go func() {
+			ticker := time.NewTicker(30 * time.Second)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case <-ticker.C:
+					seedPollTargets(ctx, poller, store, cfg)
+				}
+			}
+		}()
+		go poller.Run(ctx)
+		log.Info("observe SEL/sensor poller started",
+			"idle", poll.DefaultIdleInterval.String(),
+			"watch", poll.DefaultWatchInterval.String(),
+		)
 	}
 
 	httpSrv := &http.Server{
@@ -217,6 +278,40 @@ func openSecrets(cfg config.Config) secrets.Backend {
 		}
 	}
 	return secrets.NewMemory()
+}
+
+// seedPollTargets registers BMC endpoints from durable jobs for SEL/sensor poll.
+func seedPollTargets(ctx context.Context, p *poll.Poller, store jobstore.Store, cfg config.Config) {
+	if p == nil || store == nil {
+		return
+	}
+	states := []models.LifecycleState{
+		models.StateProvisioning,
+		models.StateProvisioned,
+		models.StateFailed,
+	}
+	for _, st := range states {
+		list, err := store.ListByState(ctx, st)
+		if err != nil {
+			continue
+		}
+		for _, j := range list {
+			if j.BMCEndpoint == "" || j.DeviceID == "" {
+				continue
+			}
+			_ = p.SetTarget(poll.Target{
+				DeviceID: j.DeviceID,
+				BMC: redfish.Config{
+					BaseURL:  j.BMCEndpoint,
+					Username: cfg.BMCUsername,
+					Password: cfg.BMCPassword,
+					AuthMode: cfg.RedfishAuthMode,
+					TLSMode:  cfg.RedfishTLSMode,
+					CAFile:   cfg.RedfishCAFile,
+				},
+			})
+		}
+	}
 }
 
 func newLogger(level string) *slog.Logger {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -129,7 +129,7 @@ func cmdServe(args []string) int {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	// Optional Discover / AI wiring (Phase 3 + 3b learning).
+	// Optional Discover / AI wiring (Phase 3 + 3b learning). No ai.Fake for Observe.
 	var fsStore fewshot.Store
 	var rec reconcile.Reconciler
 	if cfg.FewShotDir != "" {
@@ -155,12 +155,6 @@ func cmdServe(args []string) int {
 			disc := discover.NewWithFewShot(log, rec, openSecrets(cfg), nb, fsStore)
 			srvAPI.WithDiscover(disc)
 			log.Info("discover ingest/confirm API enabled")
-		}
-	}
-	// Deterministic event normalize when AI unavailable (Observe poll still works).
-	if rec == nil {
-		if r, err := reconcile.New(&ai.Fake{Content: `{}`}, log); err == nil {
-			rec = r
 		}
 	}
 
@@ -199,45 +193,50 @@ func cmdServe(args []string) int {
 			log.Warn("orphan reconcile", "err", err.Error())
 		}
 
-		// Phase 4: Observe status + background SEL/sensor poll for jobs with BMC endpoints.
+		// Phase 4: Observe status. Telemetry is Postgres-only — no silent memory fallback.
 		var telemStore telemetry.Store
 		if cfg.TelemetryDatabaseURL != "" {
 			db, err := telemetry.OpenAndMigrate(ctx, cfg.TelemetryDatabaseURL)
 			if err != nil {
-				log.Warn("telemetry store for observe", "err", err.Error())
+				log.Error("telemetry store open failed; observe events/poll disabled", "err", err.Error())
 			} else {
 				defer db.Close()
 				telemStore = telemetry.NewPostgres(db)
 			}
-		}
-		if telemStore == nil {
-			telemStore = telemetry.NewMemory()
+		} else {
+			log.Warn("SHOAL_TELEMETRY_DATABASE_URL unset; observe events/poll disabled")
 		}
 		obsSvc := observe.New(log, store, telemStore, watchSvc)
 		srvAPI.WithObserve(obsSvc)
-		log.Info("observe device status API enabled")
+		log.Info("observe device status API enabled", "telemetry", telemStore != nil)
 
-		poller := poll.New(log, telemStore, redfish.NewBMC)
-		poller.Watching = watchSvc
-		poller.Events = rec
-		seedPollTargets(ctx, poller, store, cfg)
-		go func() {
-			ticker := time.NewTicker(30 * time.Second)
-			defer ticker.Stop()
-			for {
-				select {
-				case <-ctx.Done():
-					return
-				case <-ticker.C:
-					seedPollTargets(ctx, poller, store, cfg)
-				}
+		// Background SEL/sensor poll only with durable telemetry.
+		if telemStore != nil {
+			poller := poll.New(log, telemStore, redfish.NewBMC)
+			poller.Watching = watchSvc
+			// Use real Core reconciler when AI is configured; else deterministic poll path.
+			if rec != nil {
+				poller.Events = rec
 			}
-		}()
-		go poller.Run(ctx)
-		log.Info("observe SEL/sensor poller started",
-			"idle", poll.DefaultIdleInterval.String(),
-			"watch", poll.DefaultWatchInterval.String(),
-		)
+			seedPollTargets(ctx, poller, store, cfg)
+			go func() {
+				ticker := time.NewTicker(30 * time.Second)
+				defer ticker.Stop()
+				for {
+					select {
+					case <-ctx.Done():
+						return
+					case <-ticker.C:
+						seedPollTargets(ctx, poller, store, cfg)
+					}
+				}
+			}()
+			go poller.Run(ctx)
+			log.Info("observe SEL/sensor poller started",
+				"idle", poll.DefaultIdleInterval.String(),
+				"watch", poll.DefaultWatchInterval.String(),
+			)
+		}
 	}
 
 	httpSrv := &http.Server{

--- a/internal/cli/observe.go
+++ b/internal/cli/observe.go
@@ -12,8 +12,6 @@ import (
 	"github.com/mattcburns/shoal/internal/common/models"
 	"github.com/mattcburns/shoal/internal/common/redfish"
 	"github.com/mattcburns/shoal/internal/common/telemetry"
-	"github.com/mattcburns/shoal/internal/core/ai"
-	"github.com/mattcburns/shoal/internal/core/reconcile"
 	"github.com/mattcburns/shoal/internal/observe"
 	"github.com/mattcburns/shoal/internal/observe/poll"
 )
@@ -43,10 +41,11 @@ func cmdObserveStatus(args []string) int {
 	fs := flag.NewFlagSet("observe status", flag.ContinueOnError)
 	fs.SetOutput(os.Stderr)
 	deviceID := fs.String("device-id", "", "device id (required)")
-	events := fs.Int("events", 0, "include last N telemetry events (0=status only)")
+	events := fs.Int("events", 0, "include last N telemetry events (requires SHOAL_TELEMETRY_DATABASE_URL)")
 	bmcURL := fs.String("bmc-url", "", "optional Redfish base URL for power state")
 	bmcUser := fs.String("bmc-user", cfg.BMCUsername, "BMC username")
 	bmcPass := fs.String("bmc-pass", cfg.BMCPassword, "BMC password")
+	systemID := fs.String("system-id", "", "Redfish system id (required with multi-system BMC + -bmc-url)")
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
@@ -61,23 +60,24 @@ func cmdObserveStatus(args []string) int {
 
 	store, closer, err := openJobStore(cfg)
 	if err != nil {
-		log.Warn("job store unavailable", "err", err.Error())
-	} else if closer != nil {
+		fmt.Fprintf(os.Stderr, "job store: %v\n", err)
+		return 1
+	}
+	if closer != nil {
 		defer closer()
 	}
 
-	var telem telemetry.Store
-	if cfg.TelemetryDatabaseURL != "" {
-		db, err := telemetry.OpenAndMigrate(ctx, cfg.TelemetryDatabaseURL)
-		if err != nil {
-			log.Warn("telemetry store unavailable", "err", err.Error())
-		} else {
-			defer db.Close()
-			telem = telemetry.NewPostgres(db)
-		}
+	telem, telemCloser, err := openTelemetryStore(ctx, cfg, false)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "telemetry: %v\n", err)
+		return 1
 	}
-	if telem == nil {
-		telem = telemetry.NewMemory()
+	if telemCloser != nil {
+		defer telemCloser()
+	}
+	if *events > 0 && telem == nil {
+		fmt.Fprintln(os.Stderr, "observe status: -events requires SHOAL_TELEMETRY_DATABASE_URL")
+		return 1
 	}
 
 	svc := observe.New(log, store, telem, nil)
@@ -96,16 +96,27 @@ func cmdObserveStatus(args []string) int {
 			TLSMode:  cfg.RedfishTLSMode,
 			CAFile:   cfg.RedfishCAFile,
 		})
-		if err == nil {
-			if err := bmc.Open(ctx); err == nil {
-				st, _ = svc.StatusWithPower(ctx, *deviceID, bmc, "")
-				_ = bmc.Close(context.Background())
-			}
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "bmc: %v\n", err)
+			return 1
+		}
+		if err := bmc.Open(ctx); err != nil {
+			fmt.Fprintf(os.Stderr, "bmc open: %v\n", err)
+			return 1
+		}
+		defer func() { _ = bmc.Close(context.Background()) }()
+		st, err = svc.StatusWithPower(ctx, *deviceID, bmc, *systemID)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "power state: %v\n", err)
+			return 1
 		}
 	}
 
-	out := map[string]any{"status": st}
-	if *events > 0 && telem != nil {
+	out := map[string]any{
+		"status":   st,
+		"watching": svc.Watching(*deviceID),
+	}
+	if *events > 0 {
 		evs, err := svc.ListEvents(ctx, *deviceID, time.Time{}, *events)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "events: %v\n", err)
@@ -147,35 +158,18 @@ func cmdObservePoll(args []string) int {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
-	var telem telemetry.Store
-	if cfg.TelemetryDatabaseURL != "" {
-		db, err := telemetry.OpenAndMigrate(ctx, cfg.TelemetryDatabaseURL)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "telemetry: %v\n", err)
-			return 1
-		}
-		defer db.Close()
-		telem = telemetry.NewPostgres(db)
-	} else {
-		telem = telemetry.NewMemory()
-		log.Warn("no SHOAL_TELEMETRY_DATABASE_URL; using memory store (results not durable)")
+	// Durable store required — no silent memory fallback.
+	telem, closer, err := openTelemetryStore(ctx, cfg, true)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "telemetry: %v\n", err)
+		return 1
+	}
+	if closer != nil {
+		defer closer()
 	}
 
-	var rec reconcile.Reconciler
-	if llm, err := ai.NewFromConfig(cfg); err == nil && llm != nil {
-		if r, err := reconcile.New(llm, log); err == nil {
-			rec = r
-		}
-	}
-	// Deterministic-only reconciler when AI unavailable.
-	if rec == nil {
-		if r, err := reconcile.New(&ai.Fake{Content: `{}`}, log); err == nil {
-			rec = r
-		}
-	}
-
+	// Deterministic normalize only (no ai.Fake). Core reconciler optional later.
 	p := poll.New(log, telem, redfish.NewBMC)
-	p.Events = rec
 	selN, sensN, err := p.PollOnce(ctx, poll.Target{
 		DeviceID: *deviceID,
 		SystemID: *systemID,
@@ -188,14 +182,34 @@ func cmdObservePoll(args []string) int {
 			CAFile:   cfg.RedfishCAFile,
 		},
 	})
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "poll: %v\n", err)
-		return 1
-	}
-	_ = json.NewEncoder(os.Stdout).Encode(map[string]any{
+	out := map[string]any{
 		"device_id":       *deviceID,
 		"sel_new":         selN,
 		"sensors_written": sensN,
-	})
+	}
+	if err != nil {
+		out["error"] = err.Error()
+		_ = json.NewEncoder(os.Stdout).Encode(out)
+		fmt.Fprintf(os.Stderr, "poll: %v\n", err)
+		return 1
+	}
+	_ = json.NewEncoder(os.Stdout).Encode(out)
 	return 0
+}
+
+// openTelemetryStore opens Postgres when DSN is set.
+// requireDSN=true → error if unset or open fails.
+// requireDSN=false → nil store if unset; error if set but open fails (no memory fallback).
+func openTelemetryStore(ctx context.Context, cfg config.Config, requireDSN bool) (telemetry.Store, func(), error) {
+	if cfg.TelemetryDatabaseURL == "" {
+		if requireDSN {
+			return nil, nil, fmt.Errorf("SHOAL_TELEMETRY_DATABASE_URL is required")
+		}
+		return nil, nil, nil
+	}
+	db, err := telemetry.OpenAndMigrate(ctx, cfg.TelemetryDatabaseURL)
+	if err != nil {
+		return nil, nil, err
+	}
+	return telemetry.NewPostgres(db), func() { _ = db.Close() }, nil
 }

--- a/internal/cli/observe.go
+++ b/internal/cli/observe.go
@@ -1,0 +1,201 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/mattcburns/shoal/internal/common/config"
+	"github.com/mattcburns/shoal/internal/common/models"
+	"github.com/mattcburns/shoal/internal/common/redfish"
+	"github.com/mattcburns/shoal/internal/common/telemetry"
+	"github.com/mattcburns/shoal/internal/core/ai"
+	"github.com/mattcburns/shoal/internal/core/reconcile"
+	"github.com/mattcburns/shoal/internal/observe"
+	"github.com/mattcburns/shoal/internal/observe/poll"
+)
+
+func cmdObserve(args []string) int {
+	if len(args) < 1 {
+		fmt.Fprintln(os.Stderr, "usage: shoal observe <status|poll> [flags]")
+		return 2
+	}
+	switch args[0] {
+	case "status":
+		return cmdObserveStatus(args[1:])
+	case "poll":
+		return cmdObservePoll(args[1:])
+	default:
+		fmt.Fprintf(os.Stderr, "unknown observe subcommand %q\n", args[0])
+		return 2
+	}
+}
+
+func cmdObserveStatus(args []string) int {
+	cfg, err := config.Load()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "config: %v\n", err)
+		return 1
+	}
+	fs := flag.NewFlagSet("observe status", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	deviceID := fs.String("device-id", "", "device id (required)")
+	events := fs.Int("events", 0, "include last N telemetry events (0=status only)")
+	bmcURL := fs.String("bmc-url", "", "optional Redfish base URL for power state")
+	bmcUser := fs.String("bmc-user", cfg.BMCUsername, "BMC username")
+	bmcPass := fs.String("bmc-pass", cfg.BMCPassword, "BMC password")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if *deviceID == "" {
+		fmt.Fprintln(os.Stderr, "observe status: -device-id required")
+		return 2
+	}
+
+	log := newLogger(cfg.LogLevel)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	store, closer, err := openJobStore(cfg)
+	if err != nil {
+		log.Warn("job store unavailable", "err", err.Error())
+	} else if closer != nil {
+		defer closer()
+	}
+
+	var telem telemetry.Store
+	if cfg.TelemetryDatabaseURL != "" {
+		db, err := telemetry.OpenAndMigrate(ctx, cfg.TelemetryDatabaseURL)
+		if err != nil {
+			log.Warn("telemetry store unavailable", "err", err.Error())
+		} else {
+			defer db.Close()
+			telem = telemetry.NewPostgres(db)
+		}
+	}
+	if telem == nil {
+		telem = telemetry.NewMemory()
+	}
+
+	svc := observe.New(log, store, telem, nil)
+	st, err := svc.Status(ctx, *deviceID)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "status: %v\n", err)
+		return 1
+	}
+
+	if *bmcURL != "" {
+		bmc, err := redfish.NewBMC(redfish.Config{
+			BaseURL:  *bmcURL,
+			Username: *bmcUser,
+			Password: *bmcPass,
+			AuthMode: cfg.RedfishAuthMode,
+			TLSMode:  cfg.RedfishTLSMode,
+			CAFile:   cfg.RedfishCAFile,
+		})
+		if err == nil {
+			if err := bmc.Open(ctx); err == nil {
+				st, _ = svc.StatusWithPower(ctx, *deviceID, bmc, "")
+				_ = bmc.Close(context.Background())
+			}
+		}
+	}
+
+	out := map[string]any{"status": st}
+	if *events > 0 && telem != nil {
+		evs, err := svc.ListEvents(ctx, *deviceID, time.Time{}, *events)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "events: %v\n", err)
+			return 1
+		}
+		if evs == nil {
+			evs = []models.NormalizedEvent{}
+		}
+		out["events"] = evs
+	}
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	_ = enc.Encode(out)
+	return 0
+}
+
+func cmdObservePoll(args []string) int {
+	cfg, err := config.Load()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "config: %v\n", err)
+		return 1
+	}
+	fs := flag.NewFlagSet("observe poll", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	deviceID := fs.String("device-id", "", "device id (required)")
+	bmcURL := fs.String("bmc-url", "", "Redfish base URL (required)")
+	bmcUser := fs.String("bmc-user", cfg.BMCUsername, "BMC username")
+	bmcPass := fs.String("bmc-pass", cfg.BMCPassword, "BMC password")
+	systemID := fs.String("system-id", "", "optional Redfish system id")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if *deviceID == "" || *bmcURL == "" {
+		fmt.Fprintln(os.Stderr, "observe poll: -device-id and -bmc-url required")
+		return 2
+	}
+
+	log := newLogger(cfg.LogLevel)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	var telem telemetry.Store
+	if cfg.TelemetryDatabaseURL != "" {
+		db, err := telemetry.OpenAndMigrate(ctx, cfg.TelemetryDatabaseURL)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "telemetry: %v\n", err)
+			return 1
+		}
+		defer db.Close()
+		telem = telemetry.NewPostgres(db)
+	} else {
+		telem = telemetry.NewMemory()
+		log.Warn("no SHOAL_TELEMETRY_DATABASE_URL; using memory store (results not durable)")
+	}
+
+	var rec reconcile.Reconciler
+	if llm, err := ai.NewFromConfig(cfg); err == nil && llm != nil {
+		if r, err := reconcile.New(llm, log); err == nil {
+			rec = r
+		}
+	}
+	// Deterministic-only reconciler when AI unavailable.
+	if rec == nil {
+		if r, err := reconcile.New(&ai.Fake{Content: `{}`}, log); err == nil {
+			rec = r
+		}
+	}
+
+	p := poll.New(log, telem, redfish.NewBMC)
+	p.Events = rec
+	selN, sensN, err := p.PollOnce(ctx, poll.Target{
+		DeviceID: *deviceID,
+		SystemID: *systemID,
+		BMC: redfish.Config{
+			BaseURL:  *bmcURL,
+			Username: *bmcUser,
+			Password: *bmcPass,
+			AuthMode: cfg.RedfishAuthMode,
+			TLSMode:  cfg.RedfishTLSMode,
+			CAFile:   cfg.RedfishCAFile,
+		},
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "poll: %v\n", err)
+		return 1
+	}
+	_ = json.NewEncoder(os.Stdout).Encode(map[string]any{
+		"device_id":       *deviceID,
+		"sel_new":         selN,
+		"sensors_written": sensN,
+	})
+	return 0
+}

--- a/internal/common/jobport/jobport.go
+++ b/internal/common/jobport/jobport.go
@@ -1,5 +1,5 @@
-// Package jobport defines the progress interface Observe consumes.
-// Deploy implements JobProgress; Observe must not import deploy.
+// Package jobport defines progress and job-read ports Observe consumes.
+// Deploy implements these; Observe must not import deploy.
 package jobport
 
 import (
@@ -15,4 +15,11 @@ type JobProgress interface {
 	ApplyMarker(ctx context.Context, jobID string, m models.SOLMarker) error
 	ReportStall(ctx context.Context, jobID string, reason string) error
 	ReportTransportError(ctx context.Context, jobID string, err error) error
+}
+
+// JobQuery is a read-only view of durable jobs for Observe status aggregation.
+// jobstore.Store satisfies this without Observe importing deploy.
+type JobQuery interface {
+	Get(ctx context.Context, id string) (models.ProvisioningJob, error)
+	ListByState(ctx context.Context, state models.LifecycleState) ([]models.ProvisioningJob, error)
 }

--- a/internal/common/redfish/sel_sensors.go
+++ b/internal/common/redfish/sel_sensors.go
@@ -2,6 +2,7 @@ package redfish
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
@@ -9,7 +10,11 @@ import (
 )
 
 // ListSEL collects log entries from the computer system, managers, and chassis.
-// Missing log services are skipped; returns empty slice when none are present.
+//
+// Empty result with nil error means sources were reachable and simply had no entries
+// (or no LogServices) — normal for sushy-tools.
+// Non-nil error means a hard failure: not open, system not found (when requested),
+// or every discovered log service failed while reading entries (and no entries returned).
 func (c *client) ListSEL(ctx context.Context, systemID string, opts SELOptions) ([]SELEntry, error) {
 	_ = ctx
 	api, err := c.apiClient()
@@ -23,8 +28,13 @@ func (c *client) ListSEL(ctx context.Context, systemID string, opts SELOptions) 
 
 	seen := make(map[string]struct{})
 	var out []SELEntry
+	var firstReadErr error
+	logServicesSeen := 0
+	entryReadOK := 0
+	entryReadFail := 0
 
 	appendEntries := func(logName string, entries []*gofishredfish.LogEntry) {
+		entryReadOK++
 		for _, e := range entries {
 			if e == nil {
 				continue
@@ -42,83 +52,97 @@ func (c *client) ListSEL(ctx context.Context, systemID string, opts SELOptions) 
 			}
 			seen[key] = struct{}{}
 			out = append(out, se)
+		}
+	}
+
+	readLogServices := func(services []*gofishredfish.LogService) {
+		for _, ls := range services {
+			if ls == nil {
+				continue
+			}
+			logServicesSeen++
+			entries, err := ls.Entries()
+			if err != nil {
+				entryReadFail++
+				if firstReadErr == nil {
+					firstReadErr = err
+				}
+				continue
+			}
+			appendEntries(ls.Name, entries)
 			if len(out) >= max {
 				return
 			}
 		}
 	}
 
-	// System log services
-	if sys, err := c.computerSystem(systemID); err == nil && sys != nil {
-		if services, err := sys.LogServices(); err == nil {
-			for _, ls := range services {
-				if ls == nil {
-					continue
-				}
-				entries, err := ls.Entries()
-				if err != nil {
-					continue
-				}
-				appendEntries(ls.Name, entries)
-				if len(out) >= max {
-					return out, nil
-				}
-			}
+	// System log services — system lookup failure is hard when systemID is set
+	// or when there is not exactly one system for empty id.
+	sys, sysErr := c.computerSystem(systemID)
+	if sysErr != nil {
+		// Still try managers/chassis (BMC may log there only), but remember error.
+		if firstReadErr == nil {
+			firstReadErr = sysErr
 		}
+	} else if sys != nil {
+		if services, err := sys.LogServices(); err == nil {
+			readLogServices(services)
+		}
+		// LogServices() missing/empty is soft.
+	}
+	if len(out) >= max {
+		return out[:max], nil
 	}
 
-	// Managers
 	if managers, err := api.Service.Managers(); err == nil {
 		for _, m := range managers {
 			if m == nil {
 				continue
 			}
-			services, err := m.LogServices()
-			if err != nil {
-				continue
-			}
-			for _, ls := range services {
-				if ls == nil {
-					continue
-				}
-				entries, err := ls.Entries()
-				if err != nil {
-					continue
-				}
-				appendEntries(ls.Name, entries)
+			if services, err := m.LogServices(); err == nil {
+				readLogServices(services)
 				if len(out) >= max {
-					return out, nil
+					return out[:max], nil
 				}
 			}
 		}
+	} else if firstReadErr == nil {
+		firstReadErr = fmt.Errorf("redfish: managers: %w", err)
 	}
 
-	// Chassis
 	if chassis, err := api.Service.Chassis(); err == nil {
 		for _, ch := range chassis {
 			if ch == nil {
 				continue
 			}
-			services, err := ch.LogServices()
-			if err != nil {
-				continue
-			}
-			for _, ls := range services {
-				if ls == nil {
-					continue
-				}
-				entries, err := ls.Entries()
-				if err != nil {
-					continue
-				}
-				appendEntries(ls.Name, entries)
+			if services, err := ch.LogServices(); err == nil {
+				readLogServices(services)
 				if len(out) >= max {
-					return out, nil
+					return out[:max], nil
 				}
 			}
 		}
+	} else if firstReadErr == nil {
+		firstReadErr = fmt.Errorf("redfish: chassis: %w", err)
 	}
 
+	if len(out) > max {
+		out = out[:max]
+	}
+
+	// Hard fail only when we could not return any entries and something went wrong
+	// reading entries from discovered log services, or system resolution failed with
+	// no other data path producing entries.
+	if len(out) == 0 {
+		if entryReadFail > 0 && logServicesSeen > 0 {
+			return nil, fmt.Errorf("redfish: log entry reads failed (%d services, %d read errors): %w",
+				logServicesSeen, entryReadFail, firstReadErr)
+		}
+		// systemID explicitly requested but system missing and no entries elsewhere
+		if systemID != "" && sysErr != nil {
+			return nil, fmt.Errorf("redfish: list SEL: %w", sysErr)
+		}
+	}
 	return out, nil
 }
 
@@ -155,7 +179,6 @@ func parseRedfishTime(s string) time.Time {
 	if s == "" {
 		return time.Time{}
 	}
-	// Common Redfish formats
 	layouts := []string{
 		time.RFC3339Nano,
 		time.RFC3339,
@@ -172,18 +195,19 @@ func parseRedfishTime(s string) time.Time {
 }
 
 // ListSensors collects temperature, fan, and voltage samples from chassis Thermal/Power.
-// Best-effort: skips chassis/subresources that are missing or error.
+//
+// Chassis collection failure is an error. Missing Thermal/Power on a chassis is soft
+// (skipped). Empty chassis or empty sensors with successful enumeration is OK.
 func (c *client) ListSensors(ctx context.Context, systemID string) ([]SensorSample, error) {
 	_ = ctx
-	_ = systemID // chassis list is global for multi-node sushy; filter later if needed
+	_ = systemID
 	api, err := c.apiClient()
 	if err != nil {
 		return nil, err
 	}
 	chassis, err := api.Service.Chassis()
 	if err != nil {
-		// No chassis collection → empty sensors, not hard failure for Observe poll.
-		return nil, nil
+		return nil, fmt.Errorf("redfish: chassis for sensors: %w", err)
 	}
 	var out []SensorSample
 	for _, ch := range chassis {

--- a/internal/core/reconcile/reconcile.go
+++ b/internal/core/reconcile/reconcile.go
@@ -244,23 +244,87 @@ func truncateRunes(s string, n int) string {
 	return s[:n] + "…"
 }
 
-// ReconcileEvent is a minimal text event normalizer for later Observe use.
+// ReconcileEvent normalizes Observe SEL/sensor/SOL text (deterministic-first).
+// Phase 4: keyword severity/component; full AI event path remains optional later.
 func (s *Service) ReconcileEvent(ctx context.Context, in models.RawEventInput) (models.NormalizedEvent, error) {
+	_ = ctx
 	if in.Raw != nil && redact.ContainsSensitiveKey(in.Raw) {
 		return models.NormalizedEvent{}, fmt.Errorf("reconcile: event raw still contains sensitive keys")
 	}
-	// Phase 3: deterministic pass-through; AI event path expands in Phase 4.
+	msg := strings.TrimSpace(in.Message)
+	src := strings.TrimSpace(in.Source)
+	if src == "" {
+		src = "sel"
+	}
+	sev, component := classifyEventText(msg, in.Raw)
+	ts := in.Timestamp
+	if ts.IsZero() {
+		ts = time.Now().UTC()
+	}
 	ev := models.NormalizedEvent{
 		DeviceID:  in.DeviceID,
-		EventType: in.Source,
-		Severity:  "info",
-		Message:   in.Message,
-		Timestamp: in.Timestamp,
+		EventType: src,
+		Severity:  sev,
+		Component: component,
+		Message:   msg,
+		Timestamp: ts,
 	}
 	if err := validate.NormalizedEvent(ev); err != nil {
 		return models.NormalizedEvent{}, err
 	}
 	return ev, nil
+}
+
+func classifyEventText(msg string, raw map[string]any) (severity, component string) {
+	severity = "info"
+	lower := strings.ToLower(msg)
+	switch {
+	case strings.Contains(lower, "critical"), strings.Contains(lower, "fatal"),
+		strings.Contains(lower, "failure"), strings.Contains(lower, "failed"),
+		strings.Contains(lower, "assert"):
+		severity = "critical"
+	case strings.Contains(lower, "warning"), strings.Contains(lower, "degraded"),
+		strings.Contains(lower, "throttle"), strings.Contains(lower, "predictive"):
+		severity = "warning"
+	case strings.Contains(lower, "error"):
+		severity = "error"
+	}
+	if raw != nil {
+		if s, ok := raw["severity"].(string); ok && strings.TrimSpace(s) != "" {
+			// Prefer structured BMC severity when present.
+			switch strings.ToLower(strings.TrimSpace(s)) {
+			case "critical", "warning", "ok", "info", "error":
+				if strings.EqualFold(s, "ok") {
+					severity = "info"
+				} else {
+					severity = strings.ToLower(s)
+				}
+			}
+		}
+		if c, ok := raw["sensor_type"].(string); ok && strings.TrimSpace(c) != "" {
+			component = strings.TrimSpace(c)
+		}
+		if c, ok := raw["component"].(string); ok && strings.TrimSpace(c) != "" {
+			component = strings.TrimSpace(c)
+		}
+	}
+	if component == "" {
+		switch {
+		case strings.Contains(lower, "temp"), strings.Contains(lower, "thermal"):
+			component = "thermal"
+		case strings.Contains(lower, "fan"):
+			component = "fan"
+		case strings.Contains(lower, "power"), strings.Contains(lower, "psu"), strings.Contains(lower, "voltage"):
+			component = "power"
+		case strings.Contains(lower, "memory"), strings.Contains(lower, "dimm"):
+			component = "memory"
+		case strings.Contains(lower, "cpu"), strings.Contains(lower, "processor"):
+			component = "cpu"
+		case strings.Contains(lower, "disk"), strings.Contains(lower, "drive"), strings.Contains(lower, "storage"):
+			component = "storage"
+		}
+	}
+	return severity, component
 }
 
 var _ Reconciler = (*Service)(nil)

--- a/internal/core/reconcile/reconcile_test.go
+++ b/internal/core/reconcile/reconcile_test.go
@@ -183,3 +183,25 @@ func TestReconcileEventPassThrough(t *testing.T) {
 		t.Fatalf("%+v", ev)
 	}
 }
+
+func TestReconcileEventClassifiesSeverity(t *testing.T) {
+	svc, err := reconcile.New(&ai.Fake{}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ev, err := svc.ReconcileEvent(context.Background(), models.RawEventInput{
+		DeviceID: "d1",
+		Source:   "sel",
+		Message:  "CPU thermal warning on inlet",
+		Raw:      map[string]any{"severity": "Warning", "sensor_type": "Temperature"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ev.Severity != "warning" {
+		t.Fatalf("severity=%q", ev.Severity)
+	}
+	if ev.Component != "Temperature" {
+		t.Fatalf("component=%q", ev.Component)
+	}
+}

--- a/internal/observe/poll/normalize.go
+++ b/internal/observe/poll/normalize.go
@@ -1,0 +1,83 @@
+package poll
+
+import (
+	"strings"
+	"time"
+
+	"github.com/mattcburns/shoal/internal/common/models"
+	"github.com/mattcburns/shoal/internal/common/redfish"
+)
+
+// normalizeSELEntry is the single deterministic SEL → NormalizedEvent path used
+// when no Core Reconciler is injected (and as the baseline mapping).
+func normalizeSELEntry(deviceID string, e redfish.SELEntry) models.NormalizedEvent {
+	msg := strings.TrimSpace(e.Message)
+	if msg == "" {
+		msg = e.ID
+	}
+	if msg == "" {
+		msg = "sel-entry"
+	}
+	sev := mapSELSeverity(e.Severity, msg)
+	comp := strings.TrimSpace(e.SensorType)
+	if comp == "" {
+		comp = componentFromMessage(msg)
+	}
+	ts := e.Created
+	if ts.IsZero() {
+		ts = time.Now().UTC()
+	}
+	return models.NormalizedEvent{
+		DeviceID:  deviceID,
+		EventType: "sel",
+		Severity:  sev,
+		Component: comp,
+		Message:   msg,
+		Timestamp: ts,
+	}
+}
+
+func mapSELSeverity(bmcSev, msg string) string {
+	switch strings.ToLower(strings.TrimSpace(bmcSev)) {
+	case "critical":
+		return "critical"
+	case "warning":
+		return "warning"
+	case "error":
+		return "error"
+	case "ok", "info", "informational":
+		return "info"
+	}
+	lower := strings.ToLower(msg)
+	switch {
+	case strings.Contains(lower, "critical"), strings.Contains(lower, "fatal"),
+		strings.Contains(lower, "failure"), strings.Contains(lower, "failed"):
+		return "critical"
+	case strings.Contains(lower, "warning"), strings.Contains(lower, "degraded"):
+		return "warning"
+	case strings.Contains(lower, "error"):
+		return "error"
+	default:
+		return "info"
+	}
+}
+
+func componentFromMessage(msg string) string {
+	lower := strings.ToLower(msg)
+	switch {
+	case strings.Contains(lower, "temp"), strings.Contains(lower, "thermal"):
+		return "thermal"
+	case strings.Contains(lower, "fan"):
+		return "fan"
+	case strings.Contains(lower, "power"), strings.Contains(lower, "psu"), strings.Contains(lower, "voltage"):
+		return "power"
+	case strings.Contains(lower, "memory"), strings.Contains(lower, "dimm"):
+		return "memory"
+	case strings.Contains(lower, "cpu"), strings.Contains(lower, "processor"):
+		return "cpu"
+	case strings.Contains(lower, "disk"), strings.Contains(lower, "drive"):
+		return "storage"
+	default:
+		return ""
+	}
+}

--- a/internal/observe/poll/poller.go
+++ b/internal/observe/poll/poller.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"strings"
 	"sync"
 	"time"
 
@@ -37,11 +36,12 @@ type WatchChecker interface {
 
 // Poller reads SEL/sensors via Redfish and writes telemetry.
 type Poller struct {
-	Log      *slog.Logger
-	Store    telemetry.Store
-	NewBMC   redfish.Factory
-	Events   reconcile.Reconciler // optional; deterministic path if nil
-	Watching WatchChecker         // optional
+	Log    *slog.Logger
+	Store  telemetry.Store
+	NewBMC redfish.Factory
+	// Events is optional Core reconciler; when nil, deterministic normalizeSELEntry is used.
+	Events   reconcile.Reconciler
+	Watching WatchChecker
 
 	IdleInterval  time.Duration
 	WatchInterval time.Duration
@@ -49,12 +49,12 @@ type Poller struct {
 	SELMaxEntries int
 
 	mu      sync.Mutex
-	targets map[string]Target // deviceID -> target
+	targets map[string]Target
 	seenSEL map[string]map[string]struct{}
 	sem     chan struct{}
 }
 
-// New constructs a Poller with defaults.
+// New constructs a Poller with defaults. newBMC nil → redfish.NewBMC.
 func New(log *slog.Logger, store telemetry.Store, newBMC redfish.Factory) *Poller {
 	if log == nil {
 		log = slog.Default()
@@ -113,6 +113,8 @@ func (p *Poller) Targets() []Target {
 }
 
 // PollOnce runs a single SEL+sensor poll for one target (deduped SEL writes).
+// Returns a non-nil error if Redfish fails or any normalize/write fails (counts
+// still reflect successful writes). Empty SEL/sensors with nil error is valid.
 func (p *Poller) PollOnce(ctx context.Context, t Target) (selWritten, sensorsWritten int, err error) {
 	if p.Store == nil {
 		return 0, 0, fmt.Errorf("poll: telemetry store not configured")
@@ -163,6 +165,9 @@ func (p *Poller) PollOnce(ctx context.Context, t Target) (selWritten, sensorsWri
 	seen := p.seenSEL[t.DeviceID]
 	p.mu.Unlock()
 
+	var failN int
+	var firstFail error
+
 	for _, e := range entries {
 		key := e.ODataID
 		if key == "" {
@@ -179,10 +184,18 @@ func (p *Poller) PollOnce(ctx context.Context, t Target) (selWritten, sensorsWri
 		}
 		ev, nerr := p.normalizeSEL(ctx, t.DeviceID, e)
 		if nerr != nil {
+			failN++
+			if firstFail == nil {
+				firstFail = fmt.Errorf("normalize: %w", nerr)
+			}
 			p.Log.Warn("poll normalize sel", "device_id", t.DeviceID, "err", nerr.Error())
 			continue
 		}
 		if err := p.Store.WriteEvent(ctx, ev); err != nil {
+			failN++
+			if firstFail == nil {
+				firstFail = fmt.Errorf("write event: %w", err)
+			}
 			p.Log.Warn("poll write event", "device_id", t.DeviceID, "err", err.Error())
 			continue
 		}
@@ -196,6 +209,10 @@ func (p *Poller) PollOnce(ctx context.Context, t Target) (selWritten, sensorsWri
 			name = s.Kind
 		}
 		if name == "" {
+			failN++
+			if firstFail == nil {
+				firstFail = fmt.Errorf("sensor sample missing name")
+			}
 			continue
 		}
 		if err := p.Store.WriteSensor(ctx, telemetry.SensorReading{
@@ -205,72 +222,53 @@ func (p *Poller) PollOnce(ctx context.Context, t Target) (selWritten, sensorsWri
 			Value:    s.Reading,
 			Unit:     s.Units,
 		}); err != nil {
+			failN++
+			if firstFail == nil {
+				firstFail = fmt.Errorf("write sensor: %w", err)
+			}
 			p.Log.Warn("poll write sensor", "device_id", t.DeviceID, "err", err.Error())
 			continue
 		}
 		sensorsWritten++
 	}
-	if selWritten > 0 || sensorsWritten > 0 {
-		p.Log.Info("poll complete",
-			"device_id", t.DeviceID,
-			"sel_new", selWritten,
-			"sensors", sensorsWritten,
-		)
+
+	p.Log.Info("poll complete",
+		"device_id", t.DeviceID,
+		"sel_new", selWritten,
+		"sensors", sensorsWritten,
+		"failures", failN,
+		"sel_seen", len(entries),
+		"sensor_seen", len(samples),
+	)
+	if failN > 0 {
+		return selWritten, sensorsWritten, fmt.Errorf("poll: %d item failure(s) after sel_new=%d sensors=%d: %w",
+			failN, selWritten, sensorsWritten, firstFail)
 	}
 	return selWritten, sensorsWritten, nil
 }
 
 func (p *Poller) normalizeSEL(ctx context.Context, deviceID string, e redfish.SELEntry) (models.NormalizedEvent, error) {
-	msg := e.Message
-	if msg == "" {
-		msg = e.ID
-	}
-	raw := map[string]any{
-		"severity":    e.Severity,
-		"entry_type":  e.EntryType,
-		"sensor_type": e.SensorType,
-		"log_service": e.LogService,
-		"odata_id":    e.ODataID,
-	}
-	in := models.RawEventInput{
-		DeviceID:  deviceID,
-		Source:    "sel",
-		Timestamp: e.Created,
-		Message:   msg,
-		Raw:       raw,
-	}
 	if p.Events != nil {
-		return p.Events.ReconcileEvent(ctx, in)
-	}
-	// Inline deterministic fallback (no Core wired).
-	sev := "info"
-	switch strings.ToLower(e.Severity) {
-	case "critical":
-		sev = "critical"
-	case "warning":
-		sev = "warning"
-	case "error":
-		sev = "error"
-	case "ok", "":
-		sev = "info"
-	default:
-		sev = strings.ToLower(e.Severity)
-		if sev == "" {
-			sev = "info"
+		raw := map[string]any{
+			"severity":    e.Severity,
+			"entry_type":  e.EntryType,
+			"sensor_type": e.SensorType,
+			"log_service": e.LogService,
+			"odata_id":    e.ODataID,
 		}
+		msg := e.Message
+		if msg == "" {
+			msg = e.ID
+		}
+		return p.Events.ReconcileEvent(ctx, models.RawEventInput{
+			DeviceID:  deviceID,
+			Source:    "sel",
+			Timestamp: e.Created,
+			Message:   msg,
+			Raw:       raw,
+		})
 	}
-	ts := e.Created
-	if ts.IsZero() {
-		ts = time.Now().UTC()
-	}
-	return models.NormalizedEvent{
-		DeviceID:  deviceID,
-		EventType: "sel",
-		Severity:  sev,
-		Component: e.SensorType,
-		Message:   msg,
-		Timestamp: ts,
-	}, nil
+	return normalizeSELEntry(deviceID, e), nil
 }
 
 // Run loops until ctx is cancelled. Polls all targets; uses WatchInterval when
@@ -282,7 +280,6 @@ func (p *Poller) Run(ctx context.Context) {
 	if p.WatchInterval <= 0 {
 		p.WatchInterval = DefaultWatchInterval
 	}
-	// Tick frequently enough to honor watch elevated rate; skip devices not due yet.
 	ticker := time.NewTicker(p.WatchInterval)
 	defer ticker.Stop()
 	last := make(map[string]time.Time)

--- a/internal/observe/poll/poller.go
+++ b/internal/observe/poll/poller.go
@@ -1,0 +1,329 @@
+// Package poll implements SEL/sensor polling for Observe (Phase 4).
+package poll
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/mattcburns/shoal/internal/common/models"
+	"github.com/mattcburns/shoal/internal/common/redfish"
+	"github.com/mattcburns/shoal/internal/common/telemetry"
+	"github.com/mattcburns/shoal/internal/core/reconcile"
+)
+
+// Default idle vs watch-elevated intervals.
+const (
+	DefaultIdleInterval  = 60 * time.Second
+	DefaultWatchInterval = 15 * time.Second
+	DefaultMaxConcurrent = 1
+	DefaultSELMaxEntries = 100
+)
+
+// Target is one device BMC to poll.
+type Target struct {
+	DeviceID string
+	BMC      redfish.Config
+	SystemID string // optional; empty = first/single system
+}
+
+// WatchChecker reports whether a device has an active SOL watch (elevated rate).
+type WatchChecker interface {
+	HasWatch(deviceID string) bool
+}
+
+// Poller reads SEL/sensors via Redfish and writes telemetry.
+type Poller struct {
+	Log      *slog.Logger
+	Store    telemetry.Store
+	NewBMC   redfish.Factory
+	Events   reconcile.Reconciler // optional; deterministic path if nil
+	Watching WatchChecker         // optional
+
+	IdleInterval  time.Duration
+	WatchInterval time.Duration
+	MaxConcurrent int
+	SELMaxEntries int
+
+	mu      sync.Mutex
+	targets map[string]Target // deviceID -> target
+	seenSEL map[string]map[string]struct{}
+	sem     chan struct{}
+}
+
+// New constructs a Poller with defaults.
+func New(log *slog.Logger, store telemetry.Store, newBMC redfish.Factory) *Poller {
+	if log == nil {
+		log = slog.Default()
+	}
+	if newBMC == nil {
+		newBMC = redfish.NewBMC
+	}
+	p := &Poller{
+		Log:           log,
+		Store:         store,
+		NewBMC:        newBMC,
+		IdleInterval:  DefaultIdleInterval,
+		WatchInterval: DefaultWatchInterval,
+		MaxConcurrent: DefaultMaxConcurrent,
+		SELMaxEntries: DefaultSELMaxEntries,
+		targets:       make(map[string]Target),
+		seenSEL:       make(map[string]map[string]struct{}),
+	}
+	p.sem = make(chan struct{}, p.MaxConcurrent)
+	return p
+}
+
+// SetTarget adds or replaces a poll target.
+func (p *Poller) SetTarget(t Target) error {
+	if t.DeviceID == "" {
+		return fmt.Errorf("poll: device_id required")
+	}
+	if t.BMC.BaseURL == "" {
+		return fmt.Errorf("poll: bmc base url required")
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.targets[t.DeviceID] = t
+	if p.seenSEL[t.DeviceID] == nil {
+		p.seenSEL[t.DeviceID] = make(map[string]struct{})
+	}
+	return nil
+}
+
+// RemoveTarget drops a device from the poll set.
+func (p *Poller) RemoveTarget(deviceID string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	delete(p.targets, deviceID)
+}
+
+// Targets returns a snapshot of configured targets.
+func (p *Poller) Targets() []Target {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	out := make([]Target, 0, len(p.targets))
+	for _, t := range p.targets {
+		out = append(out, t)
+	}
+	return out
+}
+
+// PollOnce runs a single SEL+sensor poll for one target (deduped SEL writes).
+func (p *Poller) PollOnce(ctx context.Context, t Target) (selWritten, sensorsWritten int, err error) {
+	if p.Store == nil {
+		return 0, 0, fmt.Errorf("poll: telemetry store not configured")
+	}
+	if t.DeviceID == "" || t.BMC.BaseURL == "" {
+		return 0, 0, fmt.Errorf("poll: incomplete target")
+	}
+	if p.MaxConcurrent <= 0 {
+		p.MaxConcurrent = DefaultMaxConcurrent
+	}
+	if p.sem == nil {
+		p.sem = make(chan struct{}, p.MaxConcurrent)
+	}
+
+	select {
+	case p.sem <- struct{}{}:
+		defer func() { <-p.sem }()
+	case <-ctx.Done():
+		return 0, 0, ctx.Err()
+	}
+
+	bmc, err := p.NewBMC(t.BMC)
+	if err != nil {
+		return 0, 0, fmt.Errorf("poll: bmc: %w", err)
+	}
+	if err := bmc.Open(ctx); err != nil {
+		return 0, 0, fmt.Errorf("poll: open: %w", err)
+	}
+	defer func() { _ = bmc.Close(context.Background()) }()
+
+	maxSEL := p.SELMaxEntries
+	if maxSEL <= 0 {
+		maxSEL = DefaultSELMaxEntries
+	}
+	entries, err := bmc.ListSEL(ctx, t.SystemID, redfish.SELOptions{MaxEntries: maxSEL})
+	if err != nil {
+		return 0, 0, fmt.Errorf("poll: list sel: %w", err)
+	}
+	samples, err := bmc.ListSensors(ctx, t.SystemID)
+	if err != nil {
+		return 0, 0, fmt.Errorf("poll: list sensors: %w", err)
+	}
+
+	p.mu.Lock()
+	if p.seenSEL[t.DeviceID] == nil {
+		p.seenSEL[t.DeviceID] = make(map[string]struct{})
+	}
+	seen := p.seenSEL[t.DeviceID]
+	p.mu.Unlock()
+
+	for _, e := range entries {
+		key := e.ODataID
+		if key == "" {
+			key = e.ID + "|" + e.Message + "|" + e.Created.UTC().Format(time.RFC3339Nano)
+		}
+		p.mu.Lock()
+		_, already := seen[key]
+		if !already {
+			seen[key] = struct{}{}
+		}
+		p.mu.Unlock()
+		if already {
+			continue
+		}
+		ev, nerr := p.normalizeSEL(ctx, t.DeviceID, e)
+		if nerr != nil {
+			p.Log.Warn("poll normalize sel", "device_id", t.DeviceID, "err", nerr.Error())
+			continue
+		}
+		if err := p.Store.WriteEvent(ctx, ev); err != nil {
+			p.Log.Warn("poll write event", "device_id", t.DeviceID, "err", err.Error())
+			continue
+		}
+		selWritten++
+	}
+
+	now := time.Now().UTC()
+	for _, s := range samples {
+		name := s.Name
+		if name == "" {
+			name = s.Kind
+		}
+		if name == "" {
+			continue
+		}
+		if err := p.Store.WriteSensor(ctx, telemetry.SensorReading{
+			DeviceID: t.DeviceID,
+			TS:       now,
+			Sensor:   name,
+			Value:    s.Reading,
+			Unit:     s.Units,
+		}); err != nil {
+			p.Log.Warn("poll write sensor", "device_id", t.DeviceID, "err", err.Error())
+			continue
+		}
+		sensorsWritten++
+	}
+	if selWritten > 0 || sensorsWritten > 0 {
+		p.Log.Info("poll complete",
+			"device_id", t.DeviceID,
+			"sel_new", selWritten,
+			"sensors", sensorsWritten,
+		)
+	}
+	return selWritten, sensorsWritten, nil
+}
+
+func (p *Poller) normalizeSEL(ctx context.Context, deviceID string, e redfish.SELEntry) (models.NormalizedEvent, error) {
+	msg := e.Message
+	if msg == "" {
+		msg = e.ID
+	}
+	raw := map[string]any{
+		"severity":    e.Severity,
+		"entry_type":  e.EntryType,
+		"sensor_type": e.SensorType,
+		"log_service": e.LogService,
+		"odata_id":    e.ODataID,
+	}
+	in := models.RawEventInput{
+		DeviceID:  deviceID,
+		Source:    "sel",
+		Timestamp: e.Created,
+		Message:   msg,
+		Raw:       raw,
+	}
+	if p.Events != nil {
+		return p.Events.ReconcileEvent(ctx, in)
+	}
+	// Inline deterministic fallback (no Core wired).
+	sev := "info"
+	switch strings.ToLower(e.Severity) {
+	case "critical":
+		sev = "critical"
+	case "warning":
+		sev = "warning"
+	case "error":
+		sev = "error"
+	case "ok", "":
+		sev = "info"
+	default:
+		sev = strings.ToLower(e.Severity)
+		if sev == "" {
+			sev = "info"
+		}
+	}
+	ts := e.Created
+	if ts.IsZero() {
+		ts = time.Now().UTC()
+	}
+	return models.NormalizedEvent{
+		DeviceID:  deviceID,
+		EventType: "sel",
+		Severity:  sev,
+		Component: e.SensorType,
+		Message:   msg,
+		Timestamp: ts,
+	}, nil
+}
+
+// Run loops until ctx is cancelled. Polls all targets; uses WatchInterval when
+// Watching.HasWatch(device) is true.
+func (p *Poller) Run(ctx context.Context) {
+	if p.IdleInterval <= 0 {
+		p.IdleInterval = DefaultIdleInterval
+	}
+	if p.WatchInterval <= 0 {
+		p.WatchInterval = DefaultWatchInterval
+	}
+	// Tick frequently enough to honor watch elevated rate; skip devices not due yet.
+	ticker := time.NewTicker(p.WatchInterval)
+	defer ticker.Stop()
+	last := make(map[string]time.Time)
+
+	pollAll := func() {
+		for _, t := range p.Targets() {
+			interval := p.IdleInterval
+			if p.Watching != nil && p.Watching.HasWatch(t.DeviceID) {
+				interval = p.WatchInterval
+			}
+			if t0, ok := last[t.DeviceID]; ok && time.Since(t0) < interval {
+				continue
+			}
+			if _, _, err := p.PollOnce(ctx, t); err != nil && ctx.Err() == nil {
+				p.Log.Warn("poll once failed", "device_id", t.DeviceID, "err", err.Error())
+			}
+			last[t.DeviceID] = time.Now()
+		}
+	}
+
+	pollAll()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			pollAll()
+		}
+	}
+}
+
+// IntervalFor returns the poll interval that would apply for deviceID.
+func (p *Poller) IntervalFor(deviceID string) time.Duration {
+	if p.Watching != nil && p.Watching.HasWatch(deviceID) {
+		if p.WatchInterval > 0 {
+			return p.WatchInterval
+		}
+		return DefaultWatchInterval
+	}
+	if p.IdleInterval > 0 {
+		return p.IdleInterval
+	}
+	return DefaultIdleInterval
+}

--- a/internal/observe/poll/poller_test.go
+++ b/internal/observe/poll/poller_test.go
@@ -7,8 +7,6 @@ import (
 
 	"github.com/mattcburns/shoal/internal/common/redfish"
 	"github.com/mattcburns/shoal/internal/common/telemetry"
-	"github.com/mattcburns/shoal/internal/core/ai"
-	"github.com/mattcburns/shoal/internal/core/reconcile"
 	"github.com/mattcburns/shoal/internal/observe/poll"
 )
 
@@ -27,12 +25,8 @@ func TestPollOnceWritesSELAndSensors(t *testing.T) {
 	fake.Sensors = []redfish.SensorSample{
 		{Name: "Inlet", Reading: 23, Units: "Cel", Kind: "temperature"},
 	}
-	rec, err := reconcile.New(&ai.Fake{}, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	// Deterministic path — no Core / no Fake AI.
 	p := poll.New(nil, store, func(redfish.Config) (redfish.BMC, error) { return fake, nil })
-	p.Events = rec
 
 	selN, sensN, err := p.PollOnce(context.Background(), poll.Target{
 		DeviceID: "dev-1",
@@ -47,7 +41,6 @@ func TestPollOnceWritesSELAndSensors(t *testing.T) {
 	if sensN != 1 {
 		t.Fatalf("sensors=%d", sensN)
 	}
-	// second poll: no new SEL
 	selN, _, err = p.PollOnce(context.Background(), poll.Target{
 		DeviceID: "dev-1",
 		BMC:      redfish.Config{BaseURL: "http://fake"},
@@ -65,8 +58,19 @@ func TestPollOnceWritesSELAndSensors(t *testing.T) {
 	if evs[0].Severity != "warning" {
 		t.Fatalf("severity=%q", evs[0].Severity)
 	}
-	if evs[0].Component != "Temperature" && evs[0].Component != "thermal" {
+	if evs[0].Component != "Temperature" {
 		t.Fatalf("component=%q", evs[0].Component)
+	}
+}
+
+func TestPollOnceSurfacesWriteFailures(t *testing.T) {
+	// nil store → hard error
+	p := poll.New(nil, nil, func(redfish.Config) (redfish.BMC, error) { return redfish.NewFake(), nil })
+	_, _, err := p.PollOnce(context.Background(), poll.Target{
+		DeviceID: "d", BMC: redfish.Config{BaseURL: "http://x"},
+	})
+	if err == nil {
+		t.Fatal("expected error without store")
 	}
 }
 

--- a/internal/observe/poll/poller_test.go
+++ b/internal/observe/poll/poller_test.go
@@ -1,0 +1,84 @@
+package poll_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/mattcburns/shoal/internal/common/redfish"
+	"github.com/mattcburns/shoal/internal/common/telemetry"
+	"github.com/mattcburns/shoal/internal/core/ai"
+	"github.com/mattcburns/shoal/internal/core/reconcile"
+	"github.com/mattcburns/shoal/internal/observe/poll"
+)
+
+type watchMap map[string]bool
+
+func (w watchMap) HasWatch(id string) bool { return w[id] }
+
+func TestPollOnceWritesSELAndSensors(t *testing.T) {
+	store := telemetry.NewMemory()
+	fake := redfish.NewFake()
+	ts := time.Now().UTC()
+	fake.SEL = []redfish.SELEntry{
+		{ID: "1", Message: "CPU thermal warning", Severity: "Warning", SensorType: "Temperature", Created: ts, ODataID: "/e/1"},
+		{ID: "1", Message: "CPU thermal warning", Severity: "Warning", SensorType: "Temperature", Created: ts, ODataID: "/e/1"}, // dup
+	}
+	fake.Sensors = []redfish.SensorSample{
+		{Name: "Inlet", Reading: 23, Units: "Cel", Kind: "temperature"},
+	}
+	rec, err := reconcile.New(&ai.Fake{}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p := poll.New(nil, store, func(redfish.Config) (redfish.BMC, error) { return fake, nil })
+	p.Events = rec
+
+	selN, sensN, err := p.PollOnce(context.Background(), poll.Target{
+		DeviceID: "dev-1",
+		BMC:      redfish.Config{BaseURL: "http://fake"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if selN != 1 {
+		t.Fatalf("sel written=%d want 1 (dedup)", selN)
+	}
+	if sensN != 1 {
+		t.Fatalf("sensors=%d", sensN)
+	}
+	// second poll: no new SEL
+	selN, _, err = p.PollOnce(context.Background(), poll.Target{
+		DeviceID: "dev-1",
+		BMC:      redfish.Config{BaseURL: "http://fake"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if selN != 0 {
+		t.Fatalf("second poll sel=%d", selN)
+	}
+	evs, _ := store.ListEvents(context.Background(), "dev-1", time.Time{}, 10)
+	if len(evs) != 1 {
+		t.Fatalf("events=%d", len(evs))
+	}
+	if evs[0].Severity != "warning" {
+		t.Fatalf("severity=%q", evs[0].Severity)
+	}
+	if evs[0].Component != "Temperature" && evs[0].Component != "thermal" {
+		t.Fatalf("component=%q", evs[0].Component)
+	}
+}
+
+func TestIntervalElevatedWhenWatching(t *testing.T) {
+	p := poll.New(nil, telemetry.NewMemory(), nil)
+	p.IdleInterval = time.Minute
+	p.WatchInterval = 10 * time.Second
+	p.Watching = watchMap{"d1": true}
+	if p.IntervalFor("d1") != 10*time.Second {
+		t.Fatal(p.IntervalFor("d1"))
+	}
+	if p.IntervalFor("other") != time.Minute {
+		t.Fatal(p.IntervalFor("other"))
+	}
+}

--- a/internal/observe/service.go
+++ b/internal/observe/service.go
@@ -1,0 +1,176 @@
+// Package observe aggregates device status and owns poll/SOL surfaces.
+package observe
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/mattcburns/shoal/internal/common/jobport"
+	"github.com/mattcburns/shoal/internal/common/models"
+	"github.com/mattcburns/shoal/internal/common/redfish"
+	"github.com/mattcburns/shoal/internal/common/telemetry"
+	"github.com/mattcburns/shoal/internal/observe/poll"
+	"github.com/mattcburns/shoal/internal/observe/sol"
+)
+
+// WatchState reports active SOL ownership (implemented by sol.WatchService).
+type WatchState interface {
+	HasWatch(deviceID string) bool
+}
+
+// Service builds DeviceStatus and optional event listings for operators.
+type Service struct {
+	Log       *slog.Logger
+	Jobs      jobport.JobQuery
+	Telemetry telemetry.Store
+	Watches   WatchState
+	// Optional one-shot poller for live refresh during status.
+	Poller *poll.Poller
+}
+
+// New constructs an Observe service.
+func New(log *slog.Logger, jobs jobport.JobQuery, store telemetry.Store, watches WatchState) *Service {
+	if log == nil {
+		log = slog.Default()
+	}
+	return &Service{Log: log, Jobs: jobs, Telemetry: store, Watches: watches}
+}
+
+// Status aggregates job + telemetry + optional watch flag for a device.
+func (s *Service) Status(ctx context.Context, deviceID string) (models.DeviceStatus, error) {
+	if deviceID == "" {
+		return models.DeviceStatus{}, fmt.Errorf("observe: device_id required")
+	}
+	st := models.DeviceStatus{
+		DeviceID:  deviceID,
+		UpdatedAt: time.Now().UTC(),
+	}
+
+	if job, ok := s.latestJob(ctx, deviceID); ok {
+		st.LifecycleState = job.State
+		st.ActiveJobID = job.ID
+		st.Phase = job.Phase
+		st.Percent = job.Percent
+		if job.UpdatedAt != nil {
+			st.UpdatedAt = job.UpdatedAt.UTC()
+		}
+		if job.Error != "" && st.LastEvent == "" {
+			st.LastEvent = job.Error
+		}
+	}
+
+	if s.Telemetry != nil {
+		evs, err := s.Telemetry.ListEvents(ctx, deviceID, time.Time{}, 1)
+		if err != nil {
+			s.Log.Warn("list events for status", "device_id", deviceID, "err", err.Error())
+		} else if len(evs) > 0 {
+			st.LastEvent = formatEvent(evs[0])
+			if evs[0].Timestamp.After(st.UpdatedAt) {
+				st.UpdatedAt = evs[0].Timestamp
+			}
+		}
+	}
+
+	if s.Watches != nil && s.Watches.HasWatch(deviceID) {
+		// Encode watch activity in last_event suffix only if empty phase context.
+		if st.Phase == "" && st.ActiveJobID != "" {
+			st.Phase = "WATCHING"
+		}
+	}
+
+	return st, nil
+}
+
+// StatusWithPower optionally fills PowerState via Redfish GetSystem.
+func (s *Service) StatusWithPower(ctx context.Context, deviceID string, bmc redfish.BMC, systemID string) (models.DeviceStatus, error) {
+	st, err := s.Status(ctx, deviceID)
+	if err != nil {
+		return st, err
+	}
+	if bmc == nil {
+		return st, nil
+	}
+	sys, err := bmc.GetSystem(ctx, systemID)
+	if err != nil {
+		s.Log.Warn("power state", "device_id", deviceID, "err", err.Error())
+		return st, nil
+	}
+	st.PowerState = sys.PowerState
+	return st, nil
+}
+
+// ListEvents returns recent telemetry events for a device.
+func (s *Service) ListEvents(ctx context.Context, deviceID string, since time.Time, limit int) ([]models.NormalizedEvent, error) {
+	if s.Telemetry == nil {
+		return nil, fmt.Errorf("observe: telemetry store not configured")
+	}
+	if deviceID == "" {
+		return nil, fmt.Errorf("observe: device_id required")
+	}
+	return s.Telemetry.ListEvents(ctx, deviceID, since, limit)
+}
+
+func (s *Service) latestJob(ctx context.Context, deviceID string) (models.ProvisioningJob, bool) {
+	if s.Jobs == nil {
+		return models.ProvisioningJob{}, false
+	}
+	// Prefer active provisioning; else most recently updated job for device.
+	states := []models.LifecycleState{
+		models.StateProvisioning,
+		models.StateProvisioned,
+		models.StateFailed,
+		models.StateReady,
+		models.StateDiscovered,
+	}
+	var best models.ProvisioningJob
+	var found bool
+	for _, st := range states {
+		list, err := s.Jobs.ListByState(ctx, st)
+		if err != nil {
+			continue
+		}
+		for _, j := range list {
+			if j.DeviceID != deviceID {
+				continue
+			}
+			if !found {
+				best, found = j, true
+				continue
+			}
+			// Prefer PROVISIONING always when present.
+			if best.State != models.StateProvisioning && j.State == models.StateProvisioning {
+				best = j
+				continue
+			}
+			if best.State == models.StateProvisioning && j.State != models.StateProvisioning {
+				continue
+			}
+			bt, jt := time.Time{}, time.Time{}
+			if best.UpdatedAt != nil {
+				bt = *best.UpdatedAt
+			}
+			if j.UpdatedAt != nil {
+				jt = *j.UpdatedAt
+			}
+			if jt.After(bt) {
+				best = j
+			}
+		}
+		if found && best.State == models.StateProvisioning {
+			return best, true
+		}
+	}
+	return best, found
+}
+
+func formatEvent(e models.NormalizedEvent) string {
+	if e.Severity != "" && e.Message != "" {
+		return e.Severity + ": " + e.Message
+	}
+	return e.Message
+}
+
+// Ensure WatchService satisfies WatchState.
+var _ WatchState = (*sol.WatchService)(nil)

--- a/internal/observe/service.go
+++ b/internal/observe/service.go
@@ -11,7 +11,6 @@ import (
 	"github.com/mattcburns/shoal/internal/common/models"
 	"github.com/mattcburns/shoal/internal/common/redfish"
 	"github.com/mattcburns/shoal/internal/common/telemetry"
-	"github.com/mattcburns/shoal/internal/observe/poll"
 	"github.com/mattcburns/shoal/internal/observe/sol"
 )
 
@@ -24,10 +23,8 @@ type WatchState interface {
 type Service struct {
 	Log       *slog.Logger
 	Jobs      jobport.JobQuery
-	Telemetry telemetry.Store
+	Telemetry telemetry.Store // nil → no events in status / ListEvents errors
 	Watches   WatchState
-	// Optional one-shot poller for live refresh during status.
-	Poller *poll.Poller
 }
 
 // New constructs an Observe service.
@@ -38,7 +35,9 @@ func New(log *slog.Logger, jobs jobport.JobQuery, store telemetry.Store, watches
 	return &Service{Log: log, Jobs: jobs, Telemetry: store, Watches: watches}
 }
 
-// Status aggregates job + telemetry + optional watch flag for a device.
+// Status aggregates job + telemetry for a device.
+// ActiveJobID is set only when the latest job is PROVISIONING (truly active).
+// Does not invent SOL phases (e.g. no synthetic "WATCHING").
 func (s *Service) Status(ctx context.Context, deviceID string) (models.DeviceStatus, error) {
 	if deviceID == "" {
 		return models.DeviceStatus{}, fmt.Errorf("observe: device_id required")
@@ -50,13 +49,15 @@ func (s *Service) Status(ctx context.Context, deviceID string) (models.DeviceSta
 
 	if job, ok := s.latestJob(ctx, deviceID); ok {
 		st.LifecycleState = job.State
-		st.ActiveJobID = job.ID
 		st.Phase = job.Phase
 		st.Percent = job.Percent
+		if job.State == models.StateProvisioning {
+			st.ActiveJobID = job.ID
+		}
 		if job.UpdatedAt != nil {
 			st.UpdatedAt = job.UpdatedAt.UTC()
 		}
-		if job.Error != "" && st.LastEvent == "" {
+		if job.Error != "" {
 			st.LastEvent = job.Error
 		}
 	}
@@ -64,8 +65,10 @@ func (s *Service) Status(ctx context.Context, deviceID string) (models.DeviceSta
 	if s.Telemetry != nil {
 		evs, err := s.Telemetry.ListEvents(ctx, deviceID, time.Time{}, 1)
 		if err != nil {
-			s.Log.Warn("list events for status", "device_id", deviceID, "err", err.Error())
-		} else if len(evs) > 0 {
+			return st, fmt.Errorf("observe: list events: %w", err)
+		}
+		if len(evs) > 0 {
+			// Prefer telemetry message when present; keep job error if no events.
 			st.LastEvent = formatEvent(evs[0])
 			if evs[0].Timestamp.After(st.UpdatedAt) {
 				st.UpdatedAt = evs[0].Timestamp
@@ -73,29 +76,22 @@ func (s *Service) Status(ctx context.Context, deviceID string) (models.DeviceSta
 		}
 	}
 
-	if s.Watches != nil && s.Watches.HasWatch(deviceID) {
-		// Encode watch activity in last_event suffix only if empty phase context.
-		if st.Phase == "" && st.ActiveJobID != "" {
-			st.Phase = "WATCHING"
-		}
-	}
-
 	return st, nil
 }
 
-// StatusWithPower optionally fills PowerState via Redfish GetSystem.
+// StatusWithPower fills PowerState via Redfish GetSystem. BMC errors are returned
+// (caller must not treat missing power as success when power was requested).
 func (s *Service) StatusWithPower(ctx context.Context, deviceID string, bmc redfish.BMC, systemID string) (models.DeviceStatus, error) {
 	st, err := s.Status(ctx, deviceID)
 	if err != nil {
 		return st, err
 	}
 	if bmc == nil {
-		return st, nil
+		return st, fmt.Errorf("observe: bmc required for power state")
 	}
 	sys, err := bmc.GetSystem(ctx, systemID)
 	if err != nil {
-		s.Log.Warn("power state", "device_id", deviceID, "err", err.Error())
-		return st, nil
+		return st, fmt.Errorf("observe: power state: %w", err)
 	}
 	st.PowerState = sys.PowerState
 	return st, nil
@@ -104,7 +100,7 @@ func (s *Service) StatusWithPower(ctx context.Context, deviceID string, bmc redf
 // ListEvents returns recent telemetry events for a device.
 func (s *Service) ListEvents(ctx context.Context, deviceID string, since time.Time, limit int) ([]models.NormalizedEvent, error) {
 	if s.Telemetry == nil {
-		return nil, fmt.Errorf("observe: telemetry store not configured")
+		return nil, fmt.Errorf("observe: telemetry store not configured (set SHOAL_TELEMETRY_DATABASE_URL)")
 	}
 	if deviceID == "" {
 		return nil, fmt.Errorf("observe: device_id required")
@@ -112,11 +108,15 @@ func (s *Service) ListEvents(ctx context.Context, deviceID string, since time.Ti
 	return s.Telemetry.ListEvents(ctx, deviceID, since, limit)
 }
 
+// Watching reports whether a SOL watch is active (for operators; not embedded in Phase).
+func (s *Service) Watching(deviceID string) bool {
+	return s.Watches != nil && s.Watches.HasWatch(deviceID)
+}
+
 func (s *Service) latestJob(ctx context.Context, deviceID string) (models.ProvisioningJob, bool) {
 	if s.Jobs == nil {
 		return models.ProvisioningJob{}, false
 	}
-	// Prefer active provisioning; else most recently updated job for device.
 	states := []models.LifecycleState{
 		models.StateProvisioning,
 		models.StateProvisioned,
@@ -129,6 +129,7 @@ func (s *Service) latestJob(ctx context.Context, deviceID string) (models.Provis
 	for _, st := range states {
 		list, err := s.Jobs.ListByState(ctx, st)
 		if err != nil {
+			s.Log.Warn("list jobs by state", "state", string(st), "err", err.Error())
 			continue
 		}
 		for _, j := range list {
@@ -139,7 +140,6 @@ func (s *Service) latestJob(ctx context.Context, deviceID string) (models.Provis
 				best, found = j, true
 				continue
 			}
-			// Prefer PROVISIONING always when present.
 			if best.State != models.StateProvisioning && j.State == models.StateProvisioning {
 				best = j
 				continue
@@ -172,5 +172,4 @@ func formatEvent(e models.NormalizedEvent) string {
 	return e.Message
 }
 
-// Ensure WatchService satisfies WatchState.
 var _ WatchState = (*sol.WatchService)(nil)

--- a/internal/observe/service_test.go
+++ b/internal/observe/service_test.go
@@ -43,6 +43,31 @@ func TestStatusAggregatesJobAndEvents(t *testing.T) {
 	if st.LastEvent == "" || st.Percent == nil || *st.Percent != 40 {
 		t.Fatalf("%+v", st)
 	}
+	// Must not invent WATCHING phase
+	if st.Phase == "WATCHING" {
+		t.Fatal("must not invent WATCHING phase")
+	}
+}
+
+func TestStatusFailedJobNoActiveID(t *testing.T) {
+	jobs := jobstore.NewMemory()
+	ctx := context.Background()
+	now := time.Now().UTC()
+	_ = jobs.Insert(ctx, models.ProvisioningJob{
+		ID: "j-fail", DeviceID: "n2", State: models.StateFailed,
+		Phase: "IMAGE_WRITE", Error: "bmc error", UpdatedAt: &now,
+	})
+	svc := observe.New(nil, jobs, nil, nil)
+	st, err := svc.Status(ctx, "n2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.ActiveJobID != "" {
+		t.Fatalf("failed job must not set ActiveJobID: %+v", st)
+	}
+	if st.LifecycleState != models.StateFailed || st.LastEvent != "bmc error" {
+		t.Fatalf("%+v", st)
+	}
 }
 
 func TestStatusEmptyDevice(t *testing.T) {
@@ -50,5 +75,13 @@ func TestStatusEmptyDevice(t *testing.T) {
 	_, err := svc.Status(context.Background(), "")
 	if err == nil {
 		t.Fatal("expected error")
+	}
+}
+
+func TestListEventsRequiresStore(t *testing.T) {
+	svc := observe.New(nil, nil, nil, nil)
+	_, err := svc.ListEvents(context.Background(), "d", time.Time{}, 5)
+	if err == nil {
+		t.Fatal("expected error without telemetry")
 	}
 }

--- a/internal/observe/service_test.go
+++ b/internal/observe/service_test.go
@@ -1,0 +1,54 @@
+package observe_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/mattcburns/shoal/internal/common/models"
+	"github.com/mattcburns/shoal/internal/common/telemetry"
+	"github.com/mattcburns/shoal/internal/deploy/jobstore"
+	"github.com/mattcburns/shoal/internal/observe"
+)
+
+type fakeWatch struct{ ids map[string]bool }
+
+func (f fakeWatch) HasWatch(id string) bool { return f.ids[id] }
+
+func TestStatusAggregatesJobAndEvents(t *testing.T) {
+	jobs := jobstore.NewMemory()
+	store := telemetry.NewMemory()
+	ctx := context.Background()
+	now := time.Now().UTC()
+	pct := 40
+	_ = jobs.Insert(ctx, models.ProvisioningJob{
+		ID: "j1", DeviceID: "node-1", State: models.StateProvisioning,
+		Phase: "IMAGE_WRITE", Percent: &pct, UpdatedAt: &now,
+	})
+	_ = store.WriteEvent(ctx, models.NormalizedEvent{
+		DeviceID: "node-1", Message: "fan degraded", Severity: "warning", Timestamp: now,
+	})
+
+	svc := observe.New(nil, jobs, store, fakeWatch{ids: map[string]bool{"node-1": true}})
+	st, err := svc.Status(ctx, "node-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.ActiveJobID != "j1" || st.Phase != "IMAGE_WRITE" {
+		t.Fatalf("%+v", st)
+	}
+	if st.LifecycleState != models.StateProvisioning {
+		t.Fatalf("state=%s", st.LifecycleState)
+	}
+	if st.LastEvent == "" || st.Percent == nil || *st.Percent != 40 {
+		t.Fatalf("%+v", st)
+	}
+}
+
+func TestStatusEmptyDevice(t *testing.T) {
+	svc := observe.New(nil, jobstore.NewMemory(), telemetry.NewMemory(), nil)
+	_, err := svc.Status(context.Background(), "")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}

--- a/internal/observe/sol/watch.go
+++ b/internal/observe/sol/watch.go
@@ -219,4 +219,26 @@ func (w *WatchService) ActiveCount() int {
 	return len(w.active)
 }
 
+// HasWatch reports whether deviceID currently has an active SOL session.
+func (w *WatchService) HasWatch(deviceID string) bool {
+	if deviceID == "" {
+		return false
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	_, ok := w.byDevice[deviceID]
+	return ok
+}
+
+// WatchingDeviceIDs returns device IDs with an active SOL watch.
+func (w *WatchService) WatchingDeviceIDs() []string {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	out := make([]string, 0, len(w.byDevice))
+	for id := range w.byDevice {
+		out = append(out, id)
+	}
+	return out
+}
+
 var _ watchport.WatchRegistrar = (*WatchService)(nil)


### PR DESCRIPTION
## Summary

Phase **4b** Observe broaden (depends on #8 / 4a):

- **`jobport.JobQuery`** — read-only jobs for status without Observe importing Deploy
- **`poll.Poller`** — Redfish SEL/sensors → telemetry Store; SEL dedup; idle 60s / watch-elevated 15s
- **`observe.Service`** — `DeviceStatus` aggregate (job + last event + watch)
- **CLI:** `shoal observe status|poll`
- **API:** `GET /v1/devices/{id}/status`, `GET /v1/devices/{id}/events`
- **`serve`** wires Observe + background poller (targets from jobs with `bmc_endpoint`)
- Deterministic **`ReconcileEvent`** severity/component keywords

## Test plan

- [x] `go test ./...`
- [x] staticcheck on touched packages
- [x] Lab: `observe poll` against sushy (0 SEL/sensors OK)
- [x] Lab: `observe status` against telemetry DSN
- [x] Unit: poll dedup, elevated interval, status aggregation, API handlers

## Out of scope

Graphics OCR, SSE/WS, real-hardware SOL, Phase 5 Deploy harden.