### PR TITLE
feat(deploy): NetBox lifecycle sync + reliability polish

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -252,8 +252,11 @@ imports Deploy (job reads via `jobport.JobQuery`).
 
 **Phase 5 Deploy (in progress):** Orchestrator may best-effort sync NetBox
 `lifecycle_state` via `netbox.LifecycleWriter` on Start/HandleTerminal (never
-blocks BMC on NetBox errors). Sole lifecycle writer remains Orchestrator;
-JobStore stays pure persistence.
+blocks BMC on NetBox errors). Lab bootstrap creates device custom fields
+`lifecycle_state`, `credential_ref`, `bmc_ip`. Jobs persist `system_id` +
+`credential_ref` for out-of-process cancel/orphan BMC cleanup (share
+`SHOAL_SECRETS_DIR`). Sole lifecycle writer remains Orchestrator; JobStore stays
+pure persistence.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -250,6 +250,11 @@ only (no silent memory fallback). Empty SEL/sensors with exit 0 is valid when th
 BMC has no logs; write failures and Redfish errors fail the poll. Observe never
 imports Deploy (job reads via `jobport.JobQuery`).
 
+**Phase 5 Deploy (in progress):** Orchestrator may best-effort sync NetBox
+`lifecycle_state` via `netbox.LifecycleWriter` on Start/HandleTerminal (never
+blocks BMC on NetBox errors). Sole lifecycle writer remains Orchestrator;
+JobStore stays pure persistence.
+
 ---
 
 ## 4. Coding Style

--- a/SHOAL_COMPREHENSIVE_DESIGN_AND_IMPLEMENTATION_PLAN.md
+++ b/SHOAL_COMPREHENSIVE_DESIGN_AND_IMPLEMENTATION_PLAN.md
@@ -1590,7 +1590,7 @@ go test ./...
 
 ## Open Questions
 
-**All previously open product decisions are resolved through v2.0.5.** Phase 0–3 are on `master`; Phase 4 (Observe broaden) is next.
+**All previously open product decisions are resolved through v2.0.5.** Phase 0–4 are on `master`; Phase 5 (Deploy harden) is next.
 
 | Topic | Resolution |
 |-------|------------|
@@ -1629,9 +1629,9 @@ go test ./...
 
 ---
 
-**This document (v2.0.5) is the SoT for agents.** Phase 0–3 (incl. dual-model lab + hybrid Discover + few-shot learning) are on `master`.
+**This document (v2.0.5) is the SoT for agents.** Phase 0–4 (Discover hybrid, few-shot, Observe broaden) are on `master`.
 
 Next actions:
-1. Phase 4 Observe broaden (4a Store+SEL landed; 4b poll/status CLI/API)
-2. Later: Phase 5 Deploy harden, packaging
+1. Phase 5 Deploy harden: NetBox lifecycle sync, reliability polish, profile gen+approval, ISO pipeline
+2. Later: packaging (Compose shoal service)
 3. At Phase 6: choose graphics failure-screen OCR approach before implementing

--- a/docs/lab-runbook.md
+++ b/docs/lab-runbook.md
@@ -181,6 +181,23 @@ go run ./cmd/shoal observe status -device-id shoal-node-1 \
 
 **Lab fidelity:** rich SEL/sensors need real BMC hardware.
 
+### Phase 5a: NetBox lifecycle on deploy
+
+When `SHOAL_NETBOX_URL` + `SHOAL_NETBOX_TOKEN` are set, Deploy best-effort
+syncs NetBox `lifecycle_state` (custom field or comments fallback):
+
+| Job event | NetBox state |
+|-----------|----------------|
+| Start (job row inserted) | `provisioning` |
+| Terminal DONE (post-check OK) | `provisioned` |
+| Terminal fail/cancel/stall/… | `failed` |
+
+NetBox down does **not** block BMC actions (warn log only). Device key is the
+job `device_id` (serial preferred after Discover ingest).
+
+Reliability contract (unchanged + polish): always cleanup Virtual Media + boot
+override; cancel/stall/orphan fail; DONE post-check verifies media ejected.
+
 ## 2) Fast stop (teardown / clean slate)
 ```bash
 ansible-playbook -i infra/ansible/inventory/lab-vm.yml infra/ansible/playbooks/down.yml

--- a/docs/lab-runbook.md
+++ b/docs/lab-runbook.md
@@ -184,7 +184,7 @@ go run ./cmd/shoal observe status -device-id shoal-node-1 \
 ### Phase 5a: NetBox lifecycle on deploy
 
 When `SHOAL_NETBOX_URL` + `SHOAL_NETBOX_TOKEN` are set, Deploy best-effort
-syncs NetBox `lifecycle_state` (custom field or comments fallback):
+syncs NetBox `lifecycle_state`:
 
 | Job event | NetBox state |
 |-----------|----------------|
@@ -192,11 +192,29 @@ syncs NetBox `lifecycle_state` (custom field or comments fallback):
 | Terminal DONE (post-check OK) | `provisioned` |
 | Terminal fail/cancel/stall/… | `failed` |
 
+**Custom fields** (created by `bootstrap_netbox` / `netbox_bootstrap`):
+`lifecycle_state`, `credential_ref`, `bmc_ip` on `dcim.device`. After adding
+them on an existing lab, re-run bootstrap (or create CFs once) and re-ingest
+devices so values land in custom fields instead of comments.
+
 NetBox down does **not** block BMC actions (warn log only). Device key is the
 job `device_id` (serial preferred after Discover ingest).
 
-Reliability contract (unchanged + polish): always cleanup Virtual Media + boot
-override; cancel/stall/orphan fail; DONE post-check verifies media ejected.
+**Cross-process cancel/cleanup:** jobs persist `system_id` + `credential_ref`.
+Use a **shared** secrets dir so the cancel process can resolve BMC credentials:
+
+```bash
+export SHOAL_SECRETS_DIR=./.shoal/secrets   # same path for deploy run and cancel
+mkdir -p "$SHOAL_SECRETS_DIR"
+# deploy run … then later:
+go run ./cmd/shoal deploy cancel -job <id>
+```
+
+Prefer cancel via the same `shoal serve` process (`POST /v1/jobs/{id}/cancel`)
+when the job was started under serve.
+
+Reliability contract: always cleanup Virtual Media + boot override;
+cancel/stall/orphan fail; DONE post-check verifies media ejected.
 
 ## 2) Fast stop (teardown / clean slate)
 ```bash

--- a/infra/ansible/roles/netbox_bootstrap/tasks/main.yml
+++ b/infra/ansible/roles/netbox_bootstrap/tasks/main.yml
@@ -219,6 +219,46 @@
   when: device_type_info.json.results | length > 0
   tags: [device_type]
 
+# Device custom fields for Shoal identity + lifecycle (NetBox 4.x object_types).
+# Discover/Deploy prefer custom_fields; comments are only a fallback when CFs missing.
+- name: Create Shoal device custom fields
+  uri:
+    url: "{{ shoal_netbox_url }}/api/extras/custom-fields/"
+    method: POST
+    headers: "{{ netbox_auth_header }}"
+    body_format: json
+    body:
+      name: "{{ item.name }}"
+      label: "{{ item.label }}"
+      type: text
+      object_types:
+        - dcim.device
+      required: false
+      description: "{{ item.description }}"
+      weight: "{{ item.weight | default(100) }}"
+    status_code: [200, 201, 400]
+  loop:
+    - name: lifecycle_state
+      label: Lifecycle state
+      description: "Shoal lifecycle_state (discovered|ready|provisioning|provisioned|failed)"
+      weight: 100
+    - name: credential_ref
+      label: Credential ref
+      description: "Opaque secrets backend key for BMC credentials (never a password)"
+      weight: 110
+    - name: bmc_ip
+      label: BMC IP
+      description: "Management BMC address for this device"
+      weight: 120
+  register: cf_create
+  failed_when: >
+    cf_create.status | int not in [200, 201, 400] or
+    (cf_create.status | int == 400 and
+     'already exists' not in (cf_create.json | default({}) | to_json | lower) and
+     'unique' not in (cf_create.json | default({}) | to_json | lower) and
+     'duplicate' not in (cf_create.json | default({}) | to_json | lower))
+  tags: [custom_fields]
+
 - name: Register virtual BMC nodes in NetBox
   uri:
     url: "{{ shoal_netbox_url }}/api/dcim/devices/"
@@ -252,6 +292,7 @@
       - Device Role: Virtual BMC Node (ID: {{ shoal_device_role_id }})
       - Manufacturer: Shoal Virtual (ID: {{ shoal_manufacturer_id }})
       - Device Type: Virtual Server (ID: {{ shoal_device_type_id }})
+      - Custom fields (dcim.device): lifecycle_state, credential_ref, bmc_ip
       
       Registered devices:
       {% for node in shoal_bmc_nodes %}

--- a/internal/api/jobs.go
+++ b/internal/api/jobs.go
@@ -2,10 +2,12 @@ package api
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 
 	"github.com/mattcburns/shoal/internal/common/models"
+	"github.com/mattcburns/shoal/internal/common/validate"
 	"github.com/mattcburns/shoal/internal/deploy/jobstore"
 )
 
@@ -19,6 +21,11 @@ type JobCanceler interface {
 	Cancel(ctx context.Context, jobID string) error
 }
 
+// JobStarter starts a provisioning job (Orchestrator).
+type JobStarter interface {
+	Start(ctx context.Context, req models.StartJobRequest) (models.ProvisioningJob, error)
+}
+
 // WithJobStore attaches a job store for GET /v1/jobs/{id}.
 func (s *Server) WithJobStore(store jobstore.Store) *Server {
 	s.jobs = store
@@ -29,6 +36,42 @@ func (s *Server) WithJobStore(store jobstore.Store) *Server {
 func (s *Server) WithJobCanceler(c JobCanceler) *Server {
 	s.cancel = c
 	return s
+}
+
+// WithJobStarter attaches start support for POST /v1/jobs.
+func (s *Server) WithJobStarter(st JobStarter) *Server {
+	s.start = st
+	return s
+}
+
+func (s *Server) handleStartJob(w http.ResponseWriter, r *http.Request) {
+	if s.start == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]any{
+			"error": "job start not configured",
+		})
+		return
+	}
+	var req models.StartJobRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid json"})
+		return
+	}
+	if err := validate.StartJobRequest(req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"error": err.Error()})
+		return
+	}
+	j, err := s.start.Start(r.Context(), req)
+	if err != nil {
+		s.log.Warn("start job", "err", err.Error())
+		// May still have a job row after partial start.
+		if j.ID != "" {
+			writeJSON(w, http.StatusConflict, map[string]any{"error": err.Error(), "job": j})
+			return
+		}
+		writeJSON(w, http.StatusInternalServerError, map[string]any{"error": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusCreated, j)
 }
 
 func (s *Server) handleGetJob(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -24,6 +24,7 @@ type Server struct {
 	PingDB   func(ctx context.Context, dsn string) error
 	jobs     jobstore.Store
 	cancel   JobCanceler
+	start    JobStarter
 	discover *discover.Service
 	observe  *observe.Service
 }
@@ -51,6 +52,7 @@ func (s *Server) Handler() http.Handler {
 func (s *Server) routes() {
 	s.mux.HandleFunc("GET /healthz", s.handleHealthz)
 	s.mux.HandleFunc("GET /readyz", s.handleReadyz)
+	s.mux.HandleFunc("POST /v1/jobs", s.handleStartJob)
 	s.mux.HandleFunc("GET /v1/jobs/{id}", s.handleGetJob)
 	s.mux.HandleFunc("POST /v1/jobs/{id}/cancel", s.handleCancelJob)
 	s.mux.HandleFunc("POST /v1/discover/ingest", s.handleDiscoverIngest)

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -175,12 +175,17 @@ func cmdServe(args []string) int {
 			KeyPath: cfg.SerialSSHKey,
 			UseSudo: cfg.SerialSSHSudo,
 		})
+		var nb netbox.LifecycleWriter
+		if cfg.NetBoxURL != "" && cfg.NetBoxToken != "" {
+			nb = netbox.New(cfg.NetBoxURL, cfg.NetBoxToken)
+		}
 		orch := job.NewOrchestrator(job.Options{
 			Log:                 log,
 			Store:               store,
 			Secrets:             secretBackend,
 			NewBMC:              redfish.NewBMC,
 			Watches:             watchSvc,
+			NetBox:              nb,
 			AuthMode:            cfg.RedfishAuthMode,
 			TLSMode:             cfg.RedfishTLSMode,
 			CAFile:              cfg.RedfishCAFile,
@@ -189,6 +194,7 @@ func cmdServe(args []string) int {
 		defer orch.Stop()
 		watchSvc.SetProgress(orch.ProgressPort())
 		srvAPI.WithJobCanceler(orch)
+		srvAPI.WithJobStarter(orch)
 		if err := orch.ReconcileOrphans(ctx); err != nil {
 			log.Warn("orphan reconcile", "err", err.Error())
 		}

--- a/internal/cli/deploy.go
+++ b/internal/cli/deploy.go
@@ -271,11 +271,25 @@ func cmdDeployCancel(args []string) int {
 		fmt.Fprintf(os.Stderr, "cancel: %v\n", err)
 		return 1
 	}
-	// Wait briefly for async terminal
-	time.Sleep(300 * time.Millisecond)
-	j, err := store.Get(context.Background(), *jobID)
-	if err == nil {
-		_ = json.NewEncoder(os.Stdout).Encode(j)
+	// Poll until terminal (HandleTerminal is async; cleanup may take tens of seconds).
+	var j models.ProvisioningJob
+	deadline := time.Now().Add(60 * time.Second)
+	for time.Now().Before(deadline) {
+		var err error
+		j, err = store.Get(context.Background(), *jobID)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "get job: %v\n", err)
+			return 1
+		}
+		if j.State != models.StateProvisioning {
+			break
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	_ = json.NewEncoder(os.Stdout).Encode(j)
+	if j.State == models.StateProvisioning {
+		fmt.Fprintln(os.Stderr, "cancel: still provisioning after wait (terminal async may still be running)")
+		return 1
 	}
 	return 0
 }

--- a/internal/cli/deploy.go
+++ b/internal/cli/deploy.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/mattcburns/shoal/internal/common/config"
 	"github.com/mattcburns/shoal/internal/common/models"
+	"github.com/mattcburns/shoal/internal/common/netbox"
 	"github.com/mattcburns/shoal/internal/common/redfish"
 	"github.com/mattcburns/shoal/internal/common/telemetry"
 	"github.com/mattcburns/shoal/internal/deploy/job"
@@ -104,12 +105,17 @@ func cmdDeployRun(args []string) int {
 		KeyPath: cfg.SerialSSHKey,
 		UseSudo: cfg.SerialSSHSudo,
 	})
+	var nb netbox.LifecycleWriter
+	if cfg.NetBoxURL != "" && cfg.NetBoxToken != "" {
+		nb = netbox.New(cfg.NetBoxURL, cfg.NetBoxToken)
+	}
 	orch := job.NewOrchestrator(job.Options{
 		Log:                 log,
 		Store:               store,
 		Secrets:             secretBackend,
 		NewBMC:              redfish.NewBMC,
 		Watches:             watchSvc,
+		NetBox:              nb,
 		AuthMode:            cfg.RedfishAuthMode,
 		TLSMode:             cfg.RedfishTLSMode,
 		CAFile:              cfg.RedfishCAFile,
@@ -242,12 +248,17 @@ func cmdDeployCancel(args []string) int {
 		KeyPath: cfg.SerialSSHKey,
 		UseSudo: cfg.SerialSSHSudo,
 	})
+	var nb netbox.LifecycleWriter
+	if cfg.NetBoxURL != "" && cfg.NetBoxToken != "" {
+		nb = netbox.New(cfg.NetBoxURL, cfg.NetBoxToken)
+	}
 	orch := job.NewOrchestrator(job.Options{
 		Log:                 log,
 		Store:               store,
 		Secrets:             secretBackend,
 		NewBMC:              redfish.NewBMC,
 		Watches:             watchSvc,
+		NetBox:              nb,
 		AuthMode:            cfg.RedfishAuthMode,
 		TLSMode:             cfg.RedfishTLSMode,
 		CAFile:              cfg.RedfishCAFile,

--- a/internal/common/models/models.go
+++ b/internal/common/models/models.go
@@ -81,6 +81,11 @@ type ProvisioningJob struct {
 	SOLSessionID  string         `json:"sol_session_id,omitempty"`
 	ISOURL        string         `json:"iso_url,omitempty"`
 	BMCEndpoint   string         `json:"bmc_endpoint,omitempty"`
+	// SystemID is the Redfish computer system id (for cleanup after restart/cancel).
+	SystemID string `json:"system_id,omitempty"`
+	// CredentialRef is the secrets-backend key (never a password). Required for
+	// out-of-process cancel/orphan cleanup when SHOAL_SECRETS_DIR is shared.
+	CredentialRef string `json:"credential_ref,omitempty"`
 }
 
 // RawAssetInput is Discover ingest (API/CLI).

--- a/internal/common/netbox/client.go
+++ b/internal/common/netbox/client.go
@@ -38,9 +38,17 @@ func New(baseURL, token string) *Client {
 	}
 }
 
-// API is the surface Discover depends on.
+// API is the surface Discover depends on (identity upsert).
 type API interface {
 	UpsertDevice(ctx context.Context, id models.DeviceIdentity) (string, error)
+}
+
+// LifecycleWriter is the Deploy surface for NetBox lifecycle_state only.
+// Core never calls this; Discover uses UpsertDevice on ingest.
+type LifecycleWriter interface {
+	// SetLifecycle updates lifecycle_state for a device identified by NetBox id
+	// or serial (serial lookup first, then numeric id).
+	SetLifecycle(ctx context.Context, deviceKey string, state models.LifecycleState) error
 }
 
 // UpsertDevice finds a device by serial or creates one; sets lifecycle custom field when possible.
@@ -151,6 +159,41 @@ func (c *Client) patchDevice(ctx context.Context, netboxID string, id models.Dev
 		fb := map[string]any{
 			"comments": fmt.Sprintf("lifecycle_state=%s credential_ref=%s bmc_ip=%s",
 				id.LifecycleState, id.CredentialRef, id.BMCIP),
+		}
+		return c.doJSON(ctx, http.MethodPatch, "/api/dcim/devices/"+netboxID+"/", fb, nil)
+	}
+	return nil
+}
+
+// SetLifecycle implements LifecycleWriter.
+func (c *Client) SetLifecycle(ctx context.Context, deviceKey string, state models.LifecycleState) error {
+	if c.BaseURL == "" || c.Token == "" {
+		return fmt.Errorf("netbox: missing url or token")
+	}
+	deviceKey = strings.TrimSpace(deviceKey)
+	if deviceKey == "" {
+		return fmt.Errorf("netbox: device key required")
+	}
+	if state == "" {
+		return fmt.Errorf("netbox: lifecycle state required")
+	}
+	netboxID, err := c.findBySerial(ctx, deviceKey)
+	if err != nil {
+		return err
+	}
+	if netboxID == "" {
+		// Treat key as NetBox numeric id when serial lookup misses.
+		netboxID = deviceKey
+	}
+	body := map[string]any{
+		"custom_fields": map[string]any{
+			"lifecycle_state": string(state),
+		},
+	}
+	err = c.doJSON(ctx, http.MethodPatch, "/api/dcim/devices/"+netboxID+"/", body, nil)
+	if err != nil {
+		fb := map[string]any{
+			"comments": fmt.Sprintf("lifecycle_state=%s", state),
 		}
 		return c.doJSON(ctx, http.MethodPatch, "/api/dcim/devices/"+netboxID+"/", fb, nil)
 	}
@@ -281,12 +324,17 @@ func truncate(s string, n int) string {
 // Memory is an in-memory NetBox fake for tests.
 type Memory struct {
 	BySerial map[string]models.DeviceIdentity
+	ByID     map[string]models.DeviceIdentity
 	Next     int
 }
 
 // NewMemory constructs a Memory API.
 func NewMemory() *Memory {
-	return &Memory{BySerial: map[string]models.DeviceIdentity{}, Next: 1}
+	return &Memory{
+		BySerial: map[string]models.DeviceIdentity{},
+		ByID:     map[string]models.DeviceIdentity{},
+		Next:     1,
+	}
 }
 
 // UpsertDevice implements API.
@@ -297,13 +345,41 @@ func (m *Memory) UpsertDevice(_ context.Context, id models.DeviceIdentity) (stri
 	if existing, ok := m.BySerial[id.Serial]; ok && existing.ID != "" {
 		id.ID = existing.ID
 		m.BySerial[id.Serial] = id
+		m.ByID[id.ID] = id
 		return id.ID, nil
 	}
 	id.ID = fmt.Sprintf("%d", m.Next)
 	m.Next++
 	m.BySerial[id.Serial] = id
+	m.ByID[id.ID] = id
 	return id.ID, nil
+}
+
+// SetLifecycle implements LifecycleWriter.
+func (m *Memory) SetLifecycle(_ context.Context, deviceKey string, state models.LifecycleState) error {
+	if deviceKey == "" || state == "" {
+		return fmt.Errorf("netbox/memory: device key and state required")
+	}
+	if id, ok := m.BySerial[deviceKey]; ok {
+		id.LifecycleState = state
+		m.BySerial[deviceKey] = id
+		if id.ID != "" {
+			m.ByID[id.ID] = id
+		}
+		return nil
+	}
+	if id, ok := m.ByID[deviceKey]; ok {
+		id.LifecycleState = state
+		m.ByID[deviceKey] = id
+		if id.Serial != "" {
+			m.BySerial[id.Serial] = id
+		}
+		return nil
+	}
+	return fmt.Errorf("netbox/memory: device %q not found", deviceKey)
 }
 
 var _ API = (*Client)(nil)
 var _ API = (*Memory)(nil)
+var _ LifecycleWriter = (*Client)(nil)
+var _ LifecycleWriter = (*Memory)(nil)

--- a/internal/common/netbox/client_test.go
+++ b/internal/common/netbox/client_test.go
@@ -27,6 +27,53 @@ func TestMemoryUpsert(t *testing.T) {
 	}
 }
 
+func TestMemorySetLifecycle(t *testing.T) {
+	m := netbox.NewMemory()
+	_, err := m.UpsertDevice(context.Background(), models.DeviceIdentity{
+		Serial: "NODE-1", LifecycleState: models.StateDiscovered,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := m.SetLifecycle(context.Background(), "NODE-1", models.StateProvisioning); err != nil {
+		t.Fatal(err)
+	}
+	if m.BySerial["NODE-1"].LifecycleState != models.StateProvisioning {
+		t.Fatalf("%+v", m.BySerial["NODE-1"])
+	}
+	if err := m.SetLifecycle(context.Background(), "missing", models.StateFailed); err == nil {
+		t.Fatal("expected not found")
+	}
+}
+
+func TestClientSetLifecycle(t *testing.T) {
+	var patched bool
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/dcim/devices/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"results": []any{map[string]any{"id": 7}},
+			})
+			return
+		}
+		if r.Method == http.MethodPatch {
+			patched = true
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	c := netbox.New(srv.URL, "tok")
+	if err := c.SetLifecycle(context.Background(), "SERIAL-X", models.StateProvisioned); err != nil {
+		t.Fatal(err)
+	}
+	if !patched {
+		t.Fatal("expected PATCH")
+	}
+}
+
 func TestClientFindCreate(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/dcim/devices/", func(w http.ResponseWriter, r *http.Request) {

--- a/internal/common/telemetry/schema.sql
+++ b/internal/common/telemetry/schema.sql
@@ -15,8 +15,14 @@ CREATE TABLE IF NOT EXISTS jobs (
   error            TEXT,
   sol_session_id   TEXT,
   iso_url          TEXT,
-  bmc_endpoint     TEXT
+  bmc_endpoint     TEXT,
+  system_id        TEXT,
+  credential_ref   TEXT
 );
+
+-- Phase 5a.1: columns for cross-process cancel/orphan BMC cleanup
+ALTER TABLE jobs ADD COLUMN IF NOT EXISTS system_id TEXT;
+ALTER TABLE jobs ADD COLUMN IF NOT EXISTS credential_ref TEXT;
 
 CREATE TABLE IF NOT EXISTS events (
   id TEXT PRIMARY KEY,

--- a/internal/deploy/job/orchestrator.go
+++ b/internal/deploy/job/orchestrator.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/mattcburns/shoal/internal/common/jobport"
 	"github.com/mattcburns/shoal/internal/common/models"
+	"github.com/mattcburns/shoal/internal/common/netbox"
 	"github.com/mattcburns/shoal/internal/common/redfish"
 	"github.com/mattcburns/shoal/internal/common/secrets"
 	"github.com/mattcburns/shoal/internal/common/validate"
@@ -34,6 +35,14 @@ const (
 	ReasonPanic       TerminalReason = "panic"
 )
 
+// Reliability timeouts (Phase 5 polish — named constants).
+const (
+	CleanupTimeout        = 45 * time.Second
+	UnregisterTimeout     = 10 * time.Second
+	TerminalWorkerTimeout = 2 * time.Minute
+	DefaultSOLStall       = 3 * time.Minute
+)
+
 // Orchestrator owns lifecycle transitions, BMC actions, and cleanup.
 type Orchestrator struct {
 	log        *slog.Logger
@@ -41,6 +50,7 @@ type Orchestrator struct {
 	secrets    secrets.Backend
 	newBMC     redfish.Factory
 	watches    watchport.WatchRegistrar
+	netbox     netbox.LifecycleWriter // optional; identity lifecycle only
 	authMode   string
 	tlsMode    string
 	caFile     string
@@ -76,6 +86,7 @@ type Options struct {
 	Secrets             secrets.Backend
 	NewBMC              redfish.Factory
 	Watches             watchport.WatchRegistrar
+	NetBox              netbox.LifecycleWriter // optional Phase 5 lifecycle sync
 	AuthMode            string
 	TLSMode             string
 	CAFile              string
@@ -105,6 +116,7 @@ func NewOrchestrator(opts Options) *Orchestrator {
 		secrets:    opts.Secrets,
 		newBMC:     opts.NewBMC,
 		watches:    opts.Watches,
+		netbox:     opts.NetBox,
 		authMode:   auth,
 		tlsMode:    tlsMode,
 		caFile:     opts.CAFile,
@@ -135,7 +147,7 @@ func (o *Orchestrator) terminalLoop() {
 		case <-o.stopCh:
 			return
 		case ev := <-o.terminal:
-			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+			ctx, cancel := context.WithTimeout(context.Background(), TerminalWorkerTimeout)
 			if err := o.HandleTerminal(ctx, ev.jobID, ev.reason); err != nil {
 				o.log.Error("HandleTerminal failed", "job_id", ev.jobID, "reason", string(ev.reason), "err", err.Error())
 			}
@@ -159,7 +171,9 @@ func (o *Orchestrator) Get(ctx context.Context, jobID string) (models.Provisioni
 	return o.store.Get(ctx, jobID)
 }
 
-// Start begins a provisioning job using CLI/API binding fields (no NetBox).
+// Start begins a provisioning job using CLI/API binding fields.
+// When NetBox is configured, best-effort lifecycle_state=provisioning is written
+// (failure is logged and does not block BMC actions).
 func (o *Orchestrator) Start(ctx context.Context, req models.StartJobRequest) (models.ProvisioningJob, error) {
 	if err := validate.StartJobRequest(req); err != nil {
 		return models.ProvisioningJob{}, err
@@ -204,6 +218,7 @@ func (o *Orchestrator) Start(ctx context.Context, req models.StartJobRequest) (m
 	if err := o.store.Insert(ctx, job); err != nil {
 		return models.ProvisioningJob{}, err
 	}
+	o.syncNetBoxLifecycle(ctx, req.DeviceID, models.StateProvisioning)
 
 	jobCtx, cancel := context.WithCancel(context.Background())
 	rs := &runState{
@@ -292,7 +307,7 @@ func (o *Orchestrator) provision(ctx context.Context, job models.ProvisioningJob
 	stall := req.StallTimeout
 	if stall <= 0 {
 		// Live ISO boot can take well over 90s before the first marker.
-		stall = 3 * time.Minute
+		stall = DefaultSOLStall
 	}
 	session := models.WatchSession{
 		ID:           rs.sessionID,
@@ -398,7 +413,7 @@ func (o *Orchestrator) handleTerminalOnce(ctx context.Context, jobID string, rea
 		}()
 		select {
 		case <-unregDone:
-		case <-time.After(10 * time.Second):
+		case <-time.After(UnregisterTimeout):
 			o.log.Warn("watch unregister timed out", "job_id", jobID, "session_id", sessionID)
 		case <-ctx.Done():
 			o.log.Warn("watch unregister aborted by context", "job_id", jobID)
@@ -416,13 +431,13 @@ func (o *Orchestrator) handleTerminalOnce(ctx context.Context, jobID string, rea
 	}
 
 	// Always-run cleanup when we have BMC coordinates (hard timeout so we still transition).
+	var cleanupErr error
 	if bmcURL != "" {
-		cctx, ccancel := context.WithTimeout(context.Background(), 45*time.Second)
-		err := o.cleanupBMC(cctx, bmcURL, credRef, systemID)
+		cctx, ccancel := context.WithTimeout(context.Background(), CleanupTimeout)
+		cleanupErr = o.cleanupBMC(cctx, bmcURL, credRef, systemID)
 		ccancel()
-		if err != nil {
-			o.log.Error("bmc cleanup failed", "job_id", jobID, "err", err.Error())
-			// still transition
+		if cleanupErr != nil {
+			o.log.Error("bmc cleanup failed", "job_id", jobID, "err", cleanupErr.Error())
 		}
 	}
 
@@ -432,6 +447,18 @@ func (o *Orchestrator) handleTerminalOnce(ctx context.Context, jobID string, rea
 	case ReasonDoneOK:
 		to = models.StateProvisioned
 		errMsg = ""
+		// Phase 5: DONE post-check — cleanup must have left media/boot clear.
+		if cleanupErr != nil {
+			to = models.StateFailed
+			errMsg = "post-check: bmc cleanup incomplete: " + cleanupErr.Error()
+			o.log.Warn("DONE post-check failed", "job_id", jobID, "err", cleanupErr.Error())
+		} else if bmcURL != "" {
+			if err := o.postCheckClean(context.Background(), bmcURL, credRef, systemID); err != nil {
+				to = models.StateFailed
+				errMsg = "post-check: " + err.Error()
+				o.log.Warn("DONE post-check failed", "job_id", jobID, "err", err.Error())
+			}
+		}
 	case ReasonCancel:
 		to = models.StateFailed
 		errMsg = "canceled"
@@ -464,11 +491,67 @@ func (o *Orchestrator) handleTerminalOnce(ctx context.Context, jobID string, rea
 		return err
 	}
 	o.log.Info("job terminal", "job_id", jobID, "state", string(to), "reason", string(reason))
+	o.syncNetBoxLifecycle(context.Background(), job.DeviceID, to)
 
 	o.mu.Lock()
 	delete(o.running, jobID)
 	o.mu.Unlock()
 	return nil
+}
+
+// postCheckClean verifies media ejected and boot override cleared after cleanup.
+func (o *Orchestrator) postCheckClean(ctx context.Context, bmcURL, credRef, systemID string) error {
+	user, pass := "", ""
+	if credRef != "" && o.secrets != nil {
+		if c, err := o.secrets.Get(ctx, credRef); err == nil {
+			user, pass = c.Username, c.Password
+		}
+	}
+	bmc, err := o.newBMC(redfish.Config{
+		BaseURL: bmcURL, Username: user, Password: pass,
+		AuthMode: o.authMode, TLSMode: o.tlsMode, CAFile: o.caFile, MaxConcurrent: 1,
+	})
+	if err != nil {
+		return fmt.Errorf("bmc for post-check: %w", err)
+	}
+	if err := bmc.Open(ctx); err != nil {
+		return fmt.Errorf("bmc open post-check: %w", err)
+	}
+	defer func() { _ = bmc.Close(context.Background()) }()
+	vms, err := bmc.ListVirtualMedia(ctx, systemID)
+	if err != nil {
+		return fmt.Errorf("list media post-check: %w", err)
+	}
+	for _, vm := range vms {
+		if vm.Inserted {
+			return fmt.Errorf("virtual media still inserted (%s)", vm.URI)
+		}
+	}
+	boot, err := bmc.GetBoot(ctx, systemID)
+	if err != nil {
+		return fmt.Errorf("get boot post-check: %w", err)
+	}
+	if boot.OverrideEnabled != "" && boot.OverrideEnabled != "Disabled" && boot.OverrideEnabled != "disabled" {
+		return fmt.Errorf("boot override still set (%s/%s)", boot.OverrideEnabled, boot.OverrideTarget)
+	}
+	return nil
+}
+
+// syncNetBoxLifecycle best-effort updates NetBox identity lifecycle_state.
+// Failures are logged only (do not reverse JobStore transition).
+func (o *Orchestrator) syncNetBoxLifecycle(ctx context.Context, deviceKey string, state models.LifecycleState) {
+	if o.netbox == nil || deviceKey == "" {
+		return
+	}
+	if err := o.netbox.SetLifecycle(ctx, deviceKey, state); err != nil {
+		o.log.Warn("netbox lifecycle sync failed",
+			"device_id", deviceKey,
+			"lifecycle_state", string(state),
+			"err", err.Error(),
+		)
+		return
+	}
+	o.log.Info("netbox lifecycle synced", "device_id", deviceKey, "lifecycle_state", string(state))
 }
 
 func (o *Orchestrator) cleanupBMC(ctx context.Context, bmcURL, credRef, systemID string) error {
@@ -512,16 +595,24 @@ func (o *Orchestrator) cleanupBMC(ctx context.Context, bmcURL, credRef, systemID
 
 // ReconcileOrphans fails in-flight PROVISIONING jobs left from a previous process.
 // Default policy (failOrphan=true): cleanup + FAILED for each.
+// Re-attach SOL is deferred (MVP: fail orphans is the safe default).
 func (o *Orchestrator) ReconcileOrphans(ctx context.Context) error {
 	jobs, err := o.store.ListByState(ctx, models.StateProvisioning)
 	if err != nil {
 		return err
 	}
 	for _, j := range jobs {
-		o.log.Warn("reconciling orphan job", "job_id", j.ID, "device_id", j.DeviceID, "fail", o.failOrphan)
 		if !o.failOrphan {
+			o.log.Warn("reconciling orphan job",
+				"job_id", j.ID, "device_id", j.DeviceID,
+				"decision", "skip", "reason", "SHOAL_RECONCILE_FAIL_ORPHANS=false",
+			)
 			continue
 		}
+		o.log.Warn("reconciling orphan job",
+			"job_id", j.ID, "device_id", j.DeviceID,
+			"decision", "fail_orphan", "reason", "unrecoverable_after_restart",
+		)
 		// Seed runState for cleanup coordinates.
 		o.mu.Lock()
 		if _, ok := o.running[j.ID]; !ok {
@@ -546,7 +637,7 @@ func (o *Orchestrator) enqueueTerminal(jobID string, reason TerminalReason) {
 	default:
 		// channel full — run async
 		go func() {
-			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+			ctx, cancel := context.WithTimeout(context.Background(), TerminalWorkerTimeout)
 			defer cancel()
 			_ = o.HandleTerminal(ctx, jobID, reason)
 		}()

--- a/internal/deploy/job/orchestrator.go
+++ b/internal/deploy/job/orchestrator.go
@@ -203,17 +203,21 @@ func (o *Orchestrator) Start(ctx context.Context, req models.StartJobRequest) (m
 		profile = "spike"
 	}
 	now := time.Now().UTC()
+	sessionID := "sol-" + jobID
 	job := models.ProvisioningJob{
-		ID:          jobID,
-		DeviceID:    req.DeviceID,
-		ProfileRef:  profile,
-		State:       models.StateProvisioning,
-		Attempt:     1,
-		Phase:       "STARTING",
-		StartedAt:   &now,
-		UpdatedAt:   &now,
-		ISOURL:      req.ISOURL,
-		BMCEndpoint: req.BMCEndpoint,
+		ID:            jobID,
+		DeviceID:      req.DeviceID,
+		ProfileRef:    profile,
+		State:         models.StateProvisioning,
+		Attempt:       1,
+		Phase:         "STARTING",
+		StartedAt:     &now,
+		UpdatedAt:     &now,
+		ISOURL:        req.ISOURL,
+		BMCEndpoint:   req.BMCEndpoint,
+		SystemID:      req.SystemID,
+		CredentialRef: credRef,
+		SOLSessionID:  sessionID,
 	}
 	if err := o.store.Insert(ctx, job); err != nil {
 		return models.ProvisioningJob{}, err
@@ -226,7 +230,7 @@ func (o *Orchestrator) Start(ctx context.Context, req models.StartJobRequest) (m
 		systemID:   req.SystemID,
 		credential: credRef,
 		bmcURL:     req.BMCEndpoint,
-		sessionID:  "sol-" + jobID,
+		sessionID:  sessionID,
 	}
 	o.mu.Lock()
 	o.running[jobID] = rs
@@ -283,6 +287,10 @@ func (o *Orchestrator) provision(ctx context.Context, job models.ProvisioningJob
 		}
 	}
 	rs.systemID = sys.ID
+	// Persist runtime coords so a different process can cancel/orphan-cleanup.
+	if err := o.store.UpdateRuntime(ctx, job.ID, sys.ID, rs.sessionID, rs.credential); err != nil {
+		return fmt.Errorf("persist runtime: %w", err)
+	}
 
 	vms, err := bmc.ListVirtualMedia(ctx, sys.ID)
 	if err != nil {
@@ -420,14 +428,24 @@ func (o *Orchestrator) handleTerminalOnce(ctx context.Context, jobID string, rea
 		}
 	}
 
-	// Load job for BMC endpoint if needed. Prefer Background so a cancelled
+	// Load job for BMC coordinates. Prefer Background so a cancelled
 	// caller context cannot skip the terminal state write.
 	job, err := o.store.Get(context.Background(), jobID)
 	if err != nil {
 		return err
 	}
+	// Prefer in-memory runState; fall back to durable job fields (out-of-process cancel/orphan).
 	if bmcURL == "" {
 		bmcURL = job.BMCEndpoint
+	}
+	if systemID == "" {
+		systemID = job.SystemID
+	}
+	if credRef == "" {
+		credRef = job.CredentialRef
+	}
+	if sessionID == "" {
+		sessionID = job.SOLSessionID
 	}
 
 	// Always-run cleanup when we have BMC coordinates (hard timeout so we still transition).
@@ -613,14 +631,14 @@ func (o *Orchestrator) ReconcileOrphans(ctx context.Context) error {
 			"job_id", j.ID, "device_id", j.DeviceID,
 			"decision", "fail_orphan", "reason", "unrecoverable_after_restart",
 		)
-		// Seed runState for cleanup coordinates.
+		// Seed runState from durable job fields for cleanup coordinates.
 		o.mu.Lock()
 		if _, ok := o.running[j.ID]; !ok {
 			o.running[j.ID] = &runState{
 				bmcURL:     j.BMCEndpoint,
 				sessionID:  j.SOLSessionID,
-				systemID:   "",
-				credential: "", // may fail cleanup without creds; still transition
+				systemID:   j.SystemID,
+				credential: j.CredentialRef,
 			}
 		}
 		o.mu.Unlock()

--- a/internal/deploy/job/orchestrator_test.go
+++ b/internal/deploy/job/orchestrator_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/mattcburns/shoal/internal/common/models"
+	"github.com/mattcburns/shoal/internal/common/netbox"
 	"github.com/mattcburns/shoal/internal/common/redfish"
 	"github.com/mattcburns/shoal/internal/common/secrets"
 	"github.com/mattcburns/shoal/internal/deploy/job"
@@ -20,6 +21,10 @@ func TestOrchestratorHappyPathDone(t *testing.T) {
 	store := jobstore.NewMemory()
 	sec := secrets.NewMemory()
 	fakeBMC := redfish.NewFake()
+	nb := netbox.NewMemory()
+	_, _ = nb.UpsertDevice(ctx, models.DeviceIdentity{
+		Serial: "lab-node-1", LifecycleState: models.StateDiscovered,
+	})
 	log := slog.New(slog.NewTextHandler(io.Discard, nil))
 
 	// Pipe-based SOL transport: write markers into the watch.
@@ -37,6 +42,7 @@ func TestOrchestratorHappyPathDone(t *testing.T) {
 			return fakeBMC, nil
 		},
 		Watches:             watch,
+		NetBox:              nb,
 		AuthMode:            "basic",
 		TLSMode:             "off",
 		ReconcileFailOrphan: true,
@@ -60,6 +66,9 @@ func TestOrchestratorHappyPathDone(t *testing.T) {
 	}
 	if !fakeBMC.MediaInserted() {
 		t.Fatal("expected media inserted")
+	}
+	if nb.BySerial["lab-node-1"].LifecycleState != models.StateProvisioning {
+		t.Fatalf("netbox want provisioning, got %s", nb.BySerial["lab-node-1"].LifecycleState)
 	}
 
 	// Emit SOL progress then DONE
@@ -85,6 +94,9 @@ func TestOrchestratorHappyPathDone(t *testing.T) {
 	}
 	if !fakeBMC.BootCleared() || fakeBMC.MediaInserted() {
 		t.Fatal("cleanup incomplete: media/boot still set")
+	}
+	if nb.BySerial["lab-node-1"].LifecycleState != models.StateProvisioned {
+		t.Fatalf("netbox want provisioned, got %s", nb.BySerial["lab-node-1"].LifecycleState)
 	}
 	// password must not appear on job JSON-ish fields
 	if final.BMCEndpoint == "" {

--- a/internal/deploy/job/orchestrator_test.go
+++ b/internal/deploy/job/orchestrator_test.go
@@ -70,6 +70,14 @@ func TestOrchestratorHappyPathDone(t *testing.T) {
 	if nb.BySerial["lab-node-1"].LifecycleState != models.StateProvisioning {
 		t.Fatalf("netbox want provisioning, got %s", nb.BySerial["lab-node-1"].LifecycleState)
 	}
+	// Runtime coords must be durable for out-of-process cancel.
+	loaded, err := store.Get(ctx, j.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.SystemID == "" || loaded.CredentialRef == "" || loaded.SOLSessionID == "" {
+		t.Fatalf("runtime not persisted: system=%q cred=%q sol=%q", loaded.SystemID, loaded.CredentialRef, loaded.SOLSessionID)
+	}
 
 	// Emit SOL progress then DONE
 	writeMarker(t, pw, "SHOAL|1|1|2026-06-19T04:10:00Z|BOOT|5|OK|booting")
@@ -101,6 +109,55 @@ func TestOrchestratorHappyPathDone(t *testing.T) {
 	// password must not appear on job JSON-ish fields
 	if final.BMCEndpoint == "" {
 		t.Fatal("bmc endpoint should persist")
+	}
+}
+
+func TestOrchestratorCancelWithoutRunStateUsesDurableRuntime(t *testing.T) {
+	// Simulate out-of-process cancel: job + secrets exist, but no in-memory runState.
+	ctx := context.Background()
+	store := jobstore.NewMemory()
+	sec := secrets.NewMemory()
+	fakeBMC := redfish.NewFake()
+	// Pre-insert media as if another process started the job.
+	_ = fakeBMC.InsertVirtualMedia(ctx, "/redfish/v1/Managers/1/VirtualMedia/Cd", "http://iso/x.iso")
+	_ = fakeBMC.SetBootOverrideOnceCD(ctx, "1")
+	_ = sec.Put(ctx, "job-orphan", secrets.Credential{Username: "admin", Password: "secret"})
+	now := time.Now().UTC()
+	pj := models.ProvisioningJob{
+		ID: "orphan-1", DeviceID: "d1", State: models.StateProvisioning,
+		BMCEndpoint: "http://bmc.test", SystemID: "1", CredentialRef: "job-orphan",
+		SOLSessionID: "sol-orphan-1", StartedAt: &now, UpdatedAt: &now,
+	}
+	if err := store.Insert(ctx, pj); err != nil {
+		t.Fatal(err)
+	}
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	watch := sol.NewWatchService(log, nil)
+	orch := job.NewOrchestrator(job.Options{
+		Log: log, Store: store, Secrets: sec,
+		NewBMC: func(cfg redfish.Config) (redfish.BMC, error) { return fakeBMC, nil },
+		Watches: watch, AuthMode: "basic", TLSMode: "off", ReconcileFailOrphan: true,
+	})
+	defer orch.Stop()
+	watch.SetProgress(orch.ProgressPort())
+
+	if err := orch.Cancel(ctx, "orphan-1"); err != nil {
+		t.Fatal(err)
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	var final models.ProvisioningJob
+	for time.Now().Before(deadline) {
+		final, _ = store.Get(ctx, "orphan-1")
+		if final.State == models.StateFailed {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if final.State != models.StateFailed {
+		t.Fatalf("state %s err=%s", final.State, final.Error)
+	}
+	if fakeBMC.MediaInserted() || !fakeBMC.BootCleared() {
+		t.Fatal("expected cleanup using durable system_id + credential_ref")
 	}
 }
 

--- a/internal/deploy/jobstore/memory.go
+++ b/internal/deploy/jobstore/memory.go
@@ -89,6 +89,29 @@ func (m *Memory) UpdateProgress(_ context.Context, jobID string, phase string, p
 	return nil
 }
 
+// UpdateRuntime persists system_id, sol_session_id, and credential_ref.
+func (m *Memory) UpdateRuntime(_ context.Context, jobID string, systemID, solSessionID, credentialRef string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	j, ok := m.jobs[jobID]
+	if !ok {
+		return ErrNotFound
+	}
+	if systemID != "" {
+		j.SystemID = systemID
+	}
+	if solSessionID != "" {
+		j.SOLSessionID = solSessionID
+	}
+	if credentialRef != "" {
+		j.CredentialRef = credentialRef
+	}
+	now := time.Now().UTC()
+	j.UpdatedAt = &now
+	m.jobs[jobID] = j
+	return nil
+}
+
 // Transition sets lifecycle state and optional error message.
 func (m *Memory) Transition(_ context.Context, jobID string, to models.LifecycleState, errMsg string) error {
 	m.mu.Lock()

--- a/internal/deploy/jobstore/memory_test.go
+++ b/internal/deploy/jobstore/memory_test.go
@@ -47,3 +47,23 @@ func TestMemoryStoreLifecycle(t *testing.T) {
 		t.Fatalf("want not found: %v", err)
 	}
 }
+
+func TestMemoryUpdateRuntime(t *testing.T) {
+	ctx := context.Background()
+	s := jobstore.NewMemory()
+	if err := s.Insert(ctx, models.ProvisioningJob{
+		ID: "j2", DeviceID: "d2", State: models.StateProvisioning, CredentialRef: "job-j2",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.UpdateRuntime(ctx, "j2", "sys-1", "sol-j2", "job-j2"); err != nil {
+		t.Fatal(err)
+	}
+	got, err := s.Get(ctx, "j2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.SystemID != "sys-1" || got.SOLSessionID != "sol-j2" || got.CredentialRef != "job-j2" {
+		t.Fatalf("%+v", got)
+	}
+}

--- a/internal/deploy/jobstore/postgres.go
+++ b/internal/deploy/jobstore/postgres.go
@@ -32,12 +32,14 @@ func (p *Postgres) Insert(ctx context.Context, job models.ProvisioningJob) error
 	_, err := p.db.ExecContext(ctx, `
 INSERT INTO jobs (
   id, device_id, profile_ref, state, attempt, phase, percent, last_marker_seq,
-  started_at, updated_at, error, sol_session_id, iso_url, bmc_endpoint
-) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14)`,
+  started_at, updated_at, error, sol_session_id, iso_url, bmc_endpoint,
+  system_id, credential_ref
+) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16)`,
 		job.ID, job.DeviceID, job.ProfileRef, string(job.State), job.Attempt,
 		nullString(job.Phase), nullInt(job.Percent), job.LastMarkerSeq,
 		job.StartedAt, job.UpdatedAt, nullString(job.Error), nullString(job.SOLSessionID),
 		nullString(job.ISOURL), nullString(job.BMCEndpoint),
+		nullString(job.SystemID), nullString(job.CredentialRef),
 	)
 	if err != nil {
 		return fmt.Errorf("jobstore: insert: %w", err)
@@ -49,7 +51,8 @@ INSERT INTO jobs (
 func (p *Postgres) Get(ctx context.Context, id string) (models.ProvisioningJob, error) {
 	row := p.db.QueryRowContext(ctx, `
 SELECT id, device_id, profile_ref, state, attempt, phase, percent, last_marker_seq,
-       started_at, updated_at, error, sol_session_id, iso_url, bmc_endpoint
+       started_at, updated_at, error, sol_session_id, iso_url, bmc_endpoint,
+       system_id, credential_ref
 FROM jobs WHERE id = $1`, id)
 	j, err := scanJob(row)
 	if errors.Is(err, sql.ErrNoRows) {
@@ -65,7 +68,8 @@ FROM jobs WHERE id = $1`, id)
 func (p *Postgres) ListByState(ctx context.Context, state models.LifecycleState) ([]models.ProvisioningJob, error) {
 	rows, err := p.db.QueryContext(ctx, `
 SELECT id, device_id, profile_ref, state, attempt, phase, percent, last_marker_seq,
-       started_at, updated_at, error, sol_session_id, iso_url, bmc_endpoint
+       started_at, updated_at, error, sol_session_id, iso_url, bmc_endpoint,
+       system_id, credential_ref
 FROM jobs WHERE state = $1`, string(state))
 	if err != nil {
 		return nil, fmt.Errorf("jobstore: list: %w", err)
@@ -103,6 +107,26 @@ WHERE id = $1`, jobID, phase, nullInt(percent), seq, errSoft, now)
 	return nil
 }
 
+// UpdateRuntime persists system_id, sol_session_id, and credential_ref.
+func (p *Postgres) UpdateRuntime(ctx context.Context, jobID string, systemID, solSessionID, credentialRef string) error {
+	now := time.Now().UTC()
+	res, err := p.db.ExecContext(ctx, `
+UPDATE jobs SET
+  system_id = CASE WHEN $2 <> '' THEN $2 ELSE system_id END,
+  sol_session_id = CASE WHEN $3 <> '' THEN $3 ELSE sol_session_id END,
+  credential_ref = CASE WHEN $4 <> '' THEN $4 ELSE credential_ref END,
+  updated_at = $5
+WHERE id = $1`, jobID, systemID, solSessionID, credentialRef, now)
+	if err != nil {
+		return fmt.Errorf("jobstore: update runtime: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
 // Transition sets lifecycle state.
 func (p *Postgres) Transition(ctx context.Context, jobID string, to models.LifecycleState, errMsg string) error {
 	now := time.Now().UTC()
@@ -129,13 +153,14 @@ type scannable interface {
 func scanJob(row scannable) (models.ProvisioningJob, error) {
 	var j models.ProvisioningJob
 	var state string
-	var phase, errMsg, solSess, iso, bmc sql.NullString
+	var phase, errMsg, solSess, iso, bmc, sysID, credRef sql.NullString
 	var percent sql.NullInt64
 	var started, updated sql.NullTime
 	err := row.Scan(
 		&j.ID, &j.DeviceID, &j.ProfileRef, &state, &j.Attempt,
 		&phase, &percent, &j.LastMarkerSeq,
 		&started, &updated, &errMsg, &solSess, &iso, &bmc,
+		&sysID, &credRef,
 	)
 	if err != nil {
 		return models.ProvisioningJob{}, err
@@ -167,6 +192,12 @@ func scanJob(row scannable) (models.ProvisioningJob, error) {
 	}
 	if bmc.Valid {
 		j.BMCEndpoint = bmc.String
+	}
+	if sysID.Valid {
+		j.SystemID = sysID.String
+	}
+	if credRef.Valid {
+		j.CredentialRef = credRef.String
 	}
 	return j, nil
 }

--- a/internal/deploy/jobstore/store.go
+++ b/internal/deploy/jobstore/store.go
@@ -18,5 +18,7 @@ type Store interface {
 	Get(ctx context.Context, id string) (models.ProvisioningJob, error)
 	ListByState(ctx context.Context, state models.LifecycleState) ([]models.ProvisioningJob, error)
 	UpdateProgress(ctx context.Context, jobID string, phase string, percent *int, seq int, errSoft string) error
+	// UpdateRuntime persists BMC runtime coordinates for cancel/orphan cleanup.
+	UpdateRuntime(ctx context.Context, jobID string, systemID, solSessionID, credentialRef string) error
 	Transition(ctx context.Context, jobID string, to models.LifecycleState, errMsg string) error
 }


### PR DESCRIPTION
## Summary

Phase **5a** (first of three Deploy-harden PRs):

- **`netbox.LifecycleWriter` / `SetLifecycle`** — serial or id lookup; custom field with comments fallback
- **Orchestrator** best-effort NetBox sync on Start (`provisioning`) and HandleTerminal (`provisioned`/`failed`)
- **Reliability polish:** named cleanup/unregister timeouts; DONE **post-check** (media ejected, boot clear); orphan logs use `decision=fail_orphan|skip`
- **`POST /v1/jobs`** starts a job (parity with CLI `deploy run` body)
- Docs: Phase 0–4 done; Phase 5 in progress; lab-runbook lifecycle table

## Test plan

- [x] `go test ./internal/common/netbox/ ./internal/deploy/job/ ./internal/api/ ./...`
- [x] Happy-path unit test asserts NetBox memory lifecycle provisioning → provisioned
- [ ] Optional lab: deploy run with NetBox env → device lifecycle_state updates

## Out of scope (5b/5c)

Profile gen + approval; ISO build/publish pipeline.