### PR TITLE
feat: Phase 6c multi-platform packaging and L0 host profiles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  push:
+    branches: [master, main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: go test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.22.x"
+          cache: true
+
+      - name: gofmt
+        run: |
+          out="$(gofmt -l .)"
+          if [ -n "$out" ]; then
+            echo "gofmt needed on:"
+            echo "$out"
+            exit 1
+          fi
+
+      - name: go vet
+        run: go vet ./...
+
+      - name: staticcheck
+        run: |
+          go install honnef.co/go/tools/cmd/staticcheck@2025.1.1
+          staticcheck ./...
+
+      - name: go test
+        run: go test ./...
+
+      - name: build (CGO-free smoke)
+        run: CGO_ENABLED=0 go build -o /tmp/shoal ./cmd/shoal

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,56 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: build and publish
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.22.x"
+          cache: true
+
+      - name: Build multi-platform binaries
+        env:
+          VERSION: ${{ github.ref_name }}
+        run: |
+          chmod +x scripts/build-release.sh
+          ./scripts/build-release.sh
+
+      - name: Package archives
+        run: |
+          set -euo pipefail
+          cd dist
+          for f in shoal_*; do
+            case "$f" in
+              checksums.txt|LICENSE|NOTICE|*.md) continue ;;
+            esac
+            archive="${f}.tar.gz"
+            tar -czf "$archive" "$f" LICENSE NOTICE third-party-licenses.md THIRD_PARTY_LICENSES.md
+          done
+          ls -la
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: |
+            dist/*.tar.gz
+            dist/checksums.txt
+            dist/LICENSE
+            dist/NOTICE
+            dist/third-party-licenses.md
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ infra/cloud-init-seed.iso
 coverage.out
 vendor/
 .shoal/
+
+# Release build output
+/dist/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This file is the canonical guide for how to work in this repository. It covers
 project conventions, commands, and style. For **architecture, data models, and
 the phased plan**, the source of truth is
 [`SHOAL_COMPREHENSIVE_DESIGN_AND_IMPLEMENTATION_PLAN.md`](./SHOAL_COMPREHENSIVE_DESIGN_AND_IMPLEMENTATION_PLAN.md)
-(**v2.0.5**, Go stack). When this file and the design doc disagree, fix one of
+(**v2.0.6**, Go stack). When this file and the design doc disagree, fix one of
 them in the same change — they must stay consistent.
 
 > **Read order for any task:** (1) this file, (2) the relevant Chapter 4 section
@@ -116,8 +116,13 @@ shoal/                                    # module: github.com/mattcburns/shoal
     golden/                               # prompt regression fixtures
     redfish/                              # record/replay corpus
   infra/ansible/                          # lab automation (language-agnostic)
+  scripts/
+    build-release.sh                      # multi-platform CGO-free release binaries
+  .github/workflows/                      # ci.yml + release.yml (v* tags)
   docs/
     third-party-licenses.md               # full texts of runtime Go dep licenses
+    operator-macos.md                     # Mac = operator only (Phase 6c)
+    phase-6c-plan.md                      # packaging + L0 host profiles checklist
   go.mod
   LICENSE                                 # AGPLv3 (Shoal)
   NOTICE                                  # third-party inventory + copyrights
@@ -183,6 +188,17 @@ the phase playbooks (`vm_provision`, `preflight`, `lab_up`, `bootstrap_netbox`,
 Default VM-hosted endpoints: NetBox `:8000`, sushy `:8001`, ISO HTTP `:8080`,
 Ollama `:11434`, telemetry Postgres `:5433`. Shoal app listens on **`:8088`**.
 
+**L0 host profiles (Phase 6c, `lab_vm` role):**
+
+| Profile | Notes |
+|---------|--------|
+| classic Linux | Existing path; ufw rules when active |
+| Fedora secureblue / Atomic | Modular libvirt enablement attempts; firewalld for mgmt bridge; actionable fails |
+| macOS | **Not L0** — fail fast; operator docs in `docs/operator-macos.md` |
+
+L1 remains Ubuntu + Docker. Direct-host lab on secureblue/macOS is unsupported.
+See `docs/lab-setup-checklist.md` and design v2.0.6 Phase 6c.
+
 ### 3.2 App (Go)
 
 **Go 1.22+.** Module path: `github.com/mattcburns/shoal`.
@@ -200,6 +216,14 @@ staticcheck ./...
 go test ./...
 go test ./... -tags=integration   # needs lab (up.yml)
 ```
+
+Release binaries (Phase 6c; CGO-free matrix → `dist/`):
+```bash
+./scripts/build-release.sh
+# VERSION=v0.6.0 ./scripts/build-release.sh   # override version stamp
+```
+Ships `LICENSE`, `NOTICE`, and third-party license texts next to binaries.
+GHA: `.github/workflows/ci.yml` on PR; `.github/workflows/release.yml` on `v*` tags.
 
 Run the app (Phase 1+):
 ```bash

--- a/README.md
+++ b/README.md
@@ -13,9 +13,13 @@ This repository contains the Shoal Go application and **lab automation** for a
 
 The lab topology is:
 
-- **L0**: your developer machine (runs libvirt/KVM)
+- **L0**: Linux hypervisor (libvirt/KVM) — classic distros or **Fedora secureblue**; **not macOS**
 - **L1**: dedicated lab VM (runs Ansible target host, Docker, libvirt, sushy-tools)
 - **L2**: virtual Redfish/BMC nodes (emulated by libvirt + exposed via sushy-tools)
+
+**macOS operators** use a prebuilt/darwin binary (or `go build`) against a remote
+Linux lab — see [docs/operator-macos.md](docs/operator-macos.md). Multi-platform
+release builds: `./scripts/build-release.sh` (see Phase 6c).
 
 ## What's in this repo
 - `ansible.cfg` - project-local Ansible config
@@ -28,6 +32,8 @@ The lab topology is:
 ## Lab docs
 - [Lab Runbook (Quick Ops)](docs/lab-runbook.md)
 - [Lab Setup Checklist (First-Time)](docs/lab-setup-checklist.md)
+- [Operator host: macOS](docs/operator-macos.md)
+- [Phase 6c plan (packaging + L0 hosts)](docs/phase-6c-plan.md)
 
 ## Prerequisites (L0 host)
 Install and verify:

--- a/SHOAL_COMPREHENSIVE_DESIGN_AND_IMPLEMENTATION_PLAN.md
+++ b/SHOAL_COMPREHENSIVE_DESIGN_AND_IMPLEMENTATION_PLAN.md
@@ -1,6 +1,6 @@
 # Shoal: Comprehensive Design Document & Phased Implementation Plan
 
-**Version:** 2.0.5  
+**Version:** 2.0.6  
 **Date:** July 2026  
 **Status:** Draft (post-review; open questions resolved)  
 **Author:** (architect / AI agent)  
@@ -28,11 +28,11 @@ This is a **language/stack revision** of the v1.1 product design — not a green
 
 ---
 
-## Changes in v2.0 / v2.0.1 / v2.0.2 / v2.0.3 / v2.0.4 / v2.0.5
+## Changes in v2.0 / v2.0.1 / v2.0.2 / v2.0.3 / v2.0.4 / v2.0.5 / v2.0.6
 
 Full stack rewrite of the **application** from Python to **Go (Golang)**, maximizing the Go standard library **except where Redfish complexity justifies gofish**.
 
-| Area | v1.1 (Python) | v2.0.5 (Go) |
+| Area | v1.1 (Python) | v2.0.6 (Go) |
 |------|---------------|-------------|
 | Language | Python 3.11+ | Go 1.22+ (prefer latest stable) |
 | Module path | n/a | **`github.com/mattcburns/shoal`** |
@@ -61,6 +61,8 @@ Full stack rewrite of the **application** from Python to **Go (Golang)**, maximi
 **v2.0.4 (Phase 3 AI contract):** dual-model local AI — text (`SHOAL_AI_MODEL`) vs vision (`SHOAL_AI_VISION_MODEL`); explicit `Complete` / `CompleteVision` routing; nested-lab-friendly defaults.
 
 **v2.0.5 (photo vision model):** lab vision default is **`deepseek-ocr`** (Free OCR on asset labels; parse SERIAL/VENDOR/MODEL). Rejects placeholder serials. **`moondream` is not AC-grade** for inventory OCR. Text hybrid remains `llama3.2:3b` — do **not** use `deepseek-ocr` as the text model. Phase 6 graphics failure-screen OCR remains deferred (Tesseract vs cloud vision).
+
+**v2.0.6 (Phase 6c packaging + L0 hosts):** multi-platform **CGO-free** release binaries (linux/darwin amd64/arm64) via scripts + GHA; ship `LICENSE`/`NOTICE`/`docs/third-party-licenses.md` with artifacts; **macOS is an operator host** (binary + remote/Linux lab) — not an L0 nested hypervisor. **L0 VM-hosted lab** supports classic Linux and **Fedora secureblue** (detect profile, modular libvirt, firewalld; keep ufw path). Direct-host lab on secureblue and nested lab on macOS remain **out of scope**. Compose `shoal` service image, API auth, metrics, record/replay CI → **Phase 6d+**.
 
 **Preserved (product decisions, not language):**
 
@@ -1434,9 +1436,68 @@ Graphics OCR via **Core `CompleteVision`** (not Tesseract-first), dynamic ISO / 
 
 **Phase 6b (graphics OCR):** Core `CompleteVision` + versioned `failure_screen_ocr.v1` prompt. Image sources: operator file (lab AC) or `BMC.CaptureScreenshot` with **Dell** and **Supermicro** OEM adapters (public docs; rich `CaptureDebugStep` traces). sushy has no capture — unsupported error + file path. Telemetry `events.event_type=graphics_ocr`. SOL remains primary; OCR does not commit lifecycle.
 
-### Phase 6 (remaining)
+**Phase 6c (release packaging + multi-host L0 operators) — detailed plan:**
 
-Compose shoal packaging, API auth + metrics, record/replay CI; more vendor screenshot adapters as hardware is tested.
+Operator machines and release artifacts diverge by role. The **lab topology is unchanged** (L0 hypervisor → L1 Ubuntu lab VM → L2 sushy nodes). What changes is (1) how end users obtain a binary and (2) which L0 OSes the Ansible VM-provision path supports cleanly.
+
+#### 6c.1 — Multi-platform binary packaging
+
+| Item | Decision |
+|------|----------|
+| Targets | `linux/amd64`, `linux/arm64`, `darwin/amd64`, `darwin/arm64` |
+| Linkage | **`CGO_ENABLED=0`** (stdlib + gofish + pgx; no CGO) |
+| Local build | `scripts/build-release.sh` → `dist/shoal_<os>_<arch>[.exe]` + checksums |
+| CI | GHA: unit `go test`/`vet`/`staticcheck` on PR; **release** workflow on `v*` tags publishes archives |
+| License bundle | Every archive/release asset includes `LICENSE`, `NOTICE`, `docs/third-party-licenses.md` (AGENTS §9.1) |
+| Version | Embed via `-ldflags "-X main.version=…"` (or `internal/version`) from git tag / `dev` |
+| Compose shoal image | **Deferred to 6d** (optional container wrapping the same binary) |
+
+**macOS operator model (explicit):**
+
+- Supported: download/build **darwin** binary; point env at a **reachable lab** (VM-hosted endpoints on Linux L0, or remote lab host).
+- Supported: run Ansible **from** macOS **only** if inventory targets a Linux L0/`shoal-lab-vm` over SSH (controller can be Darwin; `vm_l0` connection local must still be a Linux hypervisor).
+- **Not supported:** nested KVM lab on macOS (no `lab_vm` on Darwin). Documented alternative: Linux L0 (including secureblue) or borrow an existing lab.
+
+**Docker Desktop:** not required. Optional Podman/Colima only if the operator chooses containers; default path is binary + remote services.
+
+#### 6c.2 — L0 host profiles for VM-hosted lab
+
+`lab_vm` (play `vm_provision.yml`, hosts `vm_l0`) is the only role that mutates the **outer** hypervisor. Extend it without breaking existing classic Linux L0.
+
+| Profile | Detection (illustrative) | Behavior |
+|---------|--------------------------|----------|
+| `classic` | Default when not atomic | Require `virsh`, `qemu-img`, seed-ISO tool, nested KVM; **ufw** rules if active (existing) |
+| `secureblue` / Fedora Atomic | `/etc/os-release` ID/VARIANT + `rpm-ostree` and/or secureblue markers | Verify preinstalled virt stack; enable **system** libvirt (modular daemons preferred: `virtqemud`/`virtnetworkd`/… or `ujust set-libvirt-daemons` guidance); **firewalld** rules for mgmt bridge (NAT/DNS); do **not** force `libvirt` group membership; clear fail text with operator steps |
+| `darwin` | `ansible_system == Darwin` | **Fail fast** with pointer to operator-only docs (do not attempt domain define) |
+
+**Seed ISO tool:** accept any of `genisoimage`, `mkisofs`, `xorriso` (first found) so Atomic/Homebrew hosts without genisoimage still work.
+
+**Firewall:** rename conceptual flag to manage host firewall; keep `shoal_lab_vm_manage_ufw` as compatible alias. Paths: ufw (existing), firewalld (new), neither (no-op).
+
+**L1 unchanged:** `host_prereqs` remains Debian-family install on `shoal-lab-vm` (Ubuntu cloud image). Secureblue is **L0-only**.
+
+**Non-goals (6c):**
+
+- Direct-host lab (`lab.yml`) on secureblue or macOS  
+- Nested lab on Darwin  
+- Replacing L1 Docker with Podman  
+- API auth, metrics, record/replay CI (→ **6d**)
+
+#### 6c acceptance criteria
+
+1. `scripts/build-release.sh` produces four GOOS/GOARCH binaries with `CGO_ENABLED=0`; checksums present.
+2. GHA CI runs tests on PR; tag `v*` builds and attaches release assets including license bundle.
+3. Docs: operator macOS path; L0 secureblue checklist; README points to both.
+4. `lab_vm` on classic Linux L0: existing ufw + nested checks still pass (no regression).
+5. `lab_vm` on secureblue profile: detects profile; enables or documents system libvirt; opens firewalld for mgmt bridge when active; fails with actionable messages if virt/nested missing.
+6. `lab_vm` on Darwin localhost: fails with operator-only guidance (no partial VM create).
+7. AGENTS.md documents packaging + L0 profiles; design §7.1 unchanged unless a new Go dep is added (prefer none).
+
+### Phase 6d+ (later)
+
+Compose `shoal` service packaging; API auth + metrics; record/replay CI; more vendor screenshot adapters as hardware is tested.
+
+Executable checklist: [`docs/phase-6c-plan.md`](./docs/phase-6c-plan.md).
 
 ---
 
@@ -1602,6 +1663,7 @@ go test ./...
 | PR13 | `feat(deploy): full ISO pipeline + profile gen` | `deploy/iso`, `core/profile` | PR7, PR9 | Static base inject; approval gate |
 | PR14 | `chore: Compose shoal service + Ansible env contract` | `compose_stack`, group_vars | PR1+ | Binary image; `env.j2` NetBox token + DSN + HTTP port |
 | PR15 | `feat: Phase 6 polish` | OCR (choose approach), metrics, API auth, TLS CA | MVP | Evaluate OCR options then implement; other hardening |
+| PR16 | `feat: Phase 6c packaging + L0 host profiles` | `scripts/build-release.sh`, GHA, `lab_vm`, docs | Phase 6a–b on master | Multi-platform CGO-free binaries + NOTICE; macOS operator docs; secureblue L0 + firewalld; keep classic L0 |
 
 **High-level order:** Docs → skeleton → models/secrets → **Postgres jobs** → Redfish + SOL + **live image** → Deploy orchestrator → **Phase 2 spike** → **AI** → Discover hybrid → Observe broaden → Deploy harden → Compose package → Phase 6.
 
@@ -1609,7 +1671,7 @@ go test ./...
 
 ## Open Questions
 
-**All previously open product decisions are resolved through v2.0.5.** Phase 0–5 are on `master`; Phase 6 (polish) is next.
+**All previously open product decisions are resolved through v2.0.6.** Phase 0–5 and 6a–6b are on `master`; Phase **6c** (packaging + L0 hosts) is next; **6d+** remains later polish.
 
 | Topic | Resolution |
 |-------|------------|
@@ -1629,10 +1691,13 @@ go test ./...
 | **Lab AI text model** | **`SHOAL_AI_MODEL=llama3.2:3b`** (instruct; nested-lab friendly) |
 | **Lab AI vision model** | **`SHOAL_AI_VISION_MODEL=deepseek-ocr`** for asset-label Free OCR; **moondream not AC**; empty skips photo |
 | **Complete vs CompleteVision** | Text Discover → `Complete` + text model; photo → `CompleteVision` (`Free OCR.`) + parse SERIAL/VENDOR/MODEL; missing serial → **fail** (no synthetic IDs) |
+| **Phase 6c packaging** | Multi-platform CGO-free binaries + GHA release; license bundle; macOS = **operator only** |
+| **Phase 6c L0 hosts** | Classic Linux + **secureblue/Atomic** for VM-hosted lab; Darwin L0 nested lab **unsupported** |
+| **Compose shoal / API auth / metrics / replay CI** | **Phase 6d+** (after 6c) |
 
-**Deferred until Phase 6 (not blocking earlier phases):**
+**Deferred until Phase 6d+ (not blocking 6c):**
 
-- Exact OCR implementation choice and any extra allow-list entries it requires.
+- Compose `shoal` service image; API auth; metrics/tracing; record/replay CI; additional vendor screenshot adapters.
 
 ---
 
@@ -1648,9 +1713,9 @@ go test ./...
 
 ---
 
-**This document (v2.0.5) is the SoT for agents.** Phase 0–5 (Discover, Observe, Deploy harden) are on `master`.
+**This document (v2.0.6) is the SoT for agents.** Phase 0–5 and 6a–6b are on `master`.
 
 Next actions:
-1. Phase 6a: dynamic ISO + real payload write (in progress / next)
-2. Phase 6b–d: graphics OCR (CompleteVision), Compose shoal packaging, API auth + metrics + replay CI
+1. Phase **6c**: multi-platform packaging + macOS operator docs + L0 secureblue/classic lab_vm profiles ([`docs/phase-6c-plan.md`](./docs/phase-6c-plan.md))
+2. Phase **6d+**: Compose shoal service, API auth, metrics, record/replay CI; more vendor screenshot adapters
 3. Stretch: full distro autoinstall; NetBox device-id binding

--- a/docs/lab-runbook.md
+++ b/docs/lab-runbook.md
@@ -420,8 +420,16 @@ ansible-playbook -i infra/ansible/inventory/lab.yml infra/ansible/playbooks/down
 ```bash
 ls -l /dev/kvm
 grep -E '(vmx|svm)' /proc/cpuinfo | head
+cat /sys/module/kvm_intel/parameters/nested 2>/dev/null \
+  || cat /sys/module/kvm_amd/parameters/nested 2>/dev/null
+virsh -c qemu:///system version
 ```
 If missing, enable nested virtualization and reboot/reload KVM modules.
+
+**L0 profiles (Phase 6c):** classic Linux (ufw-aware) and **Fedora secureblue**
+(firewalld + modular libvirt). **macOS is not L0** — see
+[operator-macos.md](./operator-macos.md) and
+[lab-setup-checklist.md](./lab-setup-checklist.md) (L0 secureblue section).
 
 ### B) VM boots but SSH fails
 ```bash

--- a/docs/lab-setup-checklist.md
+++ b/docs/lab-setup-checklist.md
@@ -2,22 +2,55 @@
 First-time setup of the Shoal lab. All steps use Ansible directly; there is no Makefile.
 
 ## 1) Host prerequisites (L0)
-- [ ] `libvirt` / `virsh` installed and `libvirtd` running
-- [ ] `qemu-system-x86`, `qemu-img`, `genisoimage` installed
-- [ ] `ansible-playbook` installed
+
+L0 is the **Linux hypervisor** that runs the lab VM. **macOS is not a valid L0**
+(operator-only — see [operator-macos.md](./operator-macos.md)). Classic Linux and
+**Fedora secureblue** are supported for VM-hosted mode.
+
+### All Linux L0
+- [ ] `libvirt` / `virsh` usable with **`qemu:///system`** (system session)
+- [ ] `qemu-img` installed; QEMU/KVM stack present
+- [ ] Seed ISO tool: `genisoimage` **or** `mkisofs` **or** `xorriso`
+- [ ] `ansible-playbook` installed (on L0 or a controller that SSHs to L0)
 - [ ] `ssh` / `scp` installed
 - [ ] `/dev/kvm` exists on host
 - [ ] CPU virtualization flags present (`vmx` or `svm`)
+- [ ] **Nested virtualization** enabled on L0 (required for L2 sushy nodes)
 
 Quick checks:
 ```bash
 ls -l /dev/kvm
 grep -E '(vmx|svm)' /proc/cpuinfo | head
+cat /sys/module/kvm_intel/parameters/nested 2>/dev/null \
+  || cat /sys/module/kvm_amd/parameters/nested 2>/dev/null
+virsh -c qemu:///system version
 ```
 
 > The L0 management network (`shoal-mgmt-net`, `192.168.122.0/24`) is created
 > automatically by `up.yml`. You do **not** need to pre-create libvirt's
 > `default` network.
+
+### L0 on Fedora secureblue (optional profile)
+
+secureblue ships libvirt/QEMU/virt-manager on desktop images. Before `up.yml`:
+
+- [ ] Desktop secureblue image (virt stack preinstalled)
+- [ ] Enable **system** libvirt daemons:
+  ```bash
+  ujust set-libvirt-daemons
+  ```
+  Prefer the QEMU/KVM **system** session (bridge/NAT for the lab network). Do
+  **not** rely on the user session alone. Avoid adding your user to the
+  `libvirt` group for passwordless root-equivalent access; authenticate as needed.
+- [ ] Nested KVM enabled (same `modprobe.d` steps as classic Linux if nested is off)
+- [ ] Seed ISO tool available (`brew install xorriso` / `cdrtools`, or layer RPM)
+- [ ] Ansible available (`brew install ansible` or run playbooks from another host)
+- [ ] Optional: expect **SMT** may be disabled (secureblue mitigations) → slower nested lab / Ollama
+
+The `lab_vm` role detects secureblue/Atomic, tries modular libvirt sockets, opens
+**firewalld** for the management bridge (and still supports **ufw** on classic hosts).
+
+Direct-host lab mode (`lab.yml`) on secureblue is **not** a supported target.
 
 ## 2) Install Ansible collections
 - [ ] Run once:

--- a/docs/operator-macos.md
+++ b/docs/operator-macos.md
@@ -1,0 +1,96 @@
+# Operator host: macOS
+
+Phase **6c** treats macOS as an **operator** machine: run the Shoal binary (and optionally Ansible as a controller) against a **Linux-hosted lab**. Nested KVM lab on Darwin is **not** supported.
+
+## What works on Mac
+
+| Task | Supported? |
+|------|------------|
+| Run `shoal` CLI / `serve` against remote lab endpoints | Yes |
+| `go build` / download **darwin/amd64** or **darwin/arm64** binary | Yes |
+| Drive Ansible playbooks when `shoal-lab-vm` is a remote Linux host | Yes (SSH) |
+| Host L0 libvirt + nested L1 lab (`vm_l0` = localhost) | **No** |
+
+You do **not** need Docker Desktop for the default path. Lab services (NetBox, Ollama, Postgres, ISO HTTP, sushy) stay on the Linux lab VM.
+
+## Get a binary
+
+**Release (preferred once tags exist):**
+
+```bash
+# Example: Apple Silicon
+curl -fsSL -o shoal_darwin_arm64.tar.gz \
+  "https://github.com/mattcburns/shoal/releases/download/vX.Y.Z/shoal_darwin_arm64.tar.gz"
+tar -xzf shoal_darwin_arm64.tar.gz
+./shoal_darwin_arm64 version
+```
+
+Archives include `LICENSE`, `NOTICE`, and third-party license texts.
+
+**Local build:**
+
+```bash
+# From repo root; or use the multi-platform script
+CGO_ENABLED=0 go build -o shoal ./cmd/shoal
+
+# All release targets (including linux) into dist/
+./scripts/build-release.sh
+```
+
+## Point at a lab
+
+Typical VM-hosted endpoints (Linux L0 nested lab):
+
+| Service | Default URL |
+|---------|-------------|
+| NetBox | `http://192.168.122.100:8000` |
+| Redfish (sushy) | `http://192.168.122.100:8001` |
+| ISO | `http://192.168.122.100:8080` |
+| Shoal API (if running in lab) | `http://192.168.122.100:8088` |
+| Telemetry Postgres | `192.168.122.100:5433` |
+| Ollama | `http://192.168.122.100:11434` |
+
+Export the usual env vars (`SHOAL_NETBOX_*`, `SHOAL_TELEMETRY_DATABASE_URL`, `SHOAL_OLLAMA_URL`, BMC creds, etc.) from your vault/docs. Reachability requires VPN, LAN, or SSH tunnels to the lab management network.
+
+Example tunnel (lab VM only reachable on a remote Linux L0):
+
+```bash
+ssh -L 8000:192.168.122.100:8000 \
+    -L 8001:192.168.122.100:8001 \
+    -L 8080:192.168.122.100:8080 \
+    -L 5433:192.168.122.100:5433 \
+    -L 11434:192.168.122.100:11434 \
+    user@linux-l0-host
+```
+
+Then use `http://127.0.0.1:…` in env vars.
+
+## Where to run the nested lab
+
+Use a Linux L0 hypervisor:
+
+- Classic: Ubuntu/Fedora/Arch with libvirt + nested KVM (existing path)
+- **Fedora secureblue**: supported as L0 for VM-hosted mode — see [lab-setup-checklist.md](./lab-setup-checklist.md) § L0 secureblue
+
+Bring up from a Linux L0 (or from Mac only if inventory SSH targets that Linux host’s libvirt — advanced; default inventory uses `localhost` connection local):
+
+```bash
+ansible-playbook -i infra/ansible/inventory/lab-vm.yml \
+  infra/ansible/playbooks/up.yml --ask-become-pass
+```
+
+## Ansible from macOS
+
+- Install Ansible (Homebrew: `brew install ansible`) and collections:
+  `ansible-galaxy collection install -r infra/ansible/requirements.yml`
+- Default `lab-vm.yml` sets `vm_l0` → `localhost` with `ansible_connection: local`. That **must** be a Linux KVM host. On a Mac laptop, either:
+  1. Run `up.yml` **on** the Linux L0 (SSH in and clone the repo), or
+  2. Change inventory so `vm_l0` is the Linux hypervisor over SSH (not documented as primary; keep secrets/paths in mind).
+
+`lab_vm` **fails fast** if it detects Darwin as L0, with a pointer back to this doc.
+
+## Related
+
+- Design Phase 6c: design doc v2.0.6 / [phase-6c-plan.md](./phase-6c-plan.md)
+- Lab ops: [lab-runbook.md](./lab-runbook.md)
+- License notices: [NOTICE](../NOTICE), [third-party-licenses.md](./third-party-licenses.md)

--- a/docs/phase-6c-plan.md
+++ b/docs/phase-6c-plan.md
@@ -1,0 +1,76 @@
+# Phase 6c — Packaging + L0 host profiles
+
+Executable checklist for design **v2.0.6** § Phase 6c. Design SoT:
+[`SHOAL_COMPREHENSIVE_DESIGN_AND_IMPLEMENTATION_PLAN.md`](../SHOAL_COMPREHENSIVE_DESIGN_AND_IMPLEMENTATION_PLAN.md).
+
+## Goals
+
+1. **Ship CGO-free multi-platform binaries** (linux/darwin × amd64/arm64) with license notices.
+2. **Document macOS as operator-only** (binary + remote/Linux lab; no nested L0 on Darwin).
+3. **VM-hosted lab on secureblue L0** via Ansible, without breaking classic Linux L0.
+4. Keep L1 Ubuntu stack and direct-host Debian path unchanged.
+
+## Non-goals
+
+- Compose `shoal` container image (6d)
+- API auth, metrics, record/replay CI (6d)
+- Direct-host lab on secureblue or macOS
+- Nested KVM lab on macOS
+
+## Workstreams
+
+### A — Release packaging
+
+| # | Task | AC |
+|---|------|----|
+| A1 | `scripts/build-release.sh` — matrix build, checksums, copy LICENSE/NOTICE/third-party | Four binaries under `dist/` |
+| A2 | Version stamp via ldflags (`internal/version` or `main`) | `shoal version` / help shows tag or `dev` |
+| A3 | GHA CI: `gofmt` check, `go vet`, `staticcheck`, `go test ./...` | Green on PR |
+| A4 | GHA release on `v*` tags: build matrix + attach archives + license bundle | GitHub Release assets |
+| A5 | Docs: `docs/operator-macos.md` + README packaging blurb | Mac path clear |
+
+### B — L0 Ansible profiles (`lab_vm`)
+
+| # | Task | AC |
+|---|------|----|
+| B1 | Detect L0 profile: `classic` \| `secureblue` \| `darwin` | Fact set early in role |
+| B2 | Darwin: fail fast with operator docs pointer | No domain define attempted |
+| B3 | Seed ISO tool: `genisoimage` \| `mkisofs` \| `xorriso` | First match works |
+| B4 | Secureblue: verify virt tools; enable system libvirt (modular preferred); actionable fail if missing | Clear messages / optional enable tasks |
+| B5 | Firewall: ufw (existing) + firewalld (new); keep ufw flag as alias | NAT/DNS for mgmt bridge |
+| B6 | Do not force `libvirt` group on secureblue | Polkit/auth model preserved |
+| B7 | Docs: L0 secureblue section in checklist + runbook | Operator can re-`up.yml` |
+
+### C — Agent / design hygiene
+
+| # | Task | AC |
+|---|------|----|
+| C1 | AGENTS.md packaging + L0 notes; layout lists scripts/GHA | Agents know the contract |
+| C2 | Design v2.0.6 Phase 6c + PR16 | SoT matches code |
+
+## Suggested PR split
+
+1. **PR16a (docs/design):** design v2.0.6 + this plan (may ship with implementation).
+2. **PR16b (lab):** `lab_vm` profiles + firewalld + docs.
+3. **PR16c (packaging):** build script + version + GHA + Mac docs.
+
+Or one PR if the diff stays reviewable.
+
+## Verify
+
+```bash
+# Packaging
+./scripts/build-release.sh
+ls dist/
+CGO_ENABLED=0 go test ./...
+
+# Lab (classic or secureblue L0)
+ansible-playbook -i infra/ansible/inventory/lab-vm.yml \
+  infra/ansible/playbooks/up.yml --ask-become-pass
+ansible-playbook -i infra/ansible/inventory/lab-vm.yml \
+  infra/ansible/playbooks/smoke.yml --ask-become-pass
+```
+
+## Done when
+
+All 6c acceptance criteria in design § Phase 6c are met; classic L0 path not regressed; Mac and secureblue paths documented and automated where feasible.

--- a/infra/ansible/roles/lab_vm/defaults/main.yml
+++ b/infra/ansible/roles/lab_vm/defaults/main.yml
@@ -5,12 +5,30 @@
 # Optionally remove the SSH keypair when destroying (default: keep it).
 shoal_remove_ssh_key: false
 
-# Manage the host firewall for the lab. When the L0 host runs ufw, its default
-# deny FORWARD/INPUT policies block the lab VM's DNS + package downloads over
-# the NAT network (only ICMP echo is whitelisted), so cloud-init fails its
-# apt/snap phase. When true (and ufw is active), open the management bridge for
-# input + routed traffic. Set false to manage the host firewall yourself.
+# Manage the host firewall for the lab. When the L0 host runs ufw or firewalld,
+# default deny policies can block the lab VM's DNS + package downloads over the
+# NAT network, so cloud-init fails its apt/snap phase. When true and a known
+# firewall is active, open the management bridge for input/NAT. Set false to
+# manage the host firewall yourself.
+shoal_lab_vm_manage_firewall: true
+# Backward-compatible alias (same meaning as shoal_lab_vm_manage_firewall).
 shoal_lab_vm_manage_ufw: true
+
+# Fallback firewalld zone when the "libvirt" zone is not defined.
+shoal_lab_vm_firewalld_zone_fallback: FedoraWorkstation
+
+# On secureblue/Atomic, try enabling modular libvirt sockets before failing.
+shoal_lab_vm_try_modular_libvirt: true
+shoal_lab_vm_modular_libvirt_units:
+  - virtqemud.socket
+  - virtnetworkd.socket
+  - virtstoraged.socket
+  - virtnodedevd.socket
+  - virtinterfaced.socket
+  - virtsecretd.socket
+  - virtnwfilterd.socket
+  - virtlogd.socket
+  - virtlockd.socket
 
 # Repo root, derived from the playbook dir (infra/ansible/playbooks) so paths
 # resolve regardless of the current working directory.
@@ -25,7 +43,7 @@ shoal_lab_vm_overlay: "/var/lib/libvirt/images/{{ shoal_lab_vm_name }}.qcow2"
 shoal_lab_vm_seed_iso: "/var/lib/libvirt/images/{{ shoal_lab_vm_name }}-seed.iso"
 
 # Operator-owned scratch dir for rendered cloud-init sources + libvirt XML.
-# Read only by the operator/genisoimage (never qemu), so it can live in-repo.
+# Read only by the operator/seed-ISO tool (never qemu), so it can live in-repo.
 shoal_lab_vm_work_dir: "{{ shoal_repo_root }}/infra/ansible/.work/{{ shoal_lab_vm_name }}"
 
 # libvirt URI for L0 host operations (root via qemu:///system can create bridges).

--- a/infra/ansible/roles/lab_vm/tasks/destroy.yml
+++ b/infra/ansible/roles/lab_vm/tasks/destroy.yml
@@ -61,33 +61,8 @@
   when: shoal_mgmt_network_name in (lab_vm_networks.list_nets | default([]))
   failed_when: false
 
-- name: Check host ufw status
-  ansible.builtin.command: ufw status
-  register: lab_vm_ufw_status
-  changed_when: false
-  failed_when: false
-
-- name: Remove ufw input rule for the management bridge
-  community.general.ufw:
-    rule: allow
-    direction: in
-    interface: "{{ shoal_mgmt_network_bridge }}"
-    delete: true
-  when:
-    - lab_vm_ufw_status.rc == 0
-    - "'Status: active' in lab_vm_ufw_status.stdout"
-  failed_when: false
-
-- name: Remove ufw routed rule for the management bridge
-  community.general.ufw:
-    rule: allow
-    route: true
-    interface_in: "{{ shoal_mgmt_network_bridge }}"
-    delete: true
-  when:
-    - lab_vm_ufw_status.rc == 0
-    - "'Status: active' in lab_vm_ufw_status.stdout"
-  failed_when: false
+- name: Tear down host firewall rules for management bridge
+  ansible.builtin.include_tasks: firewall_teardown.yml
 
 - name: Remove generated work directory
   ansible.builtin.file:

--- a/infra/ansible/roles/lab_vm/tasks/detect_profile.yml
+++ b/infra/ansible/roles/lab_vm/tasks/detect_profile.yml
@@ -1,0 +1,69 @@
+---
+# Classify the L0 hypervisor host for profile-specific steps.
+# Profiles: classic | secureblue | darwin
+
+- name: Fail when L0 is macOS (nested lab unsupported)
+  ansible.builtin.fail:
+    msg: |
+      Nested VM-hosted lab on macOS is not supported (no KVM L0 path).
+
+      macOS is an operator host only: use a prebuilt darwin binary (or go build)
+      against a lab running on a Linux L0 (classic Fedora/Ubuntu/Arch, or
+      Fedora secureblue). See docs/operator-macos.md and docs/lab-setup-checklist.md.
+
+      To drive Ansible from this Mac, the inventory's vm_l0 host must be a
+      Linux hypervisor (SSH), not localhost with ansible_connection=local on Darwin.
+  when: ansible_system | default('') == "Darwin"
+
+- name: Detect secureblue / Fedora Atomic L0 markers
+  ansible.builtin.shell: |
+    set -e
+    if [ -f /etc/os-release ]; then
+      # shellcheck disable=SC1091
+      . /etc/os-release
+      echo "ID=${ID:-}"
+      echo "VARIANT_ID=${VARIANT_ID:-}"
+      echo "NAME=${NAME:-}"
+    fi
+    if command -v rpm-ostree >/dev/null 2>&1; then
+      echo "RPM_OSTREE=1"
+      rpm-ostree status 2>/dev/null | head -n 5 || true
+    else
+      echo "RPM_OSTREE=0"
+    fi
+    if [ -e /usr/share/ublue-os ] || [ -e /usr/lib/os-release.d/secureblue ] \
+      || grep -qi secureblue /etc/os-release 2>/dev/null; then
+      echo "SECUREBLUE_MARKER=1"
+    else
+      echo "SECUREBLUE_MARKER=0"
+    fi
+  args:
+    executable: /bin/bash
+  register: lab_vm_profile_probe
+  changed_when: false
+  failed_when: false
+  become: false
+
+- name: Set shoal_l0_profile fact
+  ansible.builtin.set_fact:
+    shoal_l0_profile: >-
+      {{
+        'secureblue'
+        if (
+          'SECUREBLUE_MARKER=1' in lab_vm_profile_probe.stdout
+          or (
+            'RPM_OSTREE=1' in lab_vm_profile_probe.stdout
+            and (
+              'ID=fedora' in lab_vm_profile_probe.stdout
+              or 'fedora' in (lab_vm_profile_probe.stdout | lower)
+            )
+          )
+        )
+        else 'classic'
+      }}
+  become: false
+
+- name: Show detected L0 profile
+  ansible.builtin.debug:
+    msg: "L0 host profile: {{ shoal_l0_profile }}"
+  become: false

--- a/infra/ansible/roles/lab_vm/tasks/ensure_libvirt.yml
+++ b/infra/ansible/roles/lab_vm/tasks/ensure_libvirt.yml
@@ -1,0 +1,82 @@
+---
+# Ensure system libvirt is usable for qemu:///system on L0.
+# Classic hosts usually already run libvirtd; secureblue uses modular daemons
+# (enable via sockets or document ujust set-libvirt-daemons).
+
+- name: Probe virsh against system URI
+  ansible.builtin.command:
+    argv:
+      - virsh
+      - -c
+      - "{{ shoal_libvirt_uri }}"
+      - version
+  register: lab_vm_virsh_probe
+  changed_when: false
+  failed_when: false
+  become: true
+
+- name: Enable modular libvirt sockets when present (Atomic / modern Fedora)
+  when:
+    - lab_vm_virsh_probe.rc != 0
+    - shoal_l0_profile == "secureblue" or shoal_lab_vm_try_modular_libvirt | bool
+  block:
+    - name: Check which modular libvirt sockets exist
+      ansible.builtin.stat:
+        path: "/usr/lib/systemd/system/{{ item }}"
+      loop: "{{ shoal_lab_vm_modular_libvirt_units }}"
+      register: lab_vm_modular_units
+
+    - name: Enable and start modular libvirt sockets
+      ansible.builtin.systemd:
+        name: "{{ item.item }}"
+        state: started
+        enabled: true
+      loop: "{{ lab_vm_modular_units.results }}"
+      when: item.stat.exists | default(false)
+      failed_when: false
+
+- name: Enable monolithic libvirtd when present and virsh still down
+  when: lab_vm_virsh_probe.rc != 0
+  block:
+    - name: Stat libvirtd.service
+      ansible.builtin.stat:
+        path: /usr/lib/systemd/system/libvirtd.service
+      register: lab_vm_libvirtd_unit
+
+    - name: Start libvirtd
+      ansible.builtin.systemd:
+        name: libvirtd
+        state: started
+        enabled: true
+      when: lab_vm_libvirtd_unit.stat.exists | default(false)
+      failed_when: false
+
+- name: Re-probe virsh after enablement attempts
+  ansible.builtin.command:
+    argv:
+      - virsh
+      - -c
+      - "{{ shoal_libvirt_uri }}"
+      - version
+  register: lab_vm_virsh_probe2
+  changed_when: false
+  failed_when: false
+  become: true
+
+- name: Fail if system libvirt is still not usable
+  ansible.builtin.fail:
+    msg: |
+      Cannot talk to libvirt at {{ shoal_libvirt_uri }}.
+
+      {% if shoal_l0_profile == 'secureblue' %}
+      On Fedora secureblue, enable system libvirt daemons then re-run:
+        ujust set-libvirt-daemons
+      Use the QEMU/KVM *system* session (not user session) so the lab can
+      create the management bridge network. See:
+        https://secureblue.dev/faq#libvirt
+        docs/lab-setup-checklist.md (L0 secureblue)
+      {% else %}
+      Ensure libvirt and QEMU/KVM are installed and the system daemon is running:
+        virsh -c {{ shoal_libvirt_uri }} list --all
+      {% endif %}
+  when: (lab_vm_virsh_probe2.rc | default(lab_vm_virsh_probe.rc)) != 0

--- a/infra/ansible/roles/lab_vm/tasks/firewall.yml
+++ b/infra/ansible/roles/lab_vm/tasks/firewall.yml
@@ -1,0 +1,129 @@
+---
+# Open the management bridge so the L1 VM can use host dnsmasq (DNS/DHCP) and
+# NAT egress. Supports ufw (classic Ubuntu/Debian L0) and firewalld (Fedora /
+# secureblue). No-op when neither firewall is active.
+
+- name: Resolve whether host firewall management is enabled
+  ansible.builtin.set_fact:
+    shoal_lab_vm_manage_firewall_effective: >-
+      {{
+        (shoal_lab_vm_manage_firewall | default(shoal_lab_vm_manage_ufw) | bool)
+      }}
+  become: false
+
+- name: Check host ufw status
+  ansible.builtin.command: ufw status
+  register: lab_vm_ufw_status
+  changed_when: false
+  failed_when: false
+  when: shoal_lab_vm_manage_firewall_effective | bool
+
+- name: Open management bridge in ufw (input to host dnsmasq for DNS/DHCP)
+  community.general.ufw:
+    rule: allow
+    direction: in
+    interface: "{{ shoal_mgmt_network_bridge }}"
+  when:
+    - shoal_lab_vm_manage_firewall_effective | bool
+    - lab_vm_ufw_status is defined
+    - lab_vm_ufw_status.rc | default(1) == 0
+    - "'Status: active' in (lab_vm_ufw_status.stdout | default(''))"
+
+- name: Allow routed egress from the management bridge in ufw (VM -> internet via NAT)
+  community.general.ufw:
+    rule: allow
+    route: true
+    interface_in: "{{ shoal_mgmt_network_bridge }}"
+  when:
+    - shoal_lab_vm_manage_firewall_effective | bool
+    - lab_vm_ufw_status is defined
+    - lab_vm_ufw_status.rc | default(1) == 0
+    - "'Status: active' in (lab_vm_ufw_status.stdout | default(''))"
+
+- name: Check whether firewalld is running
+  ansible.builtin.command: firewall-cmd --state
+  register: lab_vm_firewalld_state
+  changed_when: false
+  failed_when: false
+  when: shoal_lab_vm_manage_firewall_effective | bool
+
+- name: Open management bridge in firewalld (libvirt NAT / dnsmasq)
+  when:
+    - shoal_lab_vm_manage_firewall_effective | bool
+    - lab_vm_firewalld_state is defined
+    - lab_vm_firewalld_state.rc | default(1) == 0
+    - "'running' in (lab_vm_firewalld_state.stdout | default('') | lower)"
+  block:
+    # Prefer the libvirt zone when present; otherwise attach the bridge to the
+    # default zone and allow DNS/DHCP/forward. Idempotent firewall-cmd.
+    - name: List firewalld zones
+      ansible.builtin.command: firewall-cmd --get-zones
+      register: lab_vm_fw_zones
+      changed_when: false
+
+    - name: Get firewalld default zone
+      ansible.builtin.command: firewall-cmd --get-default-zone
+      register: lab_vm_fw_default_zone
+      changed_when: false
+      failed_when: false
+
+    - name: Set fact for firewalld zone used for lab bridge
+      ansible.builtin.set_fact:
+        shoal_lab_vm_firewalld_zone: >-
+          {{
+            'libvirt'
+            if 'libvirt' in lab_vm_fw_zones.stdout.split()
+            else (
+              lab_vm_fw_default_zone.stdout | default(shoal_lab_vm_firewalld_zone_fallback, true) | trim
+            )
+          }}
+
+    - name: Ensure management bridge is in the chosen firewalld zone
+      ansible.builtin.command:
+        argv:
+          - firewall-cmd
+          - --permanent
+          - --zone={{ shoal_lab_vm_firewalld_zone }}
+          - --change-interface={{ shoal_mgmt_network_bridge }}
+      register: lab_vm_fw_if
+      changed_when: lab_vm_fw_if.rc == 0
+      failed_when: false
+
+    - name: Allow DNS in zone (dnsmasq for lab VMs)
+      ansible.builtin.command:
+        argv:
+          - firewall-cmd
+          - --permanent
+          - --zone={{ shoal_lab_vm_firewalld_zone }}
+          - --add-service=dns
+      register: lab_vm_fw_dns
+      changed_when: "'success' in (lab_vm_fw_dns.stdout | default(''))"
+      failed_when: false
+
+    - name: Allow DHCP in zone
+      ansible.builtin.command:
+        argv:
+          - firewall-cmd
+          - --permanent
+          - --zone={{ shoal_lab_vm_firewalld_zone }}
+          - --add-service=dhcp
+      register: lab_vm_fw_dhcp
+      changed_when: "'success' in (lab_vm_fw_dhcp.stdout | default(''))"
+      failed_when: false
+
+    - name: Enable masquerade in zone (NAT egress for lab VMs)
+      ansible.builtin.command:
+        argv:
+          - firewall-cmd
+          - --permanent
+          - --zone={{ shoal_lab_vm_firewalld_zone }}
+          - --add-masquerade
+      register: lab_vm_fw_masq
+      changed_when: "'success' in (lab_vm_fw_masq.stdout | default(''))"
+      failed_when: false
+
+    - name: Reload firewalld
+      ansible.builtin.command:
+        argv: [firewall-cmd, --reload]
+      changed_when: true
+      failed_when: false

--- a/infra/ansible/roles/lab_vm/tasks/firewall_teardown.yml
+++ b/infra/ansible/roles/lab_vm/tasks/firewall_teardown.yml
@@ -1,0 +1,57 @@
+---
+# Best-effort removal of L0 firewall rules created for the management bridge.
+
+- name: Check host ufw status (teardown)
+  ansible.builtin.command: ufw status
+  register: lab_vm_ufw_status
+  changed_when: false
+  failed_when: false
+
+- name: Remove ufw input rule for the management bridge
+  community.general.ufw:
+    rule: allow
+    direction: in
+    interface: "{{ shoal_mgmt_network_bridge }}"
+    delete: true
+  when:
+    - lab_vm_ufw_status.rc == 0
+    - "'Status: active' in lab_vm_ufw_status.stdout"
+  failed_when: false
+
+- name: Remove ufw routed rule for the management bridge
+  community.general.ufw:
+    rule: allow
+    route: true
+    interface_in: "{{ shoal_mgmt_network_bridge }}"
+    delete: true
+  when:
+    - lab_vm_ufw_status.rc == 0
+    - "'Status: active' in lab_vm_ufw_status.stdout"
+  failed_when: false
+
+- name: Check firewalld state (teardown)
+  ansible.builtin.command: firewall-cmd --state
+  register: lab_vm_firewalld_state
+  changed_when: false
+  failed_when: false
+
+- name: Remove management bridge from firewalld zone (best effort)
+  when:
+    - lab_vm_firewalld_state.rc | default(1) == 0
+    - "'running' in (lab_vm_firewalld_state.stdout | default('') | lower)"
+  block:
+    - name: Drop interface from libvirt zone if present
+      ansible.builtin.command:
+        argv:
+          - firewall-cmd
+          - --permanent
+          - --zone=libvirt
+          - --remove-interface={{ shoal_mgmt_network_bridge }}
+      failed_when: false
+      changed_when: false
+
+    - name: Reload firewalld after teardown
+      ansible.builtin.command:
+        argv: [firewall-cmd, --reload]
+      failed_when: false
+      changed_when: false

--- a/infra/ansible/roles/lab_vm/tasks/main.yml
+++ b/infra/ansible/roles/lab_vm/tasks/main.yml
@@ -6,7 +6,10 @@
 # artifacts (SSH key, downloads, rendered cloud-init, seed ISO) run become:false
 # so they stay owned by the operator.
 
-# ----- Prerequisites -----
+# ----- Profile + prerequisites -----
+- name: Detect L0 host profile
+  ansible.builtin.include_tasks: detect_profile.yml
+
 - name: Verify /dev/kvm present
   ansible.builtin.stat:
     path: /dev/kvm
@@ -15,7 +18,14 @@
 
 - name: Fail if /dev/kvm is missing on L0
   ansible.builtin.fail:
-    msg: "/dev/kvm not found on the L0 host. Ensure CPU virtualization is enabled in firmware and the kvm module is loaded."
+    msg: |
+      /dev/kvm not found on the L0 host.
+      Ensure CPU virtualization is enabled in firmware and the kvm module is loaded.
+      {% if shoal_l0_profile == 'secureblue' %}
+      On secureblue, also enroll the secureblue Secure Boot key if kernel modules
+      fail to load (ujust enroll-secureblue-secure-boot-key) and whitelist modules
+      if needed (ujust override-enable-module …).
+      {% endif %}
   when: not lab_vm_kvm.stat.exists
 
 # Nested virtualization must be enabled on L0 so the L1 lab VM (host-passthrough)
@@ -49,14 +59,68 @@
     success_msg: "Nested virtualization is enabled on L0 (nested={{ lab_vm_nested.stdout | trim }})."
   become: false
 
-- name: Verify required commands present
-  # 'command' is a shell builtin, not an executable, so it must run via the
-  # shell module -- ansible.builtin.command would try to exec a binary named
-  # 'command' and fail with "[Errno 2] No such file or directory: b'command'".
+- name: Verify required commands present (virsh, qemu-img, curl)
   ansible.builtin.shell: "command -v {{ item }}"
-  loop: [virsh, qemu-img, genisoimage, curl]
+  loop: [virsh, qemu-img, curl]
   changed_when: false
   become: false
+
+- name: Resolve seed-ISO tool (genisoimage | mkisofs | xorriso)
+  ansible.builtin.shell: |
+    for c in genisoimage mkisofs xorriso; do
+      if command -v "$c" >/dev/null 2>&1; then
+        echo "$c"
+        exit 0
+      fi
+    done
+    exit 1
+  register: lab_vm_seed_tool
+  changed_when: false
+  failed_when: false
+  become: false
+
+- name: Fail if no seed-ISO tool is available
+  ansible.builtin.fail:
+    msg: |
+      Need one of genisoimage, mkisofs, or xorriso to build the cloud-init seed ISO.
+      {% if shoal_l0_profile == 'secureblue' %}
+      On secureblue, install via Homebrew (brew install cdrtools or xorriso) or
+      layer an RPM (rpm-ostree install genisoimage / xorriso) and reboot.
+      {% else %}
+      Install genisoimage (Debian/Ubuntu), genisoimage/cdrkit, or xorriso.
+      {% endif %}
+  when: lab_vm_seed_tool.rc != 0
+
+- name: Record seed-ISO tool name
+  ansible.builtin.set_fact:
+    shoal_lab_vm_seed_iso_tool: "{{ lab_vm_seed_tool.stdout | trim }}"
+  become: false
+
+- name: Optional warning when SMT appears disabled (nested lab is CPU-heavy)
+  ansible.builtin.shell: |
+    if [ -r /sys/devices/system/cpu/smt/active ]; then
+      cat /sys/devices/system/cpu/smt/active
+    else
+      echo unknown
+    fi
+  register: lab_vm_smt
+  changed_when: false
+  failed_when: false
+  become: false
+
+- name: Warn if SMT is off
+  ansible.builtin.debug:
+    msg: |
+      SMT appears disabled on this L0 host (smt/active={{ lab_vm_smt.stdout | default('?') | trim }}).
+      Nested lab + Ollama inside L1 will be slower. On secureblue this is often
+      intentional (mitigations). Re-enable only if you accept the security tradeoff.
+  when:
+    - lab_vm_smt.stdout is defined
+    - (lab_vm_smt.stdout | trim) == "0"
+  become: false
+
+- name: Ensure system libvirt is usable
+  ansible.builtin.include_tasks: ensure_libvirt.yml
 
 # ----- SSH keypair (operator-owned) -----
 - name: Ensure SSH key directory exists
@@ -116,37 +180,9 @@
     name: "{{ shoal_mgmt_network_name }}"
     uri: "{{ shoal_libvirt_uri }}"
 
-# ----- Host firewall (ufw) -----
-# A libvirt NAT network only works if the host allows the VM's forwarded TCP/UDP
-# and its DNS/DHCP queries to the host's dnsmasq. ufw ships default-deny FORWARD
-# and INPUT policies and only whitelists ICMP echo, so an active ufw lets the VM
-# ping out but silently blocks DNS and package downloads -- cloud-init then fails
-# in its apt/snap phase. When ufw is active, open the management bridge.
-- name: Check host ufw status
-  ansible.builtin.command: ufw status
-  register: lab_vm_ufw_status
-  changed_when: false
-  failed_when: false
-
-- name: Open management bridge in ufw (input to host dnsmasq for DNS/DHCP)
-  community.general.ufw:
-    rule: allow
-    direction: in
-    interface: "{{ shoal_mgmt_network_bridge }}"
-  when:
-    - shoal_lab_vm_manage_ufw | bool
-    - lab_vm_ufw_status.rc == 0
-    - "'Status: active' in lab_vm_ufw_status.stdout"
-
-- name: Allow routed egress from the management bridge in ufw (VM -> internet via NAT)
-  community.general.ufw:
-    rule: allow
-    route: true
-    interface_in: "{{ shoal_mgmt_network_bridge }}"
-  when:
-    - shoal_lab_vm_manage_ufw | bool
-    - lab_vm_ufw_status.rc == 0
-    - "'Status: active' in lab_vm_ufw_status.stdout"
+# ----- Host firewall (ufw and/or firewalld) -----
+- name: Configure host firewall for management bridge
+  ansible.builtin.include_tasks: firewall.yml
 
 # ----- Base image + overlay disk -----
 - name: Download base cloud image (skip if already present)
@@ -200,10 +236,10 @@
     mode: "0644"
   become: false
 
-- name: Build cloud-init seed ISO
+- name: Build cloud-init seed ISO (genisoimage/mkisofs)
   ansible.builtin.command:
     argv:
-      - genisoimage
+      - "{{ shoal_lab_vm_seed_iso_tool }}"
       - -output
       - "{{ shoal_lab_vm_seed_iso }}"
       - -volid
@@ -215,6 +251,26 @@
       - "{{ shoal_lab_vm_work_dir }}/network-config"
   become: true
   changed_when: true
+  when: shoal_lab_vm_seed_iso_tool in ["genisoimage", "mkisofs"]
+
+- name: Build cloud-init seed ISO (xorriso)
+  ansible.builtin.command:
+    argv:
+      - xorriso
+      - -as
+      - mkisofs
+      - -output
+      - "{{ shoal_lab_vm_seed_iso }}"
+      - -volid
+      - cidata
+      - -joliet
+      - -rock
+      - "{{ shoal_lab_vm_work_dir }}/user-data"
+      - "{{ shoal_lab_vm_work_dir }}/meta-data"
+      - "{{ shoal_lab_vm_work_dir }}/network-config"
+  become: true
+  changed_when: true
+  when: shoal_lab_vm_seed_iso_tool == "xorriso"
 
 # ----- VM domain -----
 - name: Render VM domain XML

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -35,7 +35,7 @@ import (
 )
 
 // Version is the application version string (overridable via -ldflags).
-var Version = "0.6.0-phase6b"
+var Version = "0.6.0-phase6c"
 
 // Run dispatches subcommands. args should be os.Args[1:].
 func Run(args []string) int {

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Build CGO-free multi-platform shoal binaries and a license notice bundle.
+# Output: dist/shoal_<os>_<arch> and dist/checksums.txt
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+VERSION="${VERSION:-}"
+if [[ -z "$VERSION" ]]; then
+  if git describe --tags --always --dirty 2>/dev/null | grep -q .; then
+    VERSION="$(git describe --tags --always --dirty)"
+  else
+    VERSION="dev"
+  fi
+fi
+
+DIST="${DIST:-$ROOT/dist}"
+mkdir -p "$DIST"
+
+LDFLAGS="-s -w -X github.com/mattcburns/shoal/internal/cli.Version=${VERSION}"
+MODULE_MAIN="./cmd/shoal"
+
+# GOOS/GOARCH pairs for Phase 6c
+TARGETS=(
+  "linux/amd64"
+  "linux/arm64"
+  "darwin/amd64"
+  "darwin/arm64"
+)
+
+echo "Building shoal version=${VERSION} into ${DIST}"
+
+for target in "${TARGETS[@]}"; do
+  goos="${target%/*}"
+  goarch="${target#*/}"
+  out="${DIST}/shoal_${goos}_${goarch}"
+  echo "  -> ${out}"
+  CGO_ENABLED=0 GOOS="$goos" GOARCH="$goarch" go build -trimpath -ldflags "$LDFLAGS" -o "$out" "$MODULE_MAIN"
+done
+
+# License / attribution bundle for redistribution
+cp -f LICENSE NOTICE docs/third-party-licenses.md "$DIST/"
+# Also name-stable copies for archives
+cp -f docs/third-party-licenses.md "$DIST/THIRD_PARTY_LICENSES.md"
+
+(
+  cd "$DIST"
+  # Portable checksums (sha256sum on Linux; shasum on macOS)
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum shoal_* > checksums.txt
+  else
+    shasum -a 256 shoal_* > checksums.txt
+  fi
+)
+
+echo "Done. Artifacts:"
+ls -la "$DIST"


### PR DESCRIPTION
## Summary

Phase **6c** (design **v2.0.6**): ship multi-platform CGO-free binaries and treat macOS as an operator host; extend VM-hosted lab Ansible for **Fedora secureblue** L0 without breaking classic Linux.

### Packaging
- `scripts/build-release.sh` — linux/darwin × amd64/arm64, checksums, `LICENSE`/`NOTICE`/third-party texts
- GHA: `ci.yml` (gofmt/vet/staticcheck/test), `release.yml` on `v*` tags
- Version stamp via ldflags (`internal/cli.Version`, default `0.6.0-phase6c`)
- Docs: `docs/operator-macos.md`, README/AGENTS packaging notes

### L0 lab hosts (`lab_vm`)
- Profiles: **classic** | **secureblue** | fail **Darwin** (operator-only)
- Modular libvirt enablement + actionable secureblue guidance
- Firewall: existing **ufw** + new **firewalld** for management bridge NAT/DNS
- Seed ISO: `genisoimage` | `mkisofs` | `xorriso`
- Checklist/runbook updates for secureblue L0

### Explicit non-goals (6d+)
Compose `shoal` image, API auth, metrics, record/replay CI.

## Design / plan
- Design SoT Phase 6c + PR16
- Executable checklist: `docs/phase-6c-plan.md`

## Test plan
- [x] `./scripts/build-release.sh` produces four binaries + checksums
- [x] `go test ./...` (local)
- [x] `ansible-playbook --syntax-check` on `vm_provision.yml`
- [x] GHA CI green on this PR ([run](https://github.com/mattcburns/shoal/actions/runs/29623539238))
- [x] Classic L0 `smoke.yml` regression — **passed** (lab already up: NetBox, Redfish, Ollama text+vision, ISO HTTP, serial consoles for nodes 1–5)
- [~] Classic L0 full `up.yml` converge — **blocked** here (passwordless sudo unavailable for become); smoke covers running-lab health
- [x] Secureblue L0 smoke — **N/A on this host** (CachyOS classic). Profile detect on classic L0 → `shoal_l0_profile=classic`. Needs real secureblue hardware for end-to-end `up.yml`
- [x] Tag `v0.6.0-rc.1` exercised release workflow → [prerelease](https://github.com/mattcburns/shoal/releases/tag/v0.6.0-rc.1) with multi-platform archives + license bundle
