### PR TITLE
feat(deploy): dynamic ISO write mode + optional build on Start (Phase 6a)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -241,6 +241,7 @@ go run ./cmd/shoal deploy run \
 | `SHOAL_ISO_BASE_URL` | BMC-reachable ISO HTTP prefix (lab nested: `http://192.168.124.1:8080`). Used to resolve profile `iso_base` and `deploy iso publish` |
 | `SHOAL_ISO_PUBLISH_DIR` | Filesystem dir served on `:8080` (lab: `/srv/iso`). Phase 5c publish target |
 | `SHOAL_ISO_BUILD_SCRIPT` | Optional path to `build-marker-iso.sh` (auto-discovers from repo) |
+| `SHOAL_ISO_DYNAMIC` | If `true`, Start may build+publish when `ISOURL` empty (needs publish dir + base URL; Phase 6a) |
 | `SHOAL_RECONCILE_FAIL_ORPHANS` | Default `true` |
 | `SHOAL_FEWSHOT_DIR` | Append-only learned few-shot JSONL (confirm learning). Lab Ansible default: `/var/lib/shoal/fewshot` via `shoal_fewshot_dir` + `env.j2`. Empty disables confirm |
 | `SHOAL_PROFILE_DIR` | JSON provisioning profiles + approval records (Phase 5b). Lab Ansible default: `/var/lib/shoal/profiles` via `shoal_profile_dir` + `env.j2`. Empty disables non-spike profile load |
@@ -253,14 +254,12 @@ only (no silent memory fallback). Empty SEL/sensors with exit 0 is valid when th
 BMC has no logs; write failures and Redfish errors fail the poll. Observe never
 imports Deploy (job reads via `jobport.JobQuery`).
 
-**Phase 5 Deploy:** Orchestrator best-effort syncs NetBox `lifecycle_state` on
-Start/HandleTerminal. Profiles under `SHOAL_PROFILE_DIR`; destruct /
-`needs_approval` require approve or `-approve-destruct`. **Phase 5c ISO:**
-`internal/deploy/iso` wraps `build-marker-iso.sh`, publishes to
-`SHOAL_ISO_PUBLISH_DIR`, and Start resolves empty `-iso-url` from profile
-`iso_base` + `SHOAL_ISO_BASE_URL`. Still plain HTTP on mgmt segment; Ansible
-marker_iso remains primary lab producer. Sole lifecycle writer remains
-Orchestrator; JobStore stays pure persistence.
+**Phase 5–6a Deploy:** Orchestrator best-effort syncs NetBox `lifecycle_state`.
+Profiles under `SHOAL_PROFILE_DIR`; destruct needs approve or `-approve-destruct`.
+ISO: publish + profile resolve (5c); **6a** `install-mode write` writes `/payload`
+with real SOL progress; optional `-build-iso` / `SHOAL_ISO_DYNAMIC`. Marker
+`simulate` mode remains the Phase 2 demo. Plain HTTP ISO on mgmt segment.
+Sole lifecycle writer remains Orchestrator; JobStore stays pure persistence.
 
 ---
 

--- a/SHOAL_COMPREHENSIVE_DESIGN_AND_IMPLEMENTATION_PLAN.md
+++ b/SHOAL_COMPREHENSIVE_DESIGN_AND_IMPLEMENTATION_PLAN.md
@@ -1331,6 +1331,7 @@ Default VM-hosted endpoints: NetBox `:8000`, sushy `:8001`, ISO HTTP `:8080`, Ol
 | `SHOAL_ISO_BASE_URL` | no | BMC-reachable ISO HTTP prefix (lab nested: `http://192.168.124.1:8080`). Ansible `env.j2` sets gateway + port. Used for profile `iso_base` resolve + publish URL |
 | `SHOAL_ISO_PUBLISH_DIR` | no | Filesystem publish dir (lab: `shoal_iso_server_dir` → `/srv/iso` in `env.j2`) |
 | `SHOAL_ISO_BUILD_SCRIPT` | no | Optional path to `build-marker-iso.sh` |
+| `SHOAL_ISO_DYNAMIC` | no | If `true`, Start may build+publish when ISOURL empty (Phase 6a; needs publish dir + base URL) |
 | `SHOAL_RECONCILE_FAIL_ORPHANS` | no | Default `true` |
 | `SHOAL_FEWSHOT_DIR` | no | Append-only learned few-shot JSONL (Phase 3b confirm). Lab default via Ansible `shoal_fewshot_dir` → `/var/lib/shoal/fewshot` in `env.j2` + mkdir. Empty disables confirm |
 | `SHOAL_PROFILE_DIR` | no | JSON provisioning profiles + approval records (Phase 5b). Lab default via Ansible `shoal_profile_dir` → `/var/lib/shoal/profiles` in `env.j2` + mkdir. Empty disables non-spike profile load; `spike` profile ref always allowed without a store |
@@ -1427,7 +1428,13 @@ Full ISO pipeline, reliability contract polish, profile generation + approval, N
 
 ### Phase 6: Polish
 
-Graphics OCR (**decide approach then**: `os/exec` Tesseract vs cloud vision — neither is pre-committed), dynamic ISO, metrics, TLS/API auth hardening, packaging, record/replay CI.
+Graphics OCR via **Core `CompleteVision`** (not Tesseract-first), dynamic ISO / real payload write, metrics, TLS/API auth hardening, packaging, record/replay CI.
+
+**Phase 6a (dynamic ISO + write path):** `SHOAL_INSTALL_MODE=write` live image writes `/payload` to `shoal.target` / `SHOAL_INSTALL_TARGET` (or `/tmp/shoal-install.out` fallback) with real `IMAGE_WRITE` progress; `simulate` remains Phase 2 demo. Optional `StartJobRequest.BuildISO` / `SHOAL_ISO_DYNAMIC` builds+publishes before Virtual Media. Not a full multi-distro autoinstall product — bounded payload MVP.
+
+### Phase 6 (remaining)
+
+Graphics OCR (CompleteVision failure screens), Compose shoal packaging, API auth + metrics, record/replay CI.
 
 ---
 
@@ -1600,7 +1607,7 @@ go test ./...
 
 ## Open Questions
 
-**All previously open product decisions are resolved through v2.0.5.** Phase 0–4 are on `master`; Phase 5 (Deploy harden) is next.
+**All previously open product decisions are resolved through v2.0.5.** Phase 0–5 are on `master`; Phase 6 (polish) is next.
 
 | Topic | Resolution |
 |-------|------------|
@@ -1615,7 +1622,7 @@ go test ./...
 | **Module path** | **`github.com/mattcburns/shoal`** |
 | **Redfish client** | **gofish day one**, wrapped in `internal/common/redfish` (no thin-client-first path) |
 | **App HTTP port** | **`:8088`** (`shoal_app_http_port` / `SHOAL_HTTP_ADDR`) |
-| **Phase 6 graphics OCR** | **Deferred** — evaluate Tesseract (`os/exec`) vs cloud vision for failure screens; not the same as Phase 3 asset-label OCR |
+| **Phase 6 graphics OCR** | **CompleteVision** (lab Ollama VLM / cloud) for failure screens; not Tesseract-first; not the same as Phase 3 asset-label OCR |
 | **Live image build host** | **Both:** lab VM Ansible role **primary**; developer workstation **alternate** (§8.2 / Appendix I) |
 | **Lab AI text model** | **`SHOAL_AI_MODEL=llama3.2:3b`** (instruct; nested-lab friendly) |
 | **Lab AI vision model** | **`SHOAL_AI_VISION_MODEL=deepseek-ocr`** for asset-label Free OCR; **moondream not AC**; empty skips photo |
@@ -1639,9 +1646,9 @@ go test ./...
 
 ---
 
-**This document (v2.0.5) is the SoT for agents.** Phase 0–4 (Discover hybrid, few-shot, Observe broaden) are on `master`.
+**This document (v2.0.5) is the SoT for agents.** Phase 0–5 (Discover, Observe, Deploy harden) are on `master`.
 
 Next actions:
-1. Phase 5 Deploy harden: NetBox lifecycle sync, reliability polish, profile gen+approval, ISO pipeline
-2. Later: packaging (Compose shoal service)
-3. At Phase 6: choose graphics failure-screen OCR approach before implementing
+1. Phase 6a: dynamic ISO + real payload write (in progress / next)
+2. Phase 6b–d: graphics OCR (CompleteVision), Compose shoal packaging, API auth + metrics + replay CI
+3. Stretch: full distro autoinstall; NetBox device-id binding

--- a/docs/lab-runbook.md
+++ b/docs/lab-runbook.md
@@ -287,6 +287,45 @@ Operator-supplied `-iso-url` still wins over profile resolve. Spike profile alwa
 requires `-iso-url`. Payload inject uses `SHOAL_EMBEDDED_PAYLOAD` / `-payload`
 (never secrets).
 
+### Phase 6a: real payload write (install MVP)
+
+Default marker ISO still **simulates** `IMAGE_WRITE`. For a real write of an
+embedded payload (bounded blob — not a full Ubuntu autoinstall product):
+
+```bash
+# Build write-mode ISO with a payload file (binary-safe)
+printf 'golden-rootfs-bytes' > /tmp/payload.bin
+export SHOAL_ISO_PUBLISH_DIR=/srv/iso   # on L1
+export SHOAL_ISO_BASE_URL=http://192.168.124.1:8080
+# Kernel on L1 is often 0600 root — stage a readable copy:
+#   sudo cp /boot/vmlinuz-$(uname -r) /tmp/vmlinuz && sudo chmod 644 /tmp/vmlinuz
+#   export SHOAL_KERNEL=/tmp/vmlinuz
+
+go run ./cmd/shoal deploy iso build \
+  -name shoal-install.iso \
+  -install-mode write \
+  -install-target /tmp/shoal-install.out \
+  -payload-file /tmp/payload.bin \
+  -publish
+
+# Or build at Start time:
+go run ./cmd/shoal deploy run \
+  -device-id shoal-node-1 \
+  -bmc-url http://192.168.122.100:8001 \
+  -serial-target shoal-node-1 \
+  -build-iso \
+  -iso-install-mode write \
+  -iso-payload-file /tmp/payload.bin \
+  -iso-install-target /tmp/shoal-install.out
+```
+
+Write mode emits real `IMAGE_WRITE` percent over SOL. If no block device is
+present, the image falls back to a file target (`/tmp/shoal-install.out` or
+`-install-target`). Nested sushy disks may be limited — document fidelity gaps.
+
+`SHOAL_ISO_DYNAMIC=true` also builds when `-iso-url` is empty and publish
+dir/base URL are set.
+
 ## 2) Fast stop (teardown / clean slate)
 ```bash
 ansible-playbook -i infra/ansible/inventory/lab-vm.yml infra/ansible/playbooks/down.yml

--- a/docs/phase2-live-image.md
+++ b/docs/phase2-live-image.md
@@ -18,6 +18,11 @@ Phase **5c** also exposes a Go wrapper (`shoal deploy iso build|publish`) around
 the same script, with optional `EmbeddedPayload` inject and publish into
 `SHOAL_ISO_PUBLISH_DIR`. Ansible remains the primary lab path.
 
+Phase **6a** adds `SHOAL_INSTALL_MODE=write` (or `-install-mode write`): when
+`/payload` is present the live image performs a real write with progressive
+`IMAGE_WRITE` markers (file or block target). Default remains **simulate** for
+the Phase 2 demo.
+
 ### Primary: Ansible on lab VM (L1)
 
 ```bash

--- a/infra/scripts/build-marker-iso.sh
+++ b/infra/scripts/build-marker-iso.sh
@@ -2,6 +2,16 @@
 # build-marker-iso.sh — build a minimal bootable live ISO that emits SHOAL| markers
 # on the serial console (ttyS0 / console), then powers off.
 #
+# Modes (Phase 6a):
+#   SHOAL_INSTALL_MODE=simulate (default) — Phase 2 demo markers; optional /payload size note
+#   SHOAL_INSTALL_MODE=write — when /payload is present, write it to a target with real progress
+#
+# Target selection for write mode (first match wins):
+#   1) kernel cmdline shoal.target=PATH
+#   2) SHOAL_INSTALL_TARGET at build time (baked into init)
+#   3) first of /dev/vda /dev/sda if block devices
+#   4) /tmp/shoal-install.out (lab harness fallback when no disk)
+#
 # Primary: run on the lab VM (L1) so the ISO lands in /srv/iso for nginx :8080.
 # Alternate: run on a workstation and scp the artifact into the lab ISO dir.
 #
@@ -10,6 +20,7 @@
 # Usage:
 #   ./infra/scripts/build-marker-iso.sh [/output/path/shoal-marker.iso]
 #   SHOAL_ISO_OUT=/srv/iso/shoal-marker.iso ./infra/scripts/build-marker-iso.sh
+#   SHOAL_INSTALL_MODE=write SHOAL_PAYLOAD_FILE=./rootfs.img ./infra/scripts/build-marker-iso.sh
 
 set -euo pipefail
 
@@ -72,8 +83,20 @@ if ! command -v xorriso >/dev/null 2>&1; then
   exit 1
 fi
 
+INSTALL_MODE="${SHOAL_INSTALL_MODE:-simulate}"
+case "$INSTALL_MODE" in
+  simulate|write) ;;
+  *)
+    echo "error: SHOAL_INSTALL_MODE must be simulate or write (got $INSTALL_MODE)" >&2
+    exit 1
+    ;;
+esac
+# Baked default target for write mode (can be overridden by kernel cmdline shoal.target=).
+INSTALL_TARGET_DEFAULT="${SHOAL_INSTALL_TARGET:-}"
+
 echo "kernel:  $KERNEL"
 echo "busybox: $BUSYBOX"
+echo "mode:    $INSTALL_MODE"
 echo "output:  $OUT"
 
 # --- initramfs rootfs ---
@@ -83,11 +106,11 @@ mkdir -p "$ROOT"/{bin,dev,proc,sys,tmp}
 cp "$BUSYBOX" "$ROOT/bin/busybox"
 chmod 755 "$ROOT/bin/busybox"
 # Install common applets used by /init
-for app in sh mount umount mkdir sleep cat echo poweroff reboot mkdir ln; do
+for app in sh mount umount mkdir sleep cat echo poweroff reboot mkdir ln dd wc rm sync; do
   ln -sf busybox "$ROOT/bin/$app"
 done
 
-# Optional static base inject (Phase 5c): non-secret payload file inside the image.
+# Optional payload (Phase 5c text / Phase 6a binary image).
 # Prefer SHOAL_PAYLOAD_FILE (path); else SHOAL_EMBEDDED_PAYLOAD (inline text).
 if [[ -n "${SHOAL_PAYLOAD_FILE:-}" && -r "${SHOAL_PAYLOAD_FILE}" ]]; then
   cp "${SHOAL_PAYLOAD_FILE}" "$ROOT/payload"
@@ -96,6 +119,10 @@ elif [[ -n "${SHOAL_EMBEDDED_PAYLOAD:-}" ]]; then
   printf '%s' "${SHOAL_EMBEDDED_PAYLOAD}" > "$ROOT/payload"
   chmod 644 "$ROOT/payload"
 fi
+
+# Bake install defaults for init (read by the shell script below).
+printf '%s\n' "$INSTALL_MODE" > "$ROOT/install_mode"
+printf '%s\n' "$INSTALL_TARGET_DEFAULT" > "$ROOT/install_target_default"
 
 # Init emits markers then powers off. console=ttyS0 from kernel cmdline.
 cat > "$ROOT/init" << 'INIT'
@@ -122,31 +149,114 @@ emit() {
   printf 'SHOAL|1|%s|%s|%s|%s|%s|%s\n' "$seq" "$ts" "$phase" "$percent" "$state" "$detail"
 }
 
-# Short Phase-2 demonstration sequence (no real disk write).
-# If /payload was injected (Phase 5c), note its size in BOOT detail — never echo secrets.
-boot_detail="marker live image started"
+MODE="simulate"
+if [ -f /install_mode ]; then
+  MODE="$(cat /install_mode 2>/dev/null | tr -d '\n' || echo simulate)"
+fi
+TARGET=""
+if [ -f /install_target_default ]; then
+  TARGET="$(cat /install_target_default 2>/dev/null | tr -d '\n' || true)"
+fi
+# Kernel cmdline overrides (shoal.mode= write|simulate, shoal.target=/dev/vda)
+for x in $(cat /proc/cmdline 2>/dev/null); do
+  case "$x" in
+    shoal.mode=*) MODE="${x#shoal.mode=}" ;;
+    shoal.target=*) TARGET="${x#shoal.target=}" ;;
+  esac
+done
+
+boot_detail="marker live image started mode=${MODE}"
 if [ -f /payload ]; then
   psz="$(wc -c </payload 2>/dev/null || echo 0)"
-  boot_detail="marker live image started payload_bytes=${psz}"
+  boot_detail="marker live image started mode=${MODE} payload_bytes=${psz}"
 fi
 emit BOOT 0 OK "$boot_detail"
 sleep 1
 emit BOOT - HEARTBEAT ""
-sleep 1
-emit IMAGE_WRITE 25 OK "simulated write"
-sleep 1
-emit IMAGE_WRITE - HEARTBEAT ""
-sleep 1
-emit IMAGE_WRITE 75 OK "simulated sync"
-sleep 1
-emit VERIFY 90 OK "ok"
-sleep 1
-emit DONE 100 OK "reboot pending"
+
+if [ "$MODE" = "write" ] && [ -f /payload ]; then
+  # Resolve write target.
+  if [ -z "$TARGET" ]; then
+    for cand in /dev/vda /dev/sda /dev/nvme0n1; do
+      if [ -b "$cand" ]; then TARGET="$cand"; break; fi
+    done
+  fi
+  if [ -z "$TARGET" ]; then
+    TARGET="/tmp/shoal-install.out"
+    emit IMAGE_WRITE 0 OK "no block device; using file target ${TARGET}"
+  fi
+
+  total="$(wc -c </payload 2>/dev/null || echo 0)"
+  if [ -z "$total" ] || [ "$total" = "0" ]; then
+    emit ERROR 0 ERROR "empty payload"
+    sleep 2
+    /bin/busybox poweroff -f 2>/dev/null || true
+    while true; do sleep 3600; done
+  fi
+
+  emit IMAGE_WRITE 0 OK "write start target=${TARGET} bytes=${total}"
+  # Chunked copy for progress (1 MiB blocks).
+  bs=1048576
+  # shell arithmetic: number of full blocks
+  blocks=$(( total / bs ))
+  rem=$(( total % bs ))
+  written=0
+  i=0
+  while [ "$i" -lt "$blocks" ]; do
+    dd if=/payload of="$TARGET" bs="$bs" count=1 skip="$i" seek="$i" conv=notrunc 2>/dev/null || {
+      emit ERROR 0 ERROR "dd failed at block ${i}"
+      sleep 2
+      /bin/busybox poweroff -f 2>/dev/null || true
+      while true; do sleep 3600; done
+    }
+    written=$(( written + bs ))
+    pct=$(( written * 100 / total ))
+    if [ "$pct" -gt 99 ]; then pct=99; fi
+    emit IMAGE_WRITE "$pct" OK "wrote ${written}/${total}"
+    i=$(( i + 1 ))
+  done
+  if [ "$rem" -gt 0 ]; then
+    dd if=/payload of="$TARGET" bs=1 count="$rem" skip="$written" seek="$written" conv=notrunc 2>/dev/null || {
+      emit ERROR 0 ERROR "dd failed on remainder"
+      sleep 2
+      /bin/busybox poweroff -f 2>/dev/null || true
+      while true; do sleep 3600; done
+    }
+    written=$(( written + rem ))
+  fi
+  sync 2>/dev/null || true
+  emit IMAGE_WRITE 100 OK "write complete target=${TARGET}"
+  # Verify size on target when it is a regular file.
+  if [ -f "$TARGET" ]; then
+    tsz="$(wc -c <"$TARGET" 2>/dev/null || echo 0)"
+    if [ "$tsz" = "$total" ]; then
+      emit VERIFY 100 OK "size match bytes=${total}"
+    else
+      emit ERROR 0 ERROR "size mismatch got=${tsz} want=${total}"
+      sleep 2
+      /bin/busybox poweroff -f 2>/dev/null || true
+      while true; do sleep 3600; done
+    fi
+  else
+    emit VERIFY 100 OK "write finished target=${TARGET}"
+  fi
+  emit DONE 100 OK "install write complete"
+else
+  # Phase-2 demonstration sequence (no real disk write).
+  sleep 1
+  emit IMAGE_WRITE 25 OK "simulated write"
+  sleep 1
+  emit IMAGE_WRITE - HEARTBEAT ""
+  sleep 1
+  emit IMAGE_WRITE 75 OK "simulated sync"
+  sleep 1
+  emit VERIFY 90 OK "ok"
+  sleep 1
+  emit DONE 100 OK "reboot pending"
+fi
 
 sleep 1
-# Prefer poweroff so the emulator can observe power transitions.
 /bin/busybox poweroff -f 2>/dev/null || /bin/busybox reboot -f 2>/dev/null || true
-# hang if poweroff unavailable
 while true; do sleep 3600; done
 INIT
 chmod 755 "$ROOT/init"
@@ -168,20 +278,31 @@ if [[ -n "$LDLINUX" ]]; then
   cp "$LDLINUX" "$ISO/boot/isolinux/ldlinux.c32"
 fi
 
-cat > "$ISO/boot/isolinux/isolinux.cfg" << 'CFG'
+# Pass mode/target on kernel cmdline for runtime override.
+CMDLINE="initrd=/boot/initrd.img console=ttyS0,115200n8 console=tty0 quiet shoal.mode=${INSTALL_MODE}"
+if [[ -n "$INSTALL_TARGET_DEFAULT" ]]; then
+  CMDLINE="${CMDLINE} shoal.target=${INSTALL_TARGET_DEFAULT}"
+fi
+
+cat > "$ISO/boot/isolinux/isolinux.cfg" << CFG
 DEFAULT shoal
 PROMPT 0
 TIMEOUT 10
 LABEL shoal
   KERNEL /boot/vmlinuz
-  APPEND initrd=/boot/initrd.img console=ttyS0,115200n8 console=tty0 quiet
+  APPEND ${CMDLINE}
 CFG
+
+VOLID="SHOAL_MARKER"
+if [[ "$INSTALL_MODE" = "write" ]]; then
+  VOLID="SHOAL_INSTALL"
+fi
 
 mkdir -p "$(dirname "$OUT")"
 xorriso -as mkisofs \
   -quiet \
   -o "$OUT" \
-  -V "SHOAL_MARKER" \
+  -V "$VOLID" \
   -b boot/isolinux/isolinux.bin \
   -c boot/isolinux/boot.cat \
   -no-emul-boot \
@@ -191,6 +312,6 @@ xorriso -as mkisofs \
 
 chmod 644 "$OUT" 2>/dev/null || true
 SIZE="$(wc -c < "$OUT" | tr -d ' ')"
-echo "built $OUT ($SIZE bytes)"
+echo "built $OUT ($SIZE bytes) mode=$INSTALL_MODE"
 echo "publish: copy into lab ISO dir and serve as http://<lab>:8080/$(basename "$OUT")"
 echo "BMC-reachable (VM lab nodes): http://192.168.124.1:8080/$(basename "$OUT")"

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -25,6 +25,7 @@ import (
 	"github.com/mattcburns/shoal/internal/core/fewshot"
 	"github.com/mattcburns/shoal/internal/core/profile"
 	"github.com/mattcburns/shoal/internal/core/reconcile"
+	"github.com/mattcburns/shoal/internal/deploy/iso"
 	"github.com/mattcburns/shoal/internal/deploy/job"
 	"github.com/mattcburns/shoal/internal/deploy/jobstore"
 	"github.com/mattcburns/shoal/internal/discover"
@@ -34,7 +35,7 @@ import (
 )
 
 // Version is the application version string (overridable via -ldflags).
-var Version = "0.5.0-phase5"
+var Version = "0.6.0-phase6a"
 
 // Run dispatches subcommands. args should be os.Args[1:].
 func Run(args []string) int {
@@ -205,7 +206,7 @@ func cmdServe(args []string) int {
 				log.Info("profile store enabled", "dir", cfg.ProfileDir)
 			}
 		}
-		orch := job.NewOrchestrator(job.Options{
+		orchOpts := job.Options{
 			Log:                 log,
 			Store:               store,
 			Secrets:             secretBackend,
@@ -214,11 +215,17 @@ func cmdServe(args []string) int {
 			NetBox:              nb,
 			Profiles:            profStore,
 			ISOBaseURL:          cfg.ISOBaseURL,
+			ISOPublishDir:       cfg.ISOPublishDir,
+			ISODynamic:          cfg.ISODynamic,
 			AuthMode:            cfg.RedfishAuthMode,
 			TLSMode:             cfg.RedfishTLSMode,
 			CAFile:              cfg.RedfishCAFile,
 			ReconcileFailOrphan: cfg.ReconcileFailOrphans,
-		})
+		}
+		if cfg.ISOPublishDir != "" && cfg.ISOBaseURL != "" {
+			orchOpts.ISOBuilder = iso.NewScriptBuilder(cfg.ISOBuildScript, log)
+		}
+		orch := job.NewOrchestrator(orchOpts)
 		defer orch.Stop()
 		watchSvc.SetProgress(orch.ProgressPort())
 		srvAPI.WithJobCanceler(orch)

--- a/internal/cli/deploy.go
+++ b/internal/cli/deploy.go
@@ -16,6 +16,7 @@ import (
 	"github.com/mattcburns/shoal/internal/common/redfish"
 	"github.com/mattcburns/shoal/internal/common/telemetry"
 	"github.com/mattcburns/shoal/internal/core/profile"
+	"github.com/mattcburns/shoal/internal/deploy/iso"
 	"github.com/mattcburns/shoal/internal/deploy/job"
 	"github.com/mattcburns/shoal/internal/deploy/jobstore"
 	"github.com/mattcburns/shoal/internal/observe/sol"
@@ -61,6 +62,10 @@ func cmdDeployRun(args []string) int {
 	systemID := fs.String("system-id", "", "optional Redfish system id or name")
 	profileRef := fs.String("profile-ref", "spike", "profile ref (spike = no store; else SHOAL_PROFILE_DIR)")
 	approveDestruct := fs.Bool("approve-destruct", false, "operator consent for NeedsApproval/DestructSteps profiles")
+	buildISO := fs.Bool("build-iso", false, "build+publish live ISO before start (Phase 6a; needs publish dir)")
+	isoPayload := fs.String("iso-payload-file", "", "payload file for -build-iso write mode")
+	isoMode := fs.String("iso-install-mode", "", "simulate|write for -build-iso (default write if payload set)")
+	isoTarget := fs.String("iso-install-target", "", "write target for -build-iso (e.g. /tmp/shoal-install.out)")
 	sshHost := fs.String("serial-ssh-host", cfg.SerialSSHHost, "SSH host for nested libvirt serial (VM mode)")
 	sshUser := fs.String("serial-ssh-user", cfg.SerialSSHUser, "SSH user for serial delegate")
 	sshKey := fs.String("serial-ssh-key", cfg.SerialSSHKey, "SSH private key for serial delegate")
@@ -79,16 +84,20 @@ func cmdDeployRun(args []string) int {
 		dev = *device
 	}
 	req := models.StartJobRequest{
-		DeviceID:        dev,
-		ProfileRef:      *profileRef,
-		ISOURL:          *isoURL,
-		BMCEndpoint:     *bmcURL,
-		BMCUsername:     *bmcUser,
-		BMCPassword:     *bmcPass,
-		SerialTarget:    *serial,
-		SystemID:        *systemID,
-		StallTimeout:    *stallTimeout,
-		ApproveDestruct: *approveDestruct,
+		DeviceID:         dev,
+		ProfileRef:       *profileRef,
+		ISOURL:           *isoURL,
+		BMCEndpoint:      *bmcURL,
+		BMCUsername:      *bmcUser,
+		BMCPassword:      *bmcPass,
+		SerialTarget:     *serial,
+		SystemID:         *systemID,
+		StallTimeout:     *stallTimeout,
+		ApproveDestruct:  *approveDestruct,
+		BuildISO:         *buildISO,
+		ISOPayloadFile:   *isoPayload,
+		ISOInstallMode:   *isoMode,
+		ISOInstallTarget: *isoTarget,
 	}
 
 	store, dbCloser, err := openJobStore(cfg)
@@ -123,6 +132,10 @@ func cmdDeployRun(args []string) int {
 		}
 		profStore = st
 	}
+	var isoBuilder iso.Builder
+	if cfg.ISOPublishDir != "" && cfg.ISOBaseURL != "" {
+		isoBuilder = iso.NewScriptBuilder(cfg.ISOBuildScript, log)
+	}
 	orch := job.NewOrchestrator(job.Options{
 		Log:                 log,
 		Store:               store,
@@ -132,6 +145,9 @@ func cmdDeployRun(args []string) int {
 		NetBox:              nb,
 		Profiles:            profStore,
 		ISOBaseURL:          cfg.ISOBaseURL,
+		ISOBuilder:          isoBuilder,
+		ISOPublishDir:       cfg.ISOPublishDir,
+		ISODynamic:          cfg.ISODynamic,
 		AuthMode:            cfg.RedfishAuthMode,
 		TLSMode:             cfg.RedfishTLSMode,
 		CAFile:              cfg.RedfishCAFile,

--- a/internal/cli/iso.go
+++ b/internal/cli/iso.go
@@ -43,7 +43,9 @@ func cmdISOBuild(args []string) int {
 	outDir := fs.String("out-dir", "", "local output directory (default: temp or -out parent)")
 	out := fs.String("out", "", "full output path (overrides -name/-out-dir)")
 	payload := fs.String("payload", "", "non-secret embedded payload text")
-	payloadFile := fs.String("payload-file", "", "read non-secret payload from file")
+	payloadFile := fs.String("payload-file", "", "host path copied into image as /payload (binary-safe)")
+	installMode := fs.String("install-mode", "simulate", "simulate|write (Phase 6a real payload write)")
+	installTarget := fs.String("install-target", "", "write target baked into image (e.g. /dev/vda or /tmp/out)")
 	profileRef := fs.String("profile-ref", "", "load iso_base/name/payload hints from profile store")
 	publish := fs.Bool("publish", false, "also publish to SHOAL_ISO_PUBLISH_DIR")
 	if err := fs.Parse(args); err != nil {
@@ -51,21 +53,18 @@ func cmdISOBuild(args []string) int {
 	}
 
 	in := iso.BuildInput{
-		Name:       *name,
-		OutDir:     *outDir,
-		ScriptPath: cfg.ISOBuildScript,
+		Name:          *name,
+		OutDir:        *outDir,
+		ScriptPath:    cfg.ISOBuildScript,
+		InstallMode:   *installMode,
+		InstallTarget: *installTarget,
 	}
 	if *out != "" {
 		in.OutDir = filepath.Dir(*out)
 		in.Name = filepath.Base(*out)
 	}
 	if *payloadFile != "" {
-		b, err := os.ReadFile(*payloadFile)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "payload-file: %v\n", err)
-			return 1
-		}
-		in.EmbeddedPayload = string(b)
+		in.PayloadFile = *payloadFile
 	} else if *payload != "" {
 		in.EmbeddedPayload = *payload
 	}
@@ -91,7 +90,7 @@ func cmdISOBuild(args []string) int {
 			}
 			in.Name = base
 		}
-		if in.EmbeddedPayload == "" && rec.Profile.EmbeddedPayload != "" {
+		if in.PayloadFile == "" && in.EmbeddedPayload == "" && rec.Profile.EmbeddedPayload != "" {
 			in.EmbeddedPayload = rec.Profile.EmbeddedPayload
 		}
 	}

--- a/internal/common/config/config.go
+++ b/internal/common/config/config.go
@@ -29,6 +29,8 @@ type Config struct {
 	ISOBaseURL           string // public HTTP prefix for Virtual Media (e.g. http://192.168.124.1:8080)
 	ISOPublishDir        string // filesystem dir served on :8080 (e.g. /srv/iso); Phase 5c publish
 	ISOBuildScript       string // optional path to build-marker-iso.sh
+	// ISODynamic enables build+publish on Start when BuildISO is set or ISOURL empty with profile (Phase 6a).
+	ISODynamic           bool
 	ReconcileFailOrphans bool
 	SecretsDir           string
 	// Serial SSH delegate (VM-hosted lab: nest libvirt on L1).
@@ -82,6 +84,13 @@ func Load() (Config, error) {
 			return Config{}, fmt.Errorf("config: SHOAL_RECONCILE_FAIL_ORPHANS: %w", err)
 		}
 		c.ReconcileFailOrphans = b
+	}
+	if v := os.Getenv("SHOAL_ISO_DYNAMIC"); v != "" {
+		b, err := strconv.ParseBool(v)
+		if err != nil {
+			return Config{}, fmt.Errorf("config: SHOAL_ISO_DYNAMIC: %w", err)
+		}
+		c.ISODynamic = b
 	}
 	if v := os.Getenv("SHOAL_SERIAL_SSH_SUDO"); v != "" {
 		b, err := strconv.ParseBool(v)

--- a/internal/common/models/models.go
+++ b/internal/common/models/models.go
@@ -183,6 +183,15 @@ type StartJobRequest struct {
 	// ApproveDestruct acknowledges NeedsApproval / DestructSteps on the profile (Phase 5b).
 	// Does not bypass a missing profile store entry; only supplies operator consent.
 	ApproveDestruct bool `json:"approve_destruct,omitempty"`
+	// BuildISO requests a dynamic ISO build+publish before Virtual Media (Phase 6a).
+	// Requires orchestrator ISO publish config; resulting URL fills ISOURL when empty.
+	BuildISO bool `json:"build_iso,omitempty"`
+	// ISOPayloadFile is an optional host path for binary install payload (write mode).
+	ISOPayloadFile string `json:"iso_payload_file,omitempty"`
+	// ISOInstallMode is simulate|write for dynamic builds (default simulate).
+	ISOInstallMode string `json:"iso_install_mode,omitempty"`
+	// ISOInstallTarget is optional write target baked into the image (e.g. /dev/vda).
+	ISOInstallTarget string `json:"iso_install_target,omitempty"`
 }
 
 // CancelJobRequest cancels an in-flight provisioning job.

--- a/internal/common/validate/validate.go
+++ b/internal/common/validate/validate.go
@@ -147,8 +147,9 @@ func StartJobRequest(r models.StartJobRequest) error {
 	}
 	if strings.TrimSpace(r.ISOURL) == "" {
 		ref := strings.TrimSpace(r.ProfileRef)
-		if ref == "" || ref == "spike" {
-			return fmt.Errorf("validate: iso_url is required (or non-spike profile_ref for ISO resolve)")
+		// Phase 5c: non-spike profile may resolve; Phase 6a: BuildISO may produce URL.
+		if (ref == "" || ref == "spike") && !r.BuildISO {
+			return fmt.Errorf("validate: iso_url is required (or non-spike profile_ref / build_iso)")
 		}
 	}
 	if strings.TrimSpace(r.SerialTarget) == "" {

--- a/internal/common/validate/validate_test.go
+++ b/internal/common/validate/validate_test.go
@@ -78,4 +78,12 @@ func TestStartJobRequest(t *testing.T) {
 	if err := validate.StartJobRequest(spike); err == nil {
 		t.Fatal("spike still requires iso_url")
 	}
+	// Phase 6a: BuildISO may omit iso_url
+	build := good
+	build.ISOURL = ""
+	build.ProfileRef = "spike"
+	build.BuildISO = true
+	if err := validate.StartJobRequest(build); err != nil {
+		t.Fatal(err)
+	}
 }

--- a/internal/deploy/iso/doc.go
+++ b/internal/deploy/iso/doc.go
@@ -4,6 +4,8 @@
 // Phase 5c: Go-owned Builder wraps the known-good build-marker-iso.sh,
 // publishes into SHOAL_ISO_PUBLISH_DIR, and resolves profile iso_base → URL
 // for Deploy Start when -iso-url is omitted.
+// Phase 6a: InstallModeWrite writes /payload to a target with real SOL
+// IMAGE_WRITE progress; optional dynamic BuildISO on Start.
 //
 // MVP still serves plain HTTP on the management segment (no TLS ISO server).
 package iso

--- a/internal/deploy/iso/iso.go
+++ b/internal/deploy/iso/iso.go
@@ -12,6 +12,12 @@ import (
 	"time"
 )
 
+// Install modes for the live image (Phase 6a).
+const (
+	InstallModeSimulate = "simulate" // Phase 2 marker demo (default)
+	InstallModeWrite    = "write"    // write /payload to target with real SOL progress
+)
+
 // BuildInput describes a live-image build request.
 type BuildInput struct {
 	// Name is the output basename without path (default shoal-marker.iso).
@@ -19,8 +25,15 @@ type BuildInput struct {
 	// OutDir is the directory for the local artifact (default os.TempDir or CWD).
 	OutDir string
 	// EmbeddedPayload is non-secret text written into the image as /payload.
-	// Secrets must never be passed here.
+	// Secrets must never be passed here. Prefer PayloadFile for binary images.
 	EmbeddedPayload string
+	// PayloadFile is a host path copied into the image as /payload (binary-safe).
+	PayloadFile string
+	// InstallMode is simulate (default) or write (Phase 6a real payload write).
+	InstallMode string
+	// InstallTarget is optional block device or file path baked into the image
+	// (overridable via kernel cmdline shoal.target=).
+	InstallTarget string
 	// ScriptPath overrides the marker build script (empty = auto-discover).
 	ScriptPath string
 }
@@ -93,17 +106,40 @@ func (b *ScriptBuilder) Build(ctx context.Context, in BuildInput) (Artifact, err
 	}
 	outPath := filepath.Join(outDir, name)
 
+	mode := strings.TrimSpace(in.InstallMode)
+	if mode == "" {
+		mode = InstallModeSimulate
+	}
+	if mode != InstallModeSimulate && mode != InstallModeWrite {
+		return Artifact{}, fmt.Errorf("iso: invalid install mode %q", mode)
+	}
+
 	cmd := exec.CommandContext(ctx, script, outPath)
 	cmd.Env = os.Environ()
-	// Pass embedded payload without putting secrets into argv (env is still
-	// process-visible; callers must not pass passwords).
-	if p := strings.TrimSpace(in.EmbeddedPayload); p != "" {
+	// Payload: prefer file path (binary-safe); else inline text via env.
+	// Callers must not pass passwords.
+	if pf := strings.TrimSpace(in.PayloadFile); pf != "" {
+		st, err := os.Stat(pf)
+		if err != nil {
+			return Artifact{}, fmt.Errorf("iso: payload file: %w", err)
+		}
+		if st.IsDir() {
+			return Artifact{}, fmt.Errorf("iso: payload file is a directory")
+		}
+		cmd.Env = append(cmd.Env, "SHOAL_PAYLOAD_FILE="+pf)
+	} else if p := strings.TrimSpace(in.EmbeddedPayload); p != "" {
 		if looksSecretPayload(p) {
 			return Artifact{}, fmt.Errorf("iso: embedded_payload must not contain secret-like content")
 		}
 		cmd.Env = append(cmd.Env, "SHOAL_EMBEDDED_PAYLOAD="+p)
 	}
-	cmd.Env = append(cmd.Env, "SHOAL_ISO_NAME="+name)
+	cmd.Env = append(cmd.Env,
+		"SHOAL_ISO_NAME="+name,
+		"SHOAL_INSTALL_MODE="+mode,
+	)
+	if t := strings.TrimSpace(in.InstallTarget); t != "" {
+		cmd.Env = append(cmd.Env, "SHOAL_INSTALL_TARGET="+t)
+	}
 
 	start := time.Now()
 	out, err := cmd.CombinedOutput()
@@ -117,9 +153,23 @@ func (b *ScriptBuilder) Build(ctx context.Context, in BuildInput) (Artifact, err
 	b.Log.Info("iso built",
 		"path", outPath,
 		"size", st.Size(),
+		"mode", mode,
 		"elapsed_ms", time.Since(start).Milliseconds(),
 	)
 	return Artifact{Path: outPath, Name: name, Size: st.Size()}, nil
+}
+
+// BuildAndPublish builds then publishes; returns the public BMC-reachable URL.
+func (b *ScriptBuilder) BuildAndPublish(ctx context.Context, in BuildInput, dest PublishDest) (string, Artifact, error) {
+	art, err := b.Build(ctx, in)
+	if err != nil {
+		return "", Artifact{}, err
+	}
+	url, err := b.Publish(ctx, art, dest)
+	if err != nil {
+		return "", art, err
+	}
+	return url, art, nil
 }
 
 // Publish copies the artifact into dest.Dir and returns BaseURL/name.

--- a/internal/deploy/iso/iso_test.go
+++ b/internal/deploy/iso/iso_test.go
@@ -76,6 +76,28 @@ func TestBuildRejectsSecretPayload(t *testing.T) {
 	}
 }
 
+func TestBuildRejectsBadInstallMode(t *testing.T) {
+	b := iso.NewScriptBuilder("/nonexistent-script", slog.New(slog.NewTextHandler(io.Discard, nil)))
+	_, err := b.Build(context.Background(), iso.BuildInput{
+		InstallMode: "explode",
+		OutDir:      t.TempDir(),
+	})
+	if err == nil || !strings.Contains(err.Error(), "install mode") {
+		t.Fatalf("expected mode error, got %v", err)
+	}
+}
+
+func TestBuildRejectsMissingPayloadFile(t *testing.T) {
+	b := iso.NewScriptBuilder("/nonexistent-script", slog.New(slog.NewTextHandler(io.Discard, nil)))
+	_, err := b.Build(context.Background(), iso.BuildInput{
+		PayloadFile: filepath.Join(t.TempDir(), "missing.bin"),
+		OutDir:      t.TempDir(),
+	})
+	if err == nil {
+		t.Fatal("expected payload file error")
+	}
+}
+
 func TestFindBuildScript(t *testing.T) {
 	// From module root this should resolve in normal checkouts.
 	p, err := iso.FindBuildScript()

--- a/internal/deploy/job/orchestrator.go
+++ b/internal/deploy/job/orchestrator.go
@@ -8,6 +8,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"log/slog"
+	"strings"
 	"sync"
 	"time"
 
@@ -47,18 +48,21 @@ const (
 
 // Orchestrator owns lifecycle transitions, BMC actions, and cleanup.
 type Orchestrator struct {
-	log        *slog.Logger
-	store      jobstore.Store
-	secrets    secrets.Backend
-	newBMC     redfish.Factory
-	watches    watchport.WatchRegistrar
-	netbox     netbox.LifecycleWriter // optional; identity lifecycle only
-	profiles   profile.Store          // optional; Phase 5b approval gate
-	isoBaseURL string                 // Phase 5c: resolve profile iso_base → URL
-	authMode   string
-	tlsMode    string
-	caFile     string
-	failOrphan bool
+	log           *slog.Logger
+	store         jobstore.Store
+	secrets       secrets.Backend
+	newBMC        redfish.Factory
+	watches       watchport.WatchRegistrar
+	netbox        netbox.LifecycleWriter // optional; identity lifecycle only
+	profiles      profile.Store          // optional; Phase 5b approval gate
+	isoBaseURL    string                 // Phase 5c: resolve profile iso_base → URL
+	isoBuilder    iso.Builder            // optional Phase 6a dynamic build
+	isoPublishDir string
+	isoDynamic    bool // SHOAL_ISO_DYNAMIC: build when ISOURL empty + publish configured
+	authMode      string
+	tlsMode       string
+	caFile        string
+	failOrphan    bool
 
 	mu       sync.Mutex
 	running  map[string]*runState // jobID -> state
@@ -97,6 +101,9 @@ type Options struct {
 	NetBox              netbox.LifecycleWriter // optional Phase 5 lifecycle sync
 	Profiles            profile.Store          // optional Phase 5b profile load/approval
 	ISOBaseURL          string                 // optional Phase 5c profile → ISO URL resolve
+	ISOBuilder          iso.Builder            // optional Phase 6a dynamic build
+	ISOPublishDir       string                 // publish dir for dynamic build
+	ISODynamic          bool                   // build when ISOURL empty (needs builder+publish+base)
 	AuthMode            string
 	TLSMode             string
 	CAFile              string
@@ -121,21 +128,24 @@ func NewOrchestrator(opts Options) *Orchestrator {
 		tlsMode = "off"
 	}
 	o := &Orchestrator{
-		log:        log,
-		store:      opts.Store,
-		secrets:    opts.Secrets,
-		newBMC:     opts.NewBMC,
-		watches:    opts.Watches,
-		netbox:     opts.NetBox,
-		profiles:   opts.Profiles,
-		isoBaseURL: opts.ISOBaseURL,
-		authMode:   auth,
-		tlsMode:    tlsMode,
-		caFile:     opts.CAFile,
-		failOrphan: opts.ReconcileFailOrphan, // composition root passes config default true
-		running:    make(map[string]*runState),
-		terminal:   make(chan terminalEvent, 64),
-		stopCh:     make(chan struct{}),
+		log:           log,
+		store:         opts.Store,
+		secrets:       opts.Secrets,
+		newBMC:        opts.NewBMC,
+		watches:       opts.Watches,
+		netbox:        opts.NetBox,
+		profiles:      opts.Profiles,
+		isoBaseURL:    opts.ISOBaseURL,
+		isoBuilder:    opts.ISOBuilder,
+		isoPublishDir: opts.ISOPublishDir,
+		isoDynamic:    opts.ISODynamic,
+		authMode:      auth,
+		tlsMode:       tlsMode,
+		caFile:        opts.CAFile,
+		failOrphan:    opts.ReconcileFailOrphan, // composition root passes config default true
+		running:       make(map[string]*runState),
+		terminal:      make(chan terminalEvent, 64),
+		stopCh:        make(chan struct{}),
 	}
 	o.wg.Add(1)
 	go o.terminalLoop()
@@ -188,7 +198,8 @@ func (o *Orchestrator) Get(ctx context.Context, jobID string) (models.Provisioni
 // (failure is logged and does not block BMC actions).
 // Profiles with NeedsApproval/DestructSteps require store approval or ApproveDestruct.
 // When ISOURL is empty and a non-spike profile is loaded, iso_base is resolved via
-// SHOAL_ISO_BASE_URL (Phase 5c).
+// SHOAL_ISO_BASE_URL (Phase 5c). Optional BuildISO / SHOAL_ISO_DYNAMIC builds and
+// publishes a live image first (Phase 6a).
 func (o *Orchestrator) Start(ctx context.Context, req models.StartJobRequest) (models.ProvisioningJob, error) {
 	if err := validate.StartJobRequest(req); err != nil {
 		return models.ProvisioningJob{}, err
@@ -202,6 +213,9 @@ func (o *Orchestrator) Start(ctx context.Context, req models.StartJobRequest) (m
 		profileRef = "spike"
 	}
 	if err := o.checkProfileApproval(ctx, profileRef, req.ApproveDestruct); err != nil {
+		return models.ProvisioningJob{}, err
+	}
+	if err := o.maybeBuildISO(ctx, &req, profileRef); err != nil {
 		return models.ProvisioningJob{}, err
 	}
 	if err := o.resolveISOURL(ctx, &req, profileRef); err != nil {
@@ -633,6 +647,96 @@ func (o *Orchestrator) resolveISOURL(ctx context.Context, req *models.StartJobRe
 		"iso_url", url,
 	)
 	return nil
+}
+
+// maybeBuildISO builds and publishes a live image when BuildISO is set, or when
+// ISODynamic is enabled and ISOURL is still empty.
+func (o *Orchestrator) maybeBuildISO(ctx context.Context, req *models.StartJobRequest, profileRef string) error {
+	want := req.BuildISO || (o.isoDynamic && req.ISOURL == "")
+	if !want {
+		return nil
+	}
+	// Explicit URL without BuildISO: skip rebuild.
+	if req.ISOURL != "" && !req.BuildISO {
+		return nil
+	}
+	if o.isoBuilder == nil {
+		if req.BuildISO {
+			return fmt.Errorf("job: build_iso requested but ISO builder not configured")
+		}
+		return nil
+	}
+	if o.isoPublishDir == "" || o.isoBaseURL == "" {
+		return fmt.Errorf("job: dynamic ISO requires SHOAL_ISO_PUBLISH_DIR and SHOAL_ISO_BASE_URL")
+	}
+
+	name := "shoal-install.iso"
+	mode := strings.TrimSpace(req.ISOInstallMode)
+	payloadFile := strings.TrimSpace(req.ISOPayloadFile)
+	target := strings.TrimSpace(req.ISOInstallTarget)
+	embedded := ""
+
+	if profileRef != "" && profileRef != "spike" && o.profiles != nil {
+		if rec, err := o.profiles.Get(ctx, profileRef); err == nil {
+			if rec.Profile.ISOBase != "" {
+				base := rec.Profile.ISOBase
+				// Basename only; strip URL path if operator put a full URL in iso_base.
+				if i := strings.LastIndex(base, "/"); i >= 0 {
+					base = base[i+1:]
+				}
+				if !strings.HasSuffix(strings.ToLower(base), ".iso") {
+					base += ".iso"
+				}
+				name = base
+			}
+			if payloadFile == "" && rec.Profile.EmbeddedPayload != "" {
+				embedded = rec.Profile.EmbeddedPayload
+			}
+		}
+	}
+	if mode == "" {
+		if payloadFile != "" || embedded != "" {
+			mode = iso.InstallModeWrite
+		} else {
+			mode = iso.InstallModeSimulate
+		}
+	}
+
+	in := iso.BuildInput{
+		Name:            name,
+		PayloadFile:     payloadFile,
+		EmbeddedPayload: embedded,
+		InstallMode:     mode,
+		InstallTarget:   target,
+	}
+	url, art, err := buildAndPublish(ctx, o.isoBuilder, in, iso.PublishDest{
+		Dir: o.isoPublishDir, BaseURL: o.isoBaseURL,
+	})
+	if err != nil {
+		return fmt.Errorf("job: dynamic iso build: %w", err)
+	}
+	req.ISOURL = url
+	o.log.Info("iso built dynamically",
+		"profile_ref", profileRef,
+		"path", art.Path,
+		"size", art.Size,
+		"mode", mode,
+		"iso_url", url,
+	)
+	return nil
+}
+
+// buildAndPublish uses ScriptBuilder.BuildAndPublish when available, else Build+Publish.
+func buildAndPublish(ctx context.Context, b iso.Builder, in iso.BuildInput, dest iso.PublishDest) (string, iso.Artifact, error) {
+	if sb, ok := b.(*iso.ScriptBuilder); ok {
+		return sb.BuildAndPublish(ctx, in, dest)
+	}
+	art, err := b.Build(ctx, in)
+	if err != nil {
+		return "", iso.Artifact{}, err
+	}
+	url, err := b.Publish(ctx, art, dest)
+	return url, art, err
 }
 
 // syncNetBoxLifecycle best-effort updates NetBox identity lifecycle_state.


### PR DESCRIPTION
## Summary

Phase **6a** of polish: move from simulated marker writes to a live image that can **really write** an embedded payload and report progress over SOL, plus optional dynamic build/publish at Deploy Start.

- **Live image** (`build-marker-iso.sh`): `SHOAL_INSTALL_MODE=simulate|write`; write mode `dd`s `/payload` to target with chunked `IMAGE_WRITE` progress; target from cmdline / bake-in / block devices / `/tmp/shoal-install.out` fallback
- **Go ISO**: `PayloadFile`, `InstallMode`, `InstallTarget`; `BuildAndPublish`
- **Start**: `-build-iso` / `BuildISO`, payload/mode/target fields; `SHOAL_ISO_DYNAMIC` when URL empty
- **Docs**: lab-runbook 6a, AGENTS, design next-actions (Phase 0–5 done)

**Not** a full OS installer — bounded payload blob MVP (golden rootfs / autoinstall is later stretch).

## Test plan

- [x] `gofmt`, `go vet`, `staticcheck`, `go test ./...`
- [x] Unit: install mode validation, payload file, ISO resolve (existing)
- [x] Lab (VM):
  - [x] L1 write-mode build + 2 MiB payload → `/srv/iso/shoal-install-6a.iso`
  - [x] Initrd: `install_mode=write`, payload present
  - [x] Deploy write ISO → SOL DONE (`percent=100`, `last_marker_seq=8`)
  - [x] Profile resolve without `-iso-url`
  - [x] L0 publish smoke
- [ ] CI green on PR

## Notes

- Sushy DONE post-check may still fail with `boot override still set (Continuous/Hdd)` after SOL success (known lab noise).
- Write target in lab test was guest `/tmp/shoal-install.out` — host cannot inspect post-poweroff; proof is baked write path + SOL terminal markers.