### PR TITLE
feat(deploy): ISO build/publish pipeline + profile ISO resolve (Phase 5c)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -238,7 +238,9 @@ go run ./cmd/shoal deploy run \
 | `SHOAL_REDFISH_TLS_MODE` | `off` \| `insecure` \| `custom_ca` |
 | `SHOAL_REDFISH_CA_FILE` | If `custom_ca` |
 | `SHOAL_BMC_USERNAME` / `SHOAL_BMC_PASSWORD` | Lab defaults only; production uses secrets backend per device |
-| `SHOAL_ISO_BASE_URL` | e.g. `http://192.168.122.100:8080` |
+| `SHOAL_ISO_BASE_URL` | BMC-reachable ISO HTTP prefix (lab nested: `http://192.168.124.1:8080`). Used to resolve profile `iso_base` and `deploy iso publish` |
+| `SHOAL_ISO_PUBLISH_DIR` | Filesystem dir served on `:8080` (lab: `/srv/iso`). Phase 5c publish target |
+| `SHOAL_ISO_BUILD_SCRIPT` | Optional path to `build-marker-iso.sh` (auto-discovers from repo) |
 | `SHOAL_RECONCILE_FAIL_ORPHANS` | Default `true` |
 | `SHOAL_FEWSHOT_DIR` | Append-only learned few-shot JSONL (confirm learning). Lab Ansible default: `/var/lib/shoal/fewshot` via `shoal_fewshot_dir` + `env.j2`. Empty disables confirm |
 | `SHOAL_PROFILE_DIR` | JSON provisioning profiles + approval records (Phase 5b). Lab Ansible default: `/var/lib/shoal/profiles` via `shoal_profile_dir` + `env.j2`. Empty disables non-spike profile load |
@@ -251,14 +253,14 @@ only (no silent memory fallback). Empty SEL/sensors with exit 0 is valid when th
 BMC has no logs; write failures and Redfish errors fail the poll. Observe never
 imports Deploy (job reads via `jobport.JobQuery`).
 
-**Phase 5 Deploy (in progress):** Orchestrator may best-effort sync NetBox
-`lifecycle_state` via `netbox.LifecycleWriter` on Start/HandleTerminal (never
-blocks BMC on NetBox errors). Lab bootstrap creates device custom fields
-`lifecycle_state`, `credential_ref`, `bmc_ip`. Jobs persist `system_id` +
-`credential_ref` for out-of-process cancel/orphan BMC cleanup (share
-`SHOAL_SECRETS_DIR`). Profiles live under `SHOAL_PROFILE_DIR`; destruct /
-`needs_approval` require `profile approve` or `-approve-destruct` before Start.
-Sole lifecycle writer remains Orchestrator; JobStore stays pure persistence.
+**Phase 5 Deploy:** Orchestrator best-effort syncs NetBox `lifecycle_state` on
+Start/HandleTerminal. Profiles under `SHOAL_PROFILE_DIR`; destruct /
+`needs_approval` require approve or `-approve-destruct`. **Phase 5c ISO:**
+`internal/deploy/iso` wraps `build-marker-iso.sh`, publishes to
+`SHOAL_ISO_PUBLISH_DIR`, and Start resolves empty `-iso-url` from profile
+`iso_base` + `SHOAL_ISO_BASE_URL`. Still plain HTTP on mgmt segment; Ansible
+marker_iso remains primary lab producer. Sole lifecycle writer remains
+Orchestrator; JobStore stays pure persistence.
 
 ---
 

--- a/SHOAL_COMPREHENSIVE_DESIGN_AND_IMPLEMENTATION_PLAN.md
+++ b/SHOAL_COMPREHENSIVE_DESIGN_AND_IMPLEMENTATION_PLAN.md
@@ -1328,7 +1328,9 @@ Default VM-hosted endpoints: NetBox `:8000`, sushy `:8001`, ISO HTTP `:8080`, Ol
 | `SHOAL_REDFISH_TLS_MODE` | no | `off`\|`insecure`\|`custom_ca` |
 | `SHOAL_REDFISH_CA_FILE` | if custom_ca | Path |
 | `SHOAL_BMC_USERNAME` / `SHOAL_BMC_PASSWORD` | lab only | Existing vault vars — for lab defaults / smoke; production uses secrets backend per device |
-| `SHOAL_ISO_BASE_URL` | no | e.g. `http://192.168.122.100:8080` |
+| `SHOAL_ISO_BASE_URL` | no | BMC-reachable ISO HTTP prefix (lab nested: `http://192.168.124.1:8080`). Ansible `env.j2` sets gateway + port. Used for profile `iso_base` resolve + publish URL |
+| `SHOAL_ISO_PUBLISH_DIR` | no | Filesystem publish dir (lab: `shoal_iso_server_dir` → `/srv/iso` in `env.j2`) |
+| `SHOAL_ISO_BUILD_SCRIPT` | no | Optional path to `build-marker-iso.sh` |
 | `SHOAL_RECONCILE_FAIL_ORPHANS` | no | Default `true` |
 | `SHOAL_FEWSHOT_DIR` | no | Append-only learned few-shot JSONL (Phase 3b confirm). Lab default via Ansible `shoal_fewshot_dir` → `/var/lib/shoal/fewshot` in `env.j2` + mkdir. Empty disables confirm |
 | `SHOAL_PROFILE_DIR` | no | JSON provisioning profiles + approval records (Phase 5b). Lab default via Ansible `shoal_profile_dir` → `/var/lib/shoal/profiles` in `env.j2` + mkdir. Empty disables non-spike profile load; `spike` profile ref always allowed without a store |
@@ -1420,6 +1422,8 @@ SEL/sensor poll, session caps, event normalize, watch mode, CLI status; stretch 
 Full ISO pipeline, reliability contract polish, profile generation + approval, NetBox lifecycle sync.
 
 **Phase 5b (profiles + approval):** Core `Profiler` generates `ProvisioningProfile` via AI + schema validate. Durable store under `SHOAL_PROFILE_DIR` (not NetBox). CLI `shoal profile generate|save|show|list|approve`. Deploy `Start` rejects non-`spike` refs without store entry; `NeedsApproval` / non-empty `DestructSteps` require prior `profile approve` or `StartJobRequest.ApproveDestruct` / `-approve-destruct`. AI never auto-executes destruct.
+
+**Phase 5c (ISO pipeline):** `internal/deploy/iso` `Builder` wraps `infra/scripts/build-marker-iso.sh` (`os/exec`), optional `EmbeddedPayload` → `/payload` in the image, `Publish` to `SHOAL_ISO_PUBLISH_DIR` + `SHOAL_ISO_BASE_URL`. CLI `shoal deploy iso build|publish`. Start fills empty `ISOURL` from profile `iso_base` + base URL. Lab Ansible still primary producer; serve remains nginx `:8080` plain HTTP.
 
 ### Phase 6: Polish
 

--- a/docs/lab-runbook.md
+++ b/docs/lab-runbook.md
@@ -254,6 +254,39 @@ go run ./cmd/shoal deploy run -profile-ref wipe-me -approve-destruct ...
 `-approve-destruct` is set. AI never auto-executes destruct. Spike / empty
 `profile-ref` still works with `SHOAL_PROFILE_DIR` unset.
 
+### Phase 5c: ISO build / publish / resolve
+
+**Lab default (Ansible):** `SHOAL_ISO_PUBLISH_DIR` = `shoal_iso_server_dir`
+(`/srv/iso`); `SHOAL_ISO_BASE_URL` = BMC-reachable
+`http://{{ shoal_lab_network_gateway }}:8080` (VM nested: `http://192.168.124.1:8080`).
+The `marker_iso` role remains the primary producer of `shoal-marker.iso`.
+
+**Go path (Phase 5c):** wrap the same `build-marker-iso.sh` and publish:
+
+```bash
+# On L1 (or with publish dir reachable) after sourcing lab env:
+export SHOAL_ISO_PUBLISH_DIR=/srv/iso
+export SHOAL_ISO_BASE_URL=http://192.168.124.1:8080
+
+# Build marker ISO (+ optional non-secret payload inject)
+go run ./cmd/shoal deploy iso build -name shoal-marker.iso -publish
+# Or publish a prebuilt file:
+go run ./cmd/shoal deploy iso publish -file ./shoal-marker.iso
+
+# Deploy: omit -iso-url when profile.iso_base resolves via SHOAL_ISO_BASE_URL
+export SHOAL_PROFILE_DIR=./.shoal/profiles
+go run ./cmd/shoal deploy run \
+  -device-id shoal-node-1 \
+  -bmc-url http://192.168.122.100:8001 \
+  -serial-target shoal-node-1 \
+  -profile-ref lab-1-ubuntu \
+  # iso_base e.g. "shoal-marker" → http://192.168.124.1:8080/shoal-marker.iso
+```
+
+Operator-supplied `-iso-url` still wins over profile resolve. Spike profile always
+requires `-iso-url`. Payload inject uses `SHOAL_EMBEDDED_PAYLOAD` / `-payload`
+(never secrets).
+
 ## 2) Fast stop (teardown / clean slate)
 ```bash
 ansible-playbook -i infra/ansible/inventory/lab-vm.yml infra/ansible/playbooks/down.yml

--- a/docs/phase2-live-image.md
+++ b/docs/phase2-live-image.md
@@ -14,6 +14,10 @@ See design §4.3. Reference shell emitter (non-bootable harness):
 
 ## Build + publish
 
+Phase **5c** also exposes a Go wrapper (`shoal deploy iso build|publish`) around
+the same script, with optional `EmbeddedPayload` inject and publish into
+`SHOAL_ISO_PUBLISH_DIR`. Ansible remains the primary lab path.
+
 ### Primary: Ansible on lab VM (L1)
 
 ```bash

--- a/infra/ansible/roles/compose_stack/templates/env.j2
+++ b/infra/ansible/roles/compose_stack/templates/env.j2
@@ -3,6 +3,9 @@ SHOAL_NETBOX_POSTGRES_PASSWORD={{ shoal_netbox_postgres_password }}
 SHOAL_REDIS_PASSWORD={{ shoal_redis_password }}
 SHOAL_ISO_SERVER_PORT={{ shoal_iso_server_port }}
 SHOAL_ISO_SERVER_DIR={{ shoal_iso_server_dir }}
+# Phase 5c: Go ISO publish + profile iso_base resolve (BMC-reachable base URL).
+SHOAL_ISO_PUBLISH_DIR={{ shoal_iso_server_dir }}
+SHOAL_ISO_BASE_URL=http://{{ shoal_lab_network_gateway }}:{{ shoal_iso_server_port }}
 # AI provider (see design doc §6 / v2.0.4). Provider is "ollama" (local, in the
 # lab VM) or "cloud". SHOAL_OLLAMA_URL is the base URL for the local Ollama
 # container; cloud vars are only used when SHOAL_AI_PROVIDER=cloud.

--- a/infra/scripts/build-marker-iso.sh
+++ b/infra/scripts/build-marker-iso.sh
@@ -14,6 +14,11 @@
 set -euo pipefail
 
 OUT="${1:-${SHOAL_ISO_OUT:-./shoal-marker.iso}}"
+# Optional basename override (Phase 5c Go builder sets SHOAL_ISO_NAME).
+if [[ -n "${SHOAL_ISO_NAME:-}" ]]; then
+  OUT_DIR="$(dirname "$OUT")"
+  OUT="${OUT_DIR%/}/${SHOAL_ISO_NAME}"
+fi
 WORK="$(mktemp -d "${TMPDIR:-/tmp}/shoal-marker-iso.XXXXXX")"
 cleanup() { rm -rf "$WORK"; }
 trap cleanup EXIT
@@ -82,6 +87,16 @@ for app in sh mount umount mkdir sleep cat echo poweroff reboot mkdir ln; do
   ln -sf busybox "$ROOT/bin/$app"
 done
 
+# Optional static base inject (Phase 5c): non-secret payload file inside the image.
+# Prefer SHOAL_PAYLOAD_FILE (path); else SHOAL_EMBEDDED_PAYLOAD (inline text).
+if [[ -n "${SHOAL_PAYLOAD_FILE:-}" && -r "${SHOAL_PAYLOAD_FILE}" ]]; then
+  cp "${SHOAL_PAYLOAD_FILE}" "$ROOT/payload"
+  chmod 644 "$ROOT/payload"
+elif [[ -n "${SHOAL_EMBEDDED_PAYLOAD:-}" ]]; then
+  printf '%s' "${SHOAL_EMBEDDED_PAYLOAD}" > "$ROOT/payload"
+  chmod 644 "$ROOT/payload"
+fi
+
 # Init emits markers then powers off. console=ttyS0 from kernel cmdline.
 cat > "$ROOT/init" << 'INIT'
 #!/bin/busybox sh
@@ -108,7 +123,13 @@ emit() {
 }
 
 # Short Phase-2 demonstration sequence (no real disk write).
-emit BOOT 0 OK "marker live image started"
+# If /payload was injected (Phase 5c), note its size in BOOT detail — never echo secrets.
+boot_detail="marker live image started"
+if [ -f /payload ]; then
+  psz="$(wc -c </payload 2>/dev/null || echo 0)"
+  boot_detail="marker live image started payload_bytes=${psz}"
+fi
+emit BOOT 0 OK "$boot_detail"
 sleep 1
 emit BOOT - HEARTBEAT ""
 sleep 1

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -74,12 +74,19 @@ Usage:
 Commands:
   version    Print version and exit
   serve      Run the HTTP API server
-  deploy     Provisioning: run | status | cancel
+  deploy     Provisioning: run | status | cancel | iso
   discover   Assets: ingest | confirm
   observe    Status / poll: status | poll
   profile    Profiles: generate | save | show | list | approve
 
-Phase 5 profile example:
+Phase 5c ISO example:
+  export SHOAL_ISO_BASE_URL=http://192.168.124.1:8080
+  export SHOAL_ISO_PUBLISH_DIR=/srv/iso   # on lab host, or local mirror
+  shoal deploy iso build -name shoal-marker.iso -publish
+  # deploy without -iso-url when profile.iso_base resolves via SHOAL_ISO_BASE_URL
+  shoal deploy run -profile-ref lab-1-ubuntu -bmc-url … -serial-target …
+
+Phase 5b profile example:
   export SHOAL_PROFILE_DIR=./.shoal/profiles
   export SHOAL_AI_PROVIDER=ollama SHOAL_AI_MODEL=llama3.2:3b
   shoal profile generate -os-family ubuntu -hostname lab-1 -save
@@ -206,6 +213,7 @@ func cmdServe(args []string) int {
 			Watches:             watchSvc,
 			NetBox:              nb,
 			Profiles:            profStore,
+			ISOBaseURL:          cfg.ISOBaseURL,
 			AuthMode:            cfg.RedfishAuthMode,
 			TLSMode:             cfg.RedfishTLSMode,
 			CAFile:              cfg.RedfishCAFile,

--- a/internal/cli/deploy.go
+++ b/internal/cli/deploy.go
@@ -23,7 +23,7 @@ import (
 
 func cmdDeploy(args []string) int {
 	if len(args) < 1 {
-		fmt.Fprintln(os.Stderr, "usage: shoal deploy <run|status|cancel> [flags]")
+		fmt.Fprintln(os.Stderr, "usage: shoal deploy <run|status|cancel|iso> [flags]")
 		return 2
 	}
 	switch args[0] {
@@ -33,6 +33,8 @@ func cmdDeploy(args []string) int {
 		return cmdDeployStatus(args[1:])
 	case "cancel":
 		return cmdDeployCancel(args[1:])
+	case "iso":
+		return cmdDeployISO(args[1:])
 	default:
 		fmt.Fprintf(os.Stderr, "unknown deploy subcommand %q\n", args[0])
 		return 2
@@ -55,7 +57,7 @@ func cmdDeployRun(args []string) int {
 	bmcUser := fs.String("bmc-user", cfg.BMCUsername, "BMC username")
 	bmcPass := fs.String("bmc-pass", cfg.BMCPassword, "BMC password (never logged)")
 	serial := fs.String("serial-target", "", "libvirt domain or console path")
-	isoURL := fs.String("iso-url", "", "BMC-reachable ISO URL on lab :8080")
+	isoURL := fs.String("iso-url", "", "BMC-reachable ISO URL (optional if non-spike profile + SHOAL_ISO_BASE_URL)")
 	systemID := fs.String("system-id", "", "optional Redfish system id or name")
 	profileRef := fs.String("profile-ref", "spike", "profile ref (spike = no store; else SHOAL_PROFILE_DIR)")
 	approveDestruct := fs.Bool("approve-destruct", false, "operator consent for NeedsApproval/DestructSteps profiles")
@@ -129,6 +131,7 @@ func cmdDeployRun(args []string) int {
 		Watches:             watchSvc,
 		NetBox:              nb,
 		Profiles:            profStore,
+		ISOBaseURL:          cfg.ISOBaseURL,
 		AuthMode:            cfg.RedfishAuthMode,
 		TLSMode:             cfg.RedfishTLSMode,
 		CAFile:              cfg.RedfishCAFile,

--- a/internal/cli/iso.go
+++ b/internal/cli/iso.go
@@ -1,0 +1,174 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/mattcburns/shoal/internal/common/config"
+	"github.com/mattcburns/shoal/internal/core/profile"
+	"github.com/mattcburns/shoal/internal/deploy/iso"
+)
+
+func cmdDeployISO(args []string) int {
+	if len(args) < 1 {
+		fmt.Fprintln(os.Stderr, "usage: shoal deploy iso <build|publish> [flags]")
+		return 2
+	}
+	switch args[0] {
+	case "build":
+		return cmdISOBuild(args[1:])
+	case "publish":
+		return cmdISOPublish(args[1:])
+	default:
+		fmt.Fprintf(os.Stderr, "unknown deploy iso subcommand %q\n", args[0])
+		return 2
+	}
+}
+
+func cmdISOBuild(args []string) int {
+	cfg, err := config.Load()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "config: %v\n", err)
+		return 1
+	}
+	log := newLogger(cfg.LogLevel)
+	fs := flag.NewFlagSet("deploy iso build", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	name := fs.String("name", "shoal-marker.iso", "output ISO basename")
+	outDir := fs.String("out-dir", "", "local output directory (default: temp or -out parent)")
+	out := fs.String("out", "", "full output path (overrides -name/-out-dir)")
+	payload := fs.String("payload", "", "non-secret embedded payload text")
+	payloadFile := fs.String("payload-file", "", "read non-secret payload from file")
+	profileRef := fs.String("profile-ref", "", "load iso_base/name/payload hints from profile store")
+	publish := fs.Bool("publish", false, "also publish to SHOAL_ISO_PUBLISH_DIR")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	in := iso.BuildInput{
+		Name:       *name,
+		OutDir:     *outDir,
+		ScriptPath: cfg.ISOBuildScript,
+	}
+	if *out != "" {
+		in.OutDir = filepath.Dir(*out)
+		in.Name = filepath.Base(*out)
+	}
+	if *payloadFile != "" {
+		b, err := os.ReadFile(*payloadFile)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "payload-file: %v\n", err)
+			return 1
+		}
+		in.EmbeddedPayload = string(b)
+	} else if *payload != "" {
+		in.EmbeddedPayload = *payload
+	}
+	if *profileRef != "" {
+		if cfg.ProfileDir == "" {
+			fmt.Fprintln(os.Stderr, "profile-ref requires SHOAL_PROFILE_DIR")
+			return 1
+		}
+		st, err := profile.NewFileStore(cfg.ProfileDir)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "profile store: %v\n", err)
+			return 1
+		}
+		rec, err := st.Get(context.Background(), *profileRef)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "profile: %v\n", err)
+			return 1
+		}
+		if in.Name == "shoal-marker.iso" && rec.Profile.ISOBase != "" {
+			base := filepath.Base(rec.Profile.ISOBase)
+			if filepath.Ext(base) == "" {
+				base += ".iso"
+			}
+			in.Name = base
+		}
+		if in.EmbeddedPayload == "" && rec.Profile.EmbeddedPayload != "" {
+			in.EmbeddedPayload = rec.Profile.EmbeddedPayload
+		}
+	}
+
+	b := iso.NewScriptBuilder(cfg.ISOBuildScript, log)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+	art, err := b.Build(ctx, in)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "build: %v\n", err)
+		return 1
+	}
+
+	result := map[string]any{
+		"path": art.Path,
+		"name": art.Name,
+		"size": art.Size,
+	}
+	if *publish {
+		if cfg.ISOPublishDir == "" || cfg.ISOBaseURL == "" {
+			fmt.Fprintln(os.Stderr, "publish requires SHOAL_ISO_PUBLISH_DIR and SHOAL_ISO_BASE_URL")
+			return 1
+		}
+		url, err := b.Publish(ctx, art, iso.PublishDest{Dir: cfg.ISOPublishDir, BaseURL: cfg.ISOBaseURL})
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "publish: %v\n", err)
+			return 1
+		}
+		result["url"] = url
+	}
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	_ = enc.Encode(result)
+	return 0
+}
+
+func cmdISOPublish(args []string) int {
+	cfg, err := config.Load()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "config: %v\n", err)
+		return 1
+	}
+	log := newLogger(cfg.LogLevel)
+	fs := flag.NewFlagSet("deploy iso publish", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	file := fs.String("file", "", "path to local .iso")
+	name := fs.String("name", "", "published basename (default: source basename)")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if *file == "" {
+		fmt.Fprintln(os.Stderr, "deploy iso publish: -file required")
+		return 2
+	}
+	if cfg.ISOPublishDir == "" || cfg.ISOBaseURL == "" {
+		fmt.Fprintln(os.Stderr, "publish requires SHOAL_ISO_PUBLISH_DIR and SHOAL_ISO_BASE_URL")
+		return 1
+	}
+	base := *name
+	if base == "" {
+		base = filepath.Base(*file)
+	}
+	st, err := os.Stat(*file)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "stat: %v\n", err)
+		return 1
+	}
+	b := iso.NewScriptBuilder(cfg.ISOBuildScript, log)
+	url, err := b.Publish(context.Background(), iso.Artifact{
+		Path: *file, Name: base, Size: st.Size(),
+	}, iso.PublishDest{Dir: cfg.ISOPublishDir, BaseURL: cfg.ISOBaseURL})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "publish: %v\n", err)
+		return 1
+	}
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	_ = enc.Encode(map[string]any{"path": filepath.Join(cfg.ISOPublishDir, base), "url": url, "name": base})
+	return 0
+}

--- a/internal/common/config/config.go
+++ b/internal/common/config/config.go
@@ -26,7 +26,9 @@ type Config struct {
 	RedfishCAFile        string
 	BMCUsername          string
 	BMCPassword          string
-	ISOBaseURL           string
+	ISOBaseURL           string // public HTTP prefix for Virtual Media (e.g. http://192.168.124.1:8080)
+	ISOPublishDir        string // filesystem dir served on :8080 (e.g. /srv/iso); Phase 5c publish
+	ISOBuildScript       string // optional path to build-marker-iso.sh
 	ReconcileFailOrphans bool
 	SecretsDir           string
 	// Serial SSH delegate (VM-hosted lab: nest libvirt on L1).
@@ -62,6 +64,8 @@ func Load() (Config, error) {
 		BMCUsername:          os.Getenv("SHOAL_BMC_USERNAME"),
 		BMCPassword:          os.Getenv("SHOAL_BMC_PASSWORD"),
 		ISOBaseURL:           os.Getenv("SHOAL_ISO_BASE_URL"),
+		ISOPublishDir:        os.Getenv("SHOAL_ISO_PUBLISH_DIR"),
+		ISOBuildScript:       os.Getenv("SHOAL_ISO_BUILD_SCRIPT"),
 		ReconcileFailOrphans: true,
 		SecretsDir:           envOr("SHOAL_SECRETS_DIR", ""),
 		SerialSSHHost:        os.Getenv("SHOAL_SERIAL_SSH_HOST"),

--- a/internal/common/validate/validate.go
+++ b/internal/common/validate/validate.go
@@ -136,6 +136,8 @@ func RawAssetInput(in models.RawAssetInput) error {
 }
 
 // StartJobRequest requires Phase 2 binding fields.
+// ISOURL may be empty when ProfileRef is a non-spike stored profile so Deploy can
+// resolve iso_base via SHOAL_ISO_BASE_URL (Phase 5c); Orchestrator fills it before BMC.
 func StartJobRequest(r models.StartJobRequest) error {
 	if strings.TrimSpace(r.DeviceID) == "" {
 		return fmt.Errorf("validate: device_id is required")
@@ -144,7 +146,10 @@ func StartJobRequest(r models.StartJobRequest) error {
 		return fmt.Errorf("validate: bmc_endpoint is required")
 	}
 	if strings.TrimSpace(r.ISOURL) == "" {
-		return fmt.Errorf("validate: iso_url is required")
+		ref := strings.TrimSpace(r.ProfileRef)
+		if ref == "" || ref == "spike" {
+			return fmt.Errorf("validate: iso_url is required (or non-spike profile_ref for ISO resolve)")
+		}
 	}
 	if strings.TrimSpace(r.SerialTarget) == "" {
 		return fmt.Errorf("validate: serial_target is required")

--- a/internal/common/validate/validate_test.go
+++ b/internal/common/validate/validate_test.go
@@ -66,4 +66,16 @@ func TestStartJobRequest(t *testing.T) {
 	if err := validate.StartJobRequest(bad); err == nil {
 		t.Fatal("expected error")
 	}
+	// Phase 5c: non-spike profile may omit iso_url (resolved later).
+	resolve := good
+	resolve.ISOURL = ""
+	resolve.ProfileRef = "lab-1-ubuntu"
+	if err := validate.StartJobRequest(resolve); err != nil {
+		t.Fatal(err)
+	}
+	spike := resolve
+	spike.ProfileRef = "spike"
+	if err := validate.StartJobRequest(spike); err == nil {
+		t.Fatal("spike still requires iso_url")
+	}
 }

--- a/internal/deploy/iso/doc.go
+++ b/internal/deploy/iso/doc.go
@@ -1,3 +1,9 @@
 // Package iso builds and publishes live images for Virtual Media boot.
-// Phase 2 serves ISOs via lab nginx :8080 after copy into the lab ISO dir.
+//
+// Phase 2: Ansible/lab nginx serves a prebuilt marker ISO on :8080.
+// Phase 5c: Go-owned Builder wraps the known-good build-marker-iso.sh,
+// publishes into SHOAL_ISO_PUBLISH_DIR, and resolves profile iso_base → URL
+// for Deploy Start when -iso-url is omitted.
+//
+// MVP still serves plain HTTP on the management segment (no TLS ISO server).
 package iso

--- a/internal/deploy/iso/iso.go
+++ b/internal/deploy/iso/iso.go
@@ -1,0 +1,272 @@
+package iso
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// BuildInput describes a live-image build request.
+type BuildInput struct {
+	// Name is the output basename without path (default shoal-marker.iso).
+	Name string
+	// OutDir is the directory for the local artifact (default os.TempDir or CWD).
+	OutDir string
+	// EmbeddedPayload is non-secret text written into the image as /payload.
+	// Secrets must never be passed here.
+	EmbeddedPayload string
+	// ScriptPath overrides the marker build script (empty = auto-discover).
+	ScriptPath string
+}
+
+// Artifact is a local ISO file produced by Build.
+type Artifact struct {
+	Path string
+	Name string
+	Size int64
+}
+
+// PublishDest is the lab ISO HTTP tree (or a local stand-in).
+type PublishDest struct {
+	// Dir is the filesystem directory served by nginx (e.g. /srv/iso).
+	Dir string
+	// BaseURL is the public prefix (e.g. http://192.168.124.1:8080) without trailing slash.
+	BaseURL string
+}
+
+// Builder builds and publishes bootable live ISOs for Virtual Media.
+type Builder interface {
+	Build(ctx context.Context, in BuildInput) (Artifact, error)
+	Publish(ctx context.Context, art Artifact, dest PublishDest) (string, error)
+}
+
+// ScriptBuilder wraps infra/scripts/build-marker-iso.sh via os/exec.
+type ScriptBuilder struct {
+	// ScriptPath is the absolute or relative path to build-marker-iso.sh.
+	// Empty uses FindBuildScript.
+	ScriptPath string
+	Log        *slog.Logger
+}
+
+// NewScriptBuilder constructs a ScriptBuilder.
+func NewScriptBuilder(scriptPath string, log *slog.Logger) *ScriptBuilder {
+	if log == nil {
+		log = slog.Default()
+	}
+	return &ScriptBuilder{ScriptPath: scriptPath, Log: log}
+}
+
+// Build runs the marker ISO script (xorriso/busybox host tools required).
+func (b *ScriptBuilder) Build(ctx context.Context, in BuildInput) (Artifact, error) {
+	script := in.ScriptPath
+	if script == "" {
+		script = b.ScriptPath
+	}
+	if script == "" {
+		var err error
+		script, err = FindBuildScript()
+		if err != nil {
+			return Artifact{}, err
+		}
+	}
+	name := strings.TrimSpace(in.Name)
+	if name == "" {
+		name = "shoal-marker.iso"
+	}
+	if !strings.HasSuffix(strings.ToLower(name), ".iso") {
+		name += ".iso"
+	}
+	// Sanitize basename only.
+	name = filepath.Base(name)
+	outDir := in.OutDir
+	if outDir == "" {
+		outDir = os.TempDir()
+	}
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
+		return Artifact{}, fmt.Errorf("iso: mkdir out: %w", err)
+	}
+	outPath := filepath.Join(outDir, name)
+
+	cmd := exec.CommandContext(ctx, script, outPath)
+	cmd.Env = os.Environ()
+	// Pass embedded payload without putting secrets into argv (env is still
+	// process-visible; callers must not pass passwords).
+	if p := strings.TrimSpace(in.EmbeddedPayload); p != "" {
+		if looksSecretPayload(p) {
+			return Artifact{}, fmt.Errorf("iso: embedded_payload must not contain secret-like content")
+		}
+		cmd.Env = append(cmd.Env, "SHOAL_EMBEDDED_PAYLOAD="+p)
+	}
+	cmd.Env = append(cmd.Env, "SHOAL_ISO_NAME="+name)
+
+	start := time.Now()
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return Artifact{}, fmt.Errorf("iso: build script failed: %w\n%s", err, truncate(string(out), 2<<10))
+	}
+	st, err := os.Stat(outPath)
+	if err != nil {
+		return Artifact{}, fmt.Errorf("iso: output missing after build: %w\n%s", err, truncate(string(out), 512))
+	}
+	b.Log.Info("iso built",
+		"path", outPath,
+		"size", st.Size(),
+		"elapsed_ms", time.Since(start).Milliseconds(),
+	)
+	return Artifact{Path: outPath, Name: name, Size: st.Size()}, nil
+}
+
+// Publish copies the artifact into dest.Dir and returns BaseURL/name.
+func (b *ScriptBuilder) Publish(_ context.Context, art Artifact, dest PublishDest) (string, error) {
+	if strings.TrimSpace(dest.Dir) == "" {
+		return "", fmt.Errorf("iso: publish dir is empty (set SHOAL_ISO_PUBLISH_DIR)")
+	}
+	if strings.TrimSpace(dest.BaseURL) == "" {
+		return "", fmt.Errorf("iso: base URL is empty (set SHOAL_ISO_BASE_URL)")
+	}
+	if art.Path == "" {
+		return "", fmt.Errorf("iso: empty artifact path")
+	}
+	name := art.Name
+	if name == "" {
+		name = filepath.Base(art.Path)
+	}
+	name = filepath.Base(name)
+	if err := os.MkdirAll(dest.Dir, 0o755); err != nil {
+		return "", fmt.Errorf("iso: mkdir publish: %w", err)
+	}
+	destPath := filepath.Join(dest.Dir, name)
+	if err := copyFile(art.Path, destPath); err != nil {
+		return "", err
+	}
+	url, err := PublicURL(dest.BaseURL, name)
+	if err != nil {
+		return "", err
+	}
+	b.Log.Info("iso published", "path", destPath, "url", url)
+	return url, nil
+}
+
+// PublicURL joins base URL and filename.
+func PublicURL(baseURL, filename string) (string, error) {
+	base := strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	name := filepath.Base(strings.TrimSpace(filename))
+	if base == "" {
+		return "", fmt.Errorf("iso: empty base URL")
+	}
+	if name == "" || name == "." || name == "/" {
+		return "", fmt.Errorf("iso: empty filename")
+	}
+	return base + "/" + name, nil
+}
+
+// ResolveFromProfile turns profile.iso_base into a BMC-reachable URL.
+//
+// Rules:
+//   - empty iso_base → error
+//   - http(s)://… → returned as-is
+//   - otherwise requires baseURL and appends .iso if missing
+func ResolveFromProfile(isoBase, baseURL string) (string, error) {
+	isoBase = strings.TrimSpace(isoBase)
+	if isoBase == "" {
+		return "", fmt.Errorf("iso: profile iso_base is empty")
+	}
+	lower := strings.ToLower(isoBase)
+	if strings.HasPrefix(lower, "http://") || strings.HasPrefix(lower, "https://") {
+		return isoBase, nil
+	}
+	name := isoBase
+	if !strings.HasSuffix(lower, ".iso") {
+		name += ".iso"
+	}
+	return PublicURL(baseURL, name)
+}
+
+// FindBuildScript locates infra/scripts/build-marker-iso.sh relative to cwd or common roots.
+func FindBuildScript() (string, error) {
+	if p := os.Getenv("SHOAL_ISO_BUILD_SCRIPT"); p != "" {
+		if st, err := os.Stat(p); err == nil && !st.IsDir() {
+			return p, nil
+		}
+		return "", fmt.Errorf("iso: SHOAL_ISO_BUILD_SCRIPT not found: %s", p)
+	}
+	candidates := []string{
+		"infra/scripts/build-marker-iso.sh",
+		"./infra/scripts/build-marker-iso.sh",
+		"../infra/scripts/build-marker-iso.sh",
+		"../../infra/scripts/build-marker-iso.sh",
+	}
+	// Walk up from cwd a few levels.
+	wd, _ := os.Getwd()
+	for i := 0; i < 6 && wd != ""; i++ {
+		candidates = append(candidates, filepath.Join(wd, "infra/scripts/build-marker-iso.sh"))
+		parent := filepath.Dir(wd)
+		if parent == wd {
+			break
+		}
+		wd = parent
+	}
+	for _, c := range candidates {
+		if st, err := os.Stat(c); err == nil && !st.IsDir() {
+			abs, err := filepath.Abs(c)
+			if err != nil {
+				return c, nil
+			}
+			return abs, nil
+		}
+	}
+	return "", fmt.Errorf("iso: build-marker-iso.sh not found (set SHOAL_ISO_BUILD_SCRIPT)")
+}
+
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("iso: open source: %w", err)
+	}
+	defer in.Close()
+	tmp := dst + ".tmp"
+	out, err := os.OpenFile(tmp, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
+	if err != nil {
+		return fmt.Errorf("iso: create dest: %w", err)
+	}
+	_, copyErr := io.Copy(out, in)
+	closeErr := out.Close()
+	if copyErr != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("iso: copy: %w", copyErr)
+	}
+	if closeErr != nil {
+		_ = os.Remove(tmp)
+		return closeErr
+	}
+	if err := os.Rename(tmp, dst); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("iso: rename: %w", err)
+	}
+	return nil
+}
+
+func looksSecretPayload(s string) bool {
+	lower := strings.ToLower(s)
+	for _, needle := range []string{"password", "passwd", "secret", "api_key", "apikey", "token=", "bearer "} {
+		if strings.Contains(lower, needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "…"
+}
+
+var _ Builder = (*ScriptBuilder)(nil)

--- a/internal/deploy/iso/iso_test.go
+++ b/internal/deploy/iso/iso_test.go
@@ -1,0 +1,88 @@
+package iso_test
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mattcburns/shoal/internal/deploy/iso"
+)
+
+func TestPublicURL(t *testing.T) {
+	u, err := iso.PublicURL("http://192.168.124.1:8080/", "shoal-marker.iso")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if u != "http://192.168.124.1:8080/shoal-marker.iso" {
+		t.Fatalf("got %q", u)
+	}
+}
+
+func TestResolveFromProfile(t *testing.T) {
+	u, err := iso.ResolveFromProfile("http://iso/x.iso", "")
+	if err != nil || u != "http://iso/x.iso" {
+		t.Fatalf("%q %v", u, err)
+	}
+	u, err = iso.ResolveFromProfile("ubuntu-22.04-live", "http://192.168.124.1:8080")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if u != "http://192.168.124.1:8080/ubuntu-22.04-live.iso" {
+		t.Fatalf("got %q", u)
+	}
+	if _, err := iso.ResolveFromProfile("name-only", ""); err == nil {
+		t.Fatal("expected error without base URL")
+	}
+}
+
+func TestPublishCopiesFile(t *testing.T) {
+	srcDir := t.TempDir()
+	pubDir := t.TempDir()
+	src := filepath.Join(srcDir, "test.iso")
+	if err := os.WriteFile(src, []byte("ISO-BYTES"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	b := iso.NewScriptBuilder("", slog.New(slog.NewTextHandler(io.Discard, nil)))
+	url, err := b.Publish(context.Background(), iso.Artifact{Path: src, Name: "test.iso"}, iso.PublishDest{
+		Dir: pubDir, BaseURL: "http://lab:8080",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if url != "http://lab:8080/test.iso" {
+		t.Fatalf("url %q", url)
+	}
+	got, err := os.ReadFile(filepath.Join(pubDir, "test.iso"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "ISO-BYTES" {
+		t.Fatalf("content %q", got)
+	}
+}
+
+func TestBuildRejectsSecretPayload(t *testing.T) {
+	b := iso.NewScriptBuilder("/nonexistent-script", slog.New(slog.NewTextHandler(io.Discard, nil)))
+	_, err := b.Build(context.Background(), iso.BuildInput{
+		EmbeddedPayload: "password=hunter2",
+		OutDir:          t.TempDir(),
+	})
+	if err == nil || !strings.Contains(err.Error(), "secret") {
+		t.Fatalf("expected secret rejection, got %v", err)
+	}
+}
+
+func TestFindBuildScript(t *testing.T) {
+	// From module root this should resolve in normal checkouts.
+	p, err := iso.FindBuildScript()
+	if err != nil {
+		t.Skipf("script not found in this environment: %v", err)
+	}
+	if !strings.Contains(p, "build-marker-iso.sh") {
+		t.Fatalf("unexpected path %q", p)
+	}
+}

--- a/internal/deploy/job/iso_resolve_test.go
+++ b/internal/deploy/job/iso_resolve_test.go
@@ -1,0 +1,79 @@
+package job_test
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/mattcburns/shoal/internal/common/models"
+	"github.com/mattcburns/shoal/internal/common/redfish"
+	"github.com/mattcburns/shoal/internal/common/secrets"
+	"github.com/mattcburns/shoal/internal/core/profile"
+	"github.com/mattcburns/shoal/internal/deploy/job"
+	"github.com/mattcburns/shoal/internal/deploy/jobstore"
+	"github.com/mattcburns/shoal/internal/observe/sol"
+)
+
+func TestStartResolvesISOURLFromProfile(t *testing.T) {
+	ctx := context.Background()
+	ps := profile.NewMemory()
+	_, err := ps.Save(ctx, models.ProvisioningProfile{
+		Ref: "lab-ubuntu", ISOBase: "shoal-marker", NeedsApproval: false,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	pr, _ := io.Pipe()
+	watch := sol.NewWatchService(log, nil)
+	watch.NewTransport = func(session models.WatchSession) sol.Transport {
+		return sol.NewReaderTransport(pr)
+	}
+	orch := job.NewOrchestrator(job.Options{
+		Log: log, Store: jobstore.NewMemory(), Secrets: secrets.NewMemory(),
+		Profiles: ps, ISOBaseURL: "http://192.168.124.1:8080",
+		NewBMC:  func(cfg redfish.Config) (redfish.BMC, error) { return redfish.NewFake(), nil },
+		Watches: watch, AuthMode: "basic", TLSMode: "off",
+	})
+	defer orch.Stop()
+	watch.SetProgress(orch.ProgressPort())
+
+	j, err := orch.Start(ctx, models.StartJobRequest{
+		DeviceID: "d1", ProfileRef: "lab-ubuntu",
+		// ISOURL intentionally empty
+		BMCEndpoint: "http://bmc", BMCUsername: "a", BMCPassword: "b",
+		SerialTarget: "d1",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if j.ISOURL != "http://192.168.124.1:8080/shoal-marker.iso" {
+		t.Fatalf("iso_url %q", j.ISOURL)
+	}
+}
+
+func TestStartRejectsMissingISOWithoutResolvableProfile(t *testing.T) {
+	ctx := context.Background()
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	pr, _ := io.Pipe()
+	watch := sol.NewWatchService(log, nil)
+	watch.NewTransport = func(session models.WatchSession) sol.Transport {
+		return sol.NewReaderTransport(pr)
+	}
+	orch := job.NewOrchestrator(job.Options{
+		Log: log, Store: jobstore.NewMemory(), Secrets: secrets.NewMemory(),
+		NewBMC:  func(cfg redfish.Config) (redfish.BMC, error) { return redfish.NewFake(), nil },
+		Watches: watch, AuthMode: "basic", TLSMode: "off",
+	})
+	defer orch.Stop()
+	watch.SetProgress(orch.ProgressPort())
+	_, err := orch.Start(ctx, models.StartJobRequest{
+		DeviceID: "d1", ProfileRef: "spike",
+		BMCEndpoint: "http://bmc", BMCUsername: "a", BMCPassword: "b",
+		SerialTarget: "d1",
+	})
+	if err == nil {
+		t.Fatal("expected iso_url required")
+	}
+}

--- a/internal/deploy/job/orchestrator.go
+++ b/internal/deploy/job/orchestrator.go
@@ -19,6 +19,7 @@ import (
 	"github.com/mattcburns/shoal/internal/common/validate"
 	"github.com/mattcburns/shoal/internal/common/watchport"
 	"github.com/mattcburns/shoal/internal/core/profile"
+	"github.com/mattcburns/shoal/internal/deploy/iso"
 	"github.com/mattcburns/shoal/internal/deploy/jobstore"
 	"github.com/mattcburns/shoal/internal/observe/sol"
 )
@@ -53,6 +54,7 @@ type Orchestrator struct {
 	watches    watchport.WatchRegistrar
 	netbox     netbox.LifecycleWriter // optional; identity lifecycle only
 	profiles   profile.Store          // optional; Phase 5b approval gate
+	isoBaseURL string                 // Phase 5c: resolve profile iso_base → URL
 	authMode   string
 	tlsMode    string
 	caFile     string
@@ -94,6 +96,7 @@ type Options struct {
 	Watches             watchport.WatchRegistrar
 	NetBox              netbox.LifecycleWriter // optional Phase 5 lifecycle sync
 	Profiles            profile.Store          // optional Phase 5b profile load/approval
+	ISOBaseURL          string                 // optional Phase 5c profile → ISO URL resolve
 	AuthMode            string
 	TLSMode             string
 	CAFile              string
@@ -125,6 +128,7 @@ func NewOrchestrator(opts Options) *Orchestrator {
 		watches:    opts.Watches,
 		netbox:     opts.NetBox,
 		profiles:   opts.Profiles,
+		isoBaseURL: opts.ISOBaseURL,
 		authMode:   auth,
 		tlsMode:    tlsMode,
 		caFile:     opts.CAFile,
@@ -183,6 +187,8 @@ func (o *Orchestrator) Get(ctx context.Context, jobID string) (models.Provisioni
 // When NetBox is configured, best-effort lifecycle_state=provisioning is written
 // (failure is logged and does not block BMC actions).
 // Profiles with NeedsApproval/DestructSteps require store approval or ApproveDestruct.
+// When ISOURL is empty and a non-spike profile is loaded, iso_base is resolved via
+// SHOAL_ISO_BASE_URL (Phase 5c).
 func (o *Orchestrator) Start(ctx context.Context, req models.StartJobRequest) (models.ProvisioningJob, error) {
 	if err := validate.StartJobRequest(req); err != nil {
 		return models.ProvisioningJob{}, err
@@ -197,6 +203,12 @@ func (o *Orchestrator) Start(ctx context.Context, req models.StartJobRequest) (m
 	}
 	if err := o.checkProfileApproval(ctx, profileRef, req.ApproveDestruct); err != nil {
 		return models.ProvisioningJob{}, err
+	}
+	if err := o.resolveISOURL(ctx, &req, profileRef); err != nil {
+		return models.ProvisioningJob{}, err
+	}
+	if req.ISOURL == "" {
+		return models.ProvisioningJob{}, fmt.Errorf("job: iso_url is required")
 	}
 
 	jobID := newID()
@@ -593,6 +605,34 @@ func (o *Orchestrator) checkProfileApproval(ctx context.Context, ref string, app
 		return nil
 	}
 	return fmt.Errorf("job: profile %q requires approval (run: shoal profile approve -ref %s, or pass -approve-destruct)", ref, ref)
+}
+
+// resolveISOURL fills req.ISOURL from the profile store when the operator omitted -iso-url.
+func (o *Orchestrator) resolveISOURL(ctx context.Context, req *models.StartJobRequest, profileRef string) error {
+	if req.ISOURL != "" {
+		return nil
+	}
+	if profileRef == "" || profileRef == "spike" {
+		return fmt.Errorf("job: iso_url is required for spike/empty profile_ref")
+	}
+	if o.profiles == nil {
+		return fmt.Errorf("job: cannot resolve iso_url without profile store (set SHOAL_PROFILE_DIR or pass -iso-url)")
+	}
+	rec, err := o.profiles.Get(ctx, profileRef)
+	if err != nil {
+		return fmt.Errorf("job: load profile %q for iso resolve: %w", profileRef, err)
+	}
+	url, err := iso.ResolveFromProfile(rec.Profile.ISOBase, o.isoBaseURL)
+	if err != nil {
+		return fmt.Errorf("job: resolve iso from profile %q: %w (set SHOAL_ISO_BASE_URL or pass -iso-url)", profileRef, err)
+	}
+	req.ISOURL = url
+	o.log.Info("iso resolved from profile",
+		"profile_ref", profileRef,
+		"iso_base", rec.Profile.ISOBase,
+		"iso_url", url,
+	)
+	return nil
 }
 
 // syncNetBoxLifecycle best-effort updates NetBox identity lifecycle_state.


### PR DESCRIPTION
## Summary

Phase **5c** of Deploy harden: Go-owned ISO build/publish pipeline and Start-time ISO URL resolution from profiles.

- **`internal/deploy/iso`**: `Builder` wraps `infra/scripts/build-marker-iso.sh` via `os/exec`; `Publish` to `SHOAL_ISO_PUBLISH_DIR`; `ResolveFromProfile` for `iso_base` → URL
- **Static base inject**: optional `EmbeddedPayload` / `-payload` → `/payload` in the image; BOOT detail notes `payload_bytes` (never secrets)
- **CLI**: `shoal deploy iso build|publish` (`-publish`, `-payload`, `-profile-ref`)
- **Start**: empty `-iso-url` + non-spike profile resolves via store + `SHOAL_ISO_BASE_URL`; explicit `-iso-url` wins; spike still requires URL
- **Lab Ansible**: `env.j2` sets `SHOAL_ISO_PUBLISH_DIR=/srv/iso` and BMC-reachable `SHOAL_ISO_BASE_URL=http://{{ gateway }}:8080`
- Marker ISO Ansible role remains the primary lab producer; serve stays plain HTTP nginx `:8080`

Completes the Phase 5 three-PR stack (5a lifecycle, 5b profiles, 5c ISO).

## Test plan

- [x] `gofmt`, `go vet ./...`, `go test ./...` (unit)
- [x] Unit: PublicURL, ResolveFromProfile, Publish copy, secret payload reject, Start resolve/reject
- [x] Lab (rebuilt VM, smoke green):
  - [x] Ansible env: `SHOAL_ISO_PUBLISH_DIR` + `SHOAL_ISO_BASE_URL` present
  - [x] L1 Go `deploy iso build -payload … -publish` → `/srv/iso/shoal-5c-go.iso`
  - [x] Payload verified in gzipped initrd
  - [x] Deploy **without** `-iso-url` resolves `iso_base` → BMC-reachable URL; SOL DONE markers
  - [x] Missing `SHOAL_ISO_BASE_URL` fail-closed
  - [x] Explicit `-iso-url` overrides profile; spike still requires URL
  - [x] Integration: `jobstore`, `telemetry`, `redfish` (`-tags=integration`)
- [ ] CI green on PR

## Notes

- L1 kernels are often `0600 root` — non-root builds need `SHOAL_KERNEL` pointing at a readable copy (or root/Ansible become).
- Lab noise (not 5c): NetBox 404 for ad-hoc device ids; occasional sushy DONE post-check `boot override still set (Continuous/Hdd)`.