### PR TITLE
feat: Phase 6d Compose shoal, API auth, metrics, redfish fixtures

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This file is the canonical guide for how to work in this repository. It covers
 project conventions, commands, and style. For **architecture, data models, and
 the phased plan**, the source of truth is
 [`SHOAL_COMPREHENSIVE_DESIGN_AND_IMPLEMENTATION_PLAN.md`](./SHOAL_COMPREHENSIVE_DESIGN_AND_IMPLEMENTATION_PLAN.md)
-(**v2.0.6**, Go stack). When this file and the design doc disagree, fix one of
+(**v2.0.7**, Go stack). When this file and the design doc disagree, fix one of
 them in the same change — they must stay consistent.
 
 > **Read order for any task:** (1) this file, (2) the relevant Chapter 4 section
@@ -123,6 +123,8 @@ shoal/                                    # module: github.com/mattcburns/shoal
     third-party-licenses.md               # full texts of runtime Go dep licenses
     operator-macos.md                     # Mac = operator only (Phase 6c)
     phase-6c-plan.md                      # packaging + L0 host profiles checklist
+    phase-6d-plan.md                      # compose app + auth + metrics + fixtures
+  deploy/docker/Dockerfile                # minimal runtime image for lab Compose
   go.mod
   LICENSE                                 # AGPLv3 (Shoal)
   NOTICE                                  # third-party inventory + copyrights
@@ -274,6 +276,8 @@ go run ./cmd/shoal deploy run \
 | `SHOAL_RECONCILE_FAIL_ORPHANS` | Default `true` |
 | `SHOAL_FEWSHOT_DIR` | Append-only learned few-shot JSONL (confirm learning). Lab Ansible default: `/var/lib/shoal/fewshot` via `shoal_fewshot_dir` + `env.j2`. Empty disables confirm |
 | `SHOAL_PROFILE_DIR` | JSON provisioning profiles + approval records (Phase 5b). Lab Ansible default: `/var/lib/shoal/profiles` via `shoal_profile_dir` + `env.j2`. Empty disables non-spike profile load |
+| `SHOAL_API_TOKEN` | Phase 6d: if non-empty, require `Authorization: Bearer …` for `/v1/*`. Empty = open (lab default). Never log. |
+
 
 Full table and Ansible extension points: design doc §8.1.
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ release builds: `./scripts/build-release.sh` (see Phase 6c).
 - [Lab Setup Checklist (First-Time)](docs/lab-setup-checklist.md)
 - [Operator host: macOS](docs/operator-macos.md)
 - [Phase 6c plan (packaging + L0 hosts)](docs/phase-6c-plan.md)
+- [Phase 6d plan (Compose app + auth + metrics)](docs/phase-6d-plan.md)
 
 ## Prerequisites (L0 host)
 Install and verify:

--- a/SHOAL_COMPREHENSIVE_DESIGN_AND_IMPLEMENTATION_PLAN.md
+++ b/SHOAL_COMPREHENSIVE_DESIGN_AND_IMPLEMENTATION_PLAN.md
@@ -1,6 +1,6 @@
 # Shoal: Comprehensive Design Document & Phased Implementation Plan
 
-**Version:** 2.0.6  
+**Version:** 2.0.7  
 **Date:** July 2026  
 **Status:** Draft (post-review; open questions resolved)  
 **Author:** (architect / AI agent)  
@@ -28,11 +28,11 @@ This is a **language/stack revision** of the v1.1 product design — not a green
 
 ---
 
-## Changes in v2.0 / v2.0.1 / v2.0.2 / v2.0.3 / v2.0.4 / v2.0.5 / v2.0.6
+## Changes in v2.0 / v2.0.1 / v2.0.2 / v2.0.3 / v2.0.4 / v2.0.5 / v2.0.6 / v2.0.7
 
 Full stack rewrite of the **application** from Python to **Go (Golang)**, maximizing the Go standard library **except where Redfish complexity justifies gofish**.
 
-| Area | v1.1 (Python) | v2.0.6 (Go) |
+| Area | v1.1 (Python) | v2.0.7 (Go) |
 |------|---------------|-------------|
 | Language | Python 3.11+ | Go 1.22+ (prefer latest stable) |
 | Module path | n/a | **`github.com/mattcburns/shoal`** |
@@ -63,6 +63,8 @@ Full stack rewrite of the **application** from Python to **Go (Golang)**, maximi
 **v2.0.5 (photo vision model):** lab vision default is **`deepseek-ocr`** (Free OCR on asset labels; parse SERIAL/VENDOR/MODEL). Rejects placeholder serials. **`moondream` is not AC-grade** for inventory OCR. Text hybrid remains `llama3.2:3b` — do **not** use `deepseek-ocr` as the text model. Phase 6 graphics failure-screen OCR remains deferred (Tesseract vs cloud vision).
 
 **v2.0.6 (Phase 6c packaging + L0 hosts):** multi-platform **CGO-free** release binaries (linux/darwin amd64/arm64) via scripts + GHA; ship `LICENSE`/`NOTICE`/`docs/third-party-licenses.md` with artifacts; **macOS is an operator host** (binary + remote/Linux lab) — not an L0 nested hypervisor. **L0 VM-hosted lab** supports classic Linux and **Fedora secureblue** (detect profile, modular libvirt, firewalld; keep ufw path). Direct-host lab on secureblue and nested lab on macOS remain **out of scope**. Compose `shoal` service image, API auth, metrics, record/replay CI → **Phase 6d+**.
+
+**v2.0.7 (Phase 6d ops packaging):** optional **Compose `shoal` service** in the lab stack (binary image, env from Ansible); **Bearer API token** auth for `/v1/*` when `SHOAL_API_TOKEN` set (health/ready/metrics remain open); **stdlib Prometheus text `/metrics`** (job + HTTP counters, no new deps); **record/replay fixture tests** under `testdata/redfish/` wired into unit CI. Extra OEM screenshot adapters remain hardware-driven.
 
 **Preserved (product decisions, not language):**
 
@@ -1337,6 +1339,8 @@ Default VM-hosted endpoints: NetBox `:8000`, sushy `:8001`, ISO HTTP `:8080`, Ol
 | `SHOAL_RECONCILE_FAIL_ORPHANS` | no | Default `true` |
 | `SHOAL_FEWSHOT_DIR` | no | Append-only learned few-shot JSONL (Phase 3b confirm). Lab default via Ansible `shoal_fewshot_dir` → `/var/lib/shoal/fewshot` in `env.j2` + mkdir. Empty disables confirm |
 | `SHOAL_PROFILE_DIR` | no | JSON provisioning profiles + approval records (Phase 5b). Lab default via Ansible `shoal_profile_dir` → `/var/lib/shoal/profiles` in `env.j2` + mkdir. Empty disables non-spike profile load; `spike` profile ref always allowed without a store |
+| `SHOAL_API_TOKEN` | no | Phase 6d: Bearer token for `/v1/*` when set; empty = open API (lab default). Never log. Lab Ansible: `shoal_api_token` (vault optional) |
+| `shoal_compose_app` (Ansible) | — | Phase 6d: when true (lab default), stage binary + Dockerfile and run Compose service `shoal` (`network_mode: host`, port `shoal_app_http_port` / 8088) |
 
 **Ansible extensions (when packaging app service):**
 - `compose_stack` templates: add `shoal` service (static binary image), publish `SHOAL_HTTP_ADDR` port, inject table above into `env.j2`
@@ -1493,11 +1497,68 @@ Operator machines and release artifacts diverge by role. The **lab topology is u
 6. `lab_vm` on Darwin localhost: fails with operator-only guidance (no partial VM create).
 7. AGENTS.md documents packaging + L0 profiles; design §7.1 unchanged unless a new Go dep is added (prefer none).
 
-### Phase 6d+ (later)
+### Phase 6d (Compose shoal + auth + metrics + replay CI) — detailed plan
 
-Compose `shoal` service packaging; API auth + metrics; record/replay CI; more vendor screenshot adapters as hardware is tested.
+#### 6d.1 Compose `shoal` service
 
-Executable checklist: [`docs/phase-6c-plan.md`](./docs/phase-6c-plan.md).
+| Item | Decision |
+|------|----------|
+| Enable | `shoal_compose_app: true` (default **true** in lab) |
+| Image | Local build: minimal Dockerfile copies CGO-free `shoal` binary (Ansible builds on target or controller and stages binary + Dockerfile under compose dir) |
+| Ports | host `shoal_app_http_port` (default **8088**) → container `:8088` |
+| Env | Rendered into compose service from lab vars: telemetry DSN (in-network host `telemetry-db`), NetBox URL/token, Ollama, AI models, ISO paths, BMC lab defaults, `SHOAL_API_TOKEN`, fewshot/profile dirs as volumes |
+| Volumes | ISO publish dir, fewshot dir, profile dir (rw as needed) |
+| Health | `GET /healthz` |
+
+Not a second orchestration model — same binary as release builds; Compose is lab convenience.
+
+#### 6d.2 API auth
+
+| Item | Decision |
+|------|----------|
+| Env | `SHOAL_API_TOKEN` — empty = **open** (MVP lab default); non-empty = require `Authorization: Bearer <token>` |
+| Protected | all `/v1/*` routes |
+| Open | `/healthz`, `/readyz`, `/metrics` |
+| Compare | constant-time; never log the token |
+
+CLI continues to talk to services without HTTP API for most ops; when calling API, operators pass the token via curl/env docs.
+
+#### 6d.3 Metrics
+
+| Item | Decision |
+|------|----------|
+| Endpoint | `GET /metrics` Prometheus **text exposition** (hand-written; **no** prometheus client library) |
+| Series | `shoal_http_requests_total{method,code,path}`, `shoal_jobs_started_total`, `shoal_jobs_cancel_total` |
+| Deps | stdlib only (`sync/atomic`) |
+
+#### 6d.4 Record/replay CI
+
+| Item | Decision |
+|------|----------|
+| Corpus | `testdata/redfish/*.json` (sushy-shaped System + root samples) |
+| Tests | Unit tests map fixtures → `SystemInfo` / parse helpers without live BMC |
+| CI | Covered by existing `go test ./...` in GHA |
+
+#### 6d non-goals
+
+- Full mTLS / OAuth OIDC  
+- OpenTelemetry traces  
+- Pushing images to a public registry (local compose build only)  
+- New OEM screenshot vendors without hardware  
+
+#### 6d acceptance criteria
+
+1. With `shoal_compose_app`, `up.yml` deploys `shoal` container; `GET :8088/healthz` succeeds (smoke optional when enabled).  
+2. With `SHOAL_API_TOKEN` set, `/v1/*` returns 401 without Bearer; healthz stays 200.  
+3. `/metrics` exposes job + HTTP counters.  
+4. Fixture tests under `testdata/redfish` pass in CI.  
+5. No new Go module deps (allow-list unchanged).  
+
+Executable checklist: [`docs/phase-6d-plan.md`](./docs/phase-6d-plan.md). Phase 6c checklist remains [`docs/phase-6c-plan.md`](./docs/phase-6c-plan.md).
+
+### Phase 6e+ (later)
+
+Additional vendor screenshot adapters as hardware is tested; optional image registry publish; richer tracing.
 
 ---
 
@@ -1664,6 +1725,7 @@ go test ./...
 | PR14 | `chore: Compose shoal service + Ansible env contract` | `compose_stack`, group_vars | PR1+ | Binary image; `env.j2` NetBox token + DSN + HTTP port |
 | PR15 | `feat: Phase 6 polish` | OCR (choose approach), metrics, API auth, TLS CA | MVP | Evaluate OCR options then implement; other hardening |
 | PR16 | `feat: Phase 6c packaging + L0 host profiles` | `scripts/build-release.sh`, GHA, `lab_vm`, docs | Phase 6a–b on master | Multi-platform CGO-free binaries + NOTICE; macOS operator docs; secureblue L0 + firewalld; keep classic L0 |
+| PR17 | `feat: Phase 6d compose shoal + auth + metrics + replay` | compose_stack, `api`, config, fixtures | 6c on master | Lab Compose app service; Bearer token; `/metrics`; redfish fixture CI |
 
 **High-level order:** Docs → skeleton → models/secrets → **Postgres jobs** → Redfish + SOL + **live image** → Deploy orchestrator → **Phase 2 spike** → **AI** → Discover hybrid → Observe broaden → Deploy harden → Compose package → Phase 6.
 
@@ -1671,7 +1733,7 @@ go test ./...
 
 ## Open Questions
 
-**All previously open product decisions are resolved through v2.0.6.** Phase 0–5 and 6a–6b are on `master`; Phase **6c** (packaging + L0 hosts) is next; **6d+** remains later polish.
+**All previously open product decisions are resolved through v2.0.7.** Phase 0–6c on `master`; Phase **6d** is next ops packaging.
 
 | Topic | Resolution |
 |-------|------------|
@@ -1693,11 +1755,13 @@ go test ./...
 | **Complete vs CompleteVision** | Text Discover → `Complete` + text model; photo → `CompleteVision` (`Free OCR.`) + parse SERIAL/VENDOR/MODEL; missing serial → **fail** (no synthetic IDs) |
 | **Phase 6c packaging** | Multi-platform CGO-free binaries + GHA release; license bundle; macOS = **operator only** |
 | **Phase 6c L0 hosts** | Classic Linux + **secureblue/Atomic** for VM-hosted lab; Darwin L0 nested lab **unsupported** |
-| **Compose shoal / API auth / metrics / replay CI** | **Phase 6d+** (after 6c) |
+| **Compose shoal / API auth / metrics / replay CI** | **Phase 6d** (v2.0.7) |
+| **Phase 6d API auth** | Optional Bearer `SHOAL_API_TOKEN`; open if empty; protects `/v1/*` only |
+| **Phase 6d metrics** | Stdlib Prometheus text `/metrics`; no new deps |
 
-**Deferred until Phase 6d+ (not blocking 6c):**
+**Deferred until Phase 6e+:**
 
-- Compose `shoal` service image; API auth; metrics/tracing; record/replay CI; additional vendor screenshot adapters.
+- Additional vendor screenshot adapters; registry image publish; distributed tracing.
 
 ---
 
@@ -1713,9 +1777,9 @@ go test ./...
 
 ---
 
-**This document (v2.0.6) is the SoT for agents.** Phase 0–5 and 6a–6b are on `master`.
+**This document (v2.0.7) is the SoT for agents.** Phase 0–6c are on `master`.
 
 Next actions:
-1. Phase **6c**: multi-platform packaging + macOS operator docs + L0 secureblue/classic lab_vm profiles ([`docs/phase-6c-plan.md`](./docs/phase-6c-plan.md))
-2. Phase **6d+**: Compose shoal service, API auth, metrics, record/replay CI; more vendor screenshot adapters
+1. Phase **6d**: Compose shoal + API auth + metrics + redfish fixture CI ([`docs/phase-6d-plan.md`](./docs/phase-6d-plan.md))
+2. Phase **6e+**: more vendor screenshot adapters; optional registry publish
 3. Stretch: full distro autoinstall; NetBox device-id binding

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -1,0 +1,9 @@
+# Minimal runtime image: copy a pre-built CGO-free shoal binary.
+# Build context is staged by Ansible (binary + this Dockerfile).
+FROM alpine:3.20
+RUN apk add --no-cache ca-certificates
+COPY shoal /usr/local/bin/shoal
+RUN chmod +x /usr/local/bin/shoal
+EXPOSE 8088
+ENTRYPOINT ["/usr/local/bin/shoal"]
+CMD ["serve", "-addr", ":8088"]

--- a/docs/phase-6d-plan.md
+++ b/docs/phase-6d-plan.md
@@ -1,0 +1,44 @@
+# Phase 6d — Compose shoal + auth + metrics + replay CI
+
+Executable checklist for design **v2.0.7** § Phase 6d.
+
+## Goals
+
+1. Optional lab **Compose service** running the Shoal binary on `:8088`.
+2. Optional **Bearer API token** for `/v1/*`.
+3. **`/metrics`** Prometheus text (stdlib only).
+4. **Redfish fixture tests** in unit CI (`testdata/redfish/`).
+
+## Non-goals
+
+- OIDC/mTLS, OpenTelemetry, public image registry, new OEM screenshot vendors without hardware.
+
+## Workstreams
+
+### A — Design hygiene
+- [x] Design v2.0.7 Phase 6d + this plan
+
+### B — API auth + metrics
+- [x] `SHOAL_API_TOKEN` + Bearer middleware
+- [x] `/metrics` counters
+- [x] Config + unit tests
+- [x] AGENTS env table
+
+### C — Compose shoal
+- [x] Dockerfile (binary copy)
+- [x] compose service + Ansible stage binary/build (controller build → lab host)
+- [x] env wiring (host network → published lab ports)
+- [x] smoke check when enabled
+
+### D — Record/replay fixtures
+- [x] Fixture corpus + parse tests
+- [x] Covered by `go test ./...` / GHA CI
+
+## Verify
+
+```bash
+go test ./...
+# with lab + shoal_compose_app:
+curl -sf "http://${SHOAL_LAB:-192.168.122.100}:8088/healthz"
+curl -sf "http://${SHOAL_LAB:-192.168.122.100}:8088/metrics"
+```

--- a/infra/ansible/inventory/group_vars/all/defaults.yml
+++ b/infra/ansible/inventory/group_vars/all/defaults.yml
@@ -43,6 +43,12 @@ shoal_iso_server_port: 8080
 shoal_ollama_port: 11434
 shoal_telemetry_db_port: 5433
 shoal_redis_port: 6379
+shoal_app_http_port: 8088
+
+# Phase 6d: run Shoal app as a Compose service (binary image staged by Ansible).
+shoal_compose_app: true
+# Optional Bearer token for /v1/* (empty = open lab API). Prefer vault.
+shoal_api_token: ""
 
 # --- AI provider (see design doc §6 / v2.0.4 dual-model contract) ---
 # Provider is "ollama" (local, served by the shoal-ollama container) or "cloud".

--- a/infra/ansible/inventory/group_vars/all/vault.yml.example
+++ b/infra/ansible/inventory/group_vars/all/vault.yml.example
@@ -24,3 +24,6 @@ shoal_telemetry_db_password: shoal_password
 # Cloud AI provider (only used when shoal_ai_provider == "cloud"; leave empty for
 # local Ollama). This is a secret — never commit a real key.
 shoal_cloud_ai_api_key: ""
+
+# Phase 6d: HTTP API Bearer token for Shoal /v1/* (empty disables auth).
+# shoal_api_token: ""

--- a/infra/ansible/playbooks/smoke.yml
+++ b/infra/ansible/playbooks/smoke.yml
@@ -111,6 +111,28 @@
       failed_when: false
       changed_when: false
 
+    - name: Check Shoal app healthz (Phase 6d Compose, when enabled)
+      ansible.builtin.uri:
+        url: "http://{{ shoal_service_host }}:{{ shoal_app_http_port | default(8088) }}/healthz"
+        method: GET
+        status_code: [200]
+        timeout: 10
+      register: smoke_shoal
+      failed_when: false
+      changed_when: false
+      when: shoal_compose_app | default(true) | bool
+
+    - name: Check Shoal app metrics (Phase 6d)
+      ansible.builtin.uri:
+        url: "http://{{ shoal_service_host }}:{{ shoal_app_http_port | default(8088) }}/metrics"
+        method: GET
+        status_code: [200]
+        timeout: 10
+      register: smoke_shoal_metrics
+      failed_when: false
+      changed_when: false
+      when: shoal_compose_app | default(true) | bool
+
     - name: Check each node serial console
       ansible.builtin.command: "virsh ttyconsole {{ node.name }}"
       loop: "{{ shoal_bmc_nodes }}"
@@ -145,14 +167,20 @@
           - smoke_redfish_systems.status == 200
           - smoke_ollama.status == 200
           - smoke_iso.status in [200, 403, 404]
+          - >-
+            (not (shoal_compose_app | default(true) | bool))
+            or (smoke_shoal.status | default(0) == 200
+                and smoke_shoal_metrics.status | default(0) == 200)
         fail_msg: >-
           Smoke checks failed --
           NetBox={{ smoke_netbox.status | default('err') }},
           Redfish root={{ smoke_redfish_root.status | default('err') }},
           Redfish Systems={{ smoke_redfish_systems.status | default('err') }},
           Ollama={{ smoke_ollama.status | default('err') }},
-          ISO HTTP={{ smoke_iso.status | default('err') }}.
+          ISO HTTP={{ smoke_iso.status | default('err') }},
+          Shoal healthz={{ smoke_shoal.status | default('skipped') }},
+          Shoal metrics={{ smoke_shoal_metrics.status | default('skipped') }}.
           (200/403/404 are acceptable for the ISO server.)
         success_msg: >-
           All HTTP smoke checks passed: NetBox, Redfish root, Redfish Systems,
-          Ollama, and the ISO HTTP server.
+          Ollama, ISO HTTP{% if shoal_compose_app | default(true) | bool %}, and Shoal app{% endif %}.

--- a/infra/ansible/roles/compose_stack/tasks/main.yml
+++ b/infra/ansible/roles/compose_stack/tasks/main.yml
@@ -2,6 +2,63 @@
 # Deploy and configure Docker Compose stack
 # This role deploys NetBox, PostgreSQL, Redis, Ollama, and HTTP server
 
+# Phase 6d: build CGO-free binary on the controller, stage on the lab host.
+- name: Ensure local staging dir for shoal binary (controller)
+  ansible.builtin.file:
+    path: "{{ playbook_dir }}/../../../.shoal/lab-build"
+    state: directory
+    mode: '0755'
+  delegate_to: localhost
+  become: false
+  when: shoal_compose_app | default(true) | bool
+  tags: [config, shoal]
+
+- name: Build shoal binary on controller (linux/amd64, CGO-free)
+  ansible.builtin.command:
+    argv:
+      - go
+      - build
+      - -trimpath
+      - -ldflags
+      - -s -w
+      - -o
+      - "{{ playbook_dir }}/../../../.shoal/lab-build/shoal"
+      - ./cmd/shoal
+  environment:
+    CGO_ENABLED: "0"
+    GOOS: linux
+    GOARCH: "{{ shoal_compose_app_goarch | default('amd64') }}"
+  args:
+    chdir: "{{ playbook_dir }}/../../.."
+  delegate_to: localhost
+  become: false
+  when: shoal_compose_app | default(true) | bool
+  tags: [config, shoal]
+
+- name: Ensure shoal image build context on lab host
+  file:
+    path: "{{ shoal_compose_dir }}/shoal-build"
+    state: directory
+    mode: '0755'
+  when: shoal_compose_app | default(true) | bool
+  tags: [config, shoal]
+
+- name: Copy shoal binary to lab host build context
+  ansible.builtin.copy:
+    src: "{{ playbook_dir }}/../../../.shoal/lab-build/shoal"
+    dest: "{{ shoal_compose_dir }}/shoal-build/shoal"
+    mode: '0755'
+  when: shoal_compose_app | default(true) | bool
+  tags: [config, shoal]
+
+- name: Install Dockerfile for shoal lab image
+  ansible.builtin.copy:
+    src: "{{ playbook_dir }}/../../../deploy/docker/Dockerfile"
+    dest: "{{ shoal_compose_dir }}/shoal-build/Dockerfile"
+    mode: '0644'
+  when: shoal_compose_app | default(true) | bool
+  tags: [config, shoal]
+
 - name: Copy Docker Compose file
   template:
     src: docker-compose.lab.yml.j2
@@ -114,13 +171,14 @@
 - name: Start Docker Compose stack
   shell: |
     cd {{ shoal_compose_dir }}
-    docker compose -f docker-compose.lab.yml up -d
+    docker compose -f docker-compose.lab.yml up -d --build
   register: compose_up
   changed_when: >
     'Creating' in ((compose_up.stdout | default('')) ~ (compose_up.stderr | default('')))
     or 'Starting' in ((compose_up.stdout | default('')) ~ (compose_up.stderr | default('')))
     or 'Recreating' in ((compose_up.stdout | default('')) ~ (compose_up.stderr | default('')))
     or 'Pulling' in ((compose_up.stdout | default('')) ~ (compose_up.stderr | default('')))
+    or 'Building' in ((compose_up.stdout | default('')) ~ (compose_up.stderr | default('')))
   tags: [start]
 
 - name: Wait for PostgreSQL to be healthy
@@ -223,4 +281,6 @@
         models: {{ shoal_ollama_models_to_pull | join(', ') }}
       - HTTP Server: http://{{ ansible_host }}:{{ shoal_iso_server_port }}
       - Telemetry DB: localhost:5433 (shoal_telemetry)
+      {% if shoal_compose_app | default(true) | bool %}- Shoal app: http://{{ shoal_service_host | default(ansible_host) }}:{{ shoal_app_http_port }}/healthz
+      {% endif %}
   tags: [status]

--- a/infra/ansible/roles/compose_stack/templates/docker-compose.lab.yml.j2
+++ b/infra/ansible/roles/compose_stack/templates/docker-compose.lab.yml.j2
@@ -120,6 +120,64 @@ services:
     networks:
       - shoal-lab
 
+{% if shoal_compose_app | default(true) | bool %}
+  # Phase 6d: Shoal application. host network so lab BMC/sushy IPs and published
+  # compose ports (NetBox/Ollama/telemetry) are reachable without extra routes.
+  shoal:
+    build:
+      context: {{ shoal_compose_dir }}/shoal-build
+    image: shoal:lab
+    container_name: shoal-app
+    network_mode: host
+    environment:
+      - SHOAL_HTTP_ADDR=:{{ shoal_app_http_port }}
+      - SHOAL_LOG_LEVEL={{ shoal_log_level | default('info') }}
+      - SHOAL_TELEMETRY_DATABASE_URL=postgresql://{{ shoal_telemetry_db_user }}:{{ shoal_telemetry_db_password }}@127.0.0.1:{{ shoal_telemetry_db_port }}/{{ shoal_telemetry_db_name }}
+      - SHOAL_NETBOX_URL=http://127.0.0.1:{{ shoal_netbox_port }}
+      - SHOAL_NETBOX_TOKEN={{ shoal_netbox_api_token }}
+      - SHOAL_AI_PROVIDER={{ shoal_ai_provider }}
+      - SHOAL_AI_MODEL={{ shoal_ai_model }}
+      - SHOAL_AI_VISION_MODEL={{ shoal_ai_vision_model | default('') }}
+      - SHOAL_OLLAMA_URL=http://127.0.0.1:{{ shoal_ollama_port }}
+      - SHOAL_CLOUD_AI_BASE_URL={{ shoal_cloud_ai_base_url | default('') }}
+      - SHOAL_CLOUD_AI_API_KEY={{ shoal_cloud_ai_api_key | default('') }}
+      - SHOAL_REDFISH_AUTH_MODE={{ shoal_redfish_auth_mode | default('basic') }}
+      - SHOAL_REDFISH_TLS_MODE={{ shoal_redfish_tls_mode | default('off') }}
+      - SHOAL_BMC_USERNAME={{ shoal_bmc_username }}
+      - SHOAL_BMC_PASSWORD={{ shoal_bmc_password }}
+      - SHOAL_ISO_PUBLISH_DIR=/srv/iso
+      - SHOAL_ISO_BASE_URL=http://{{ shoal_lab_network_gateway }}:{{ shoal_iso_server_port }}
+      - SHOAL_API_TOKEN={{ shoal_api_token | default('') }}
+{% if (shoal_fewshot_dir | default('') | length) > 0 %}
+      - SHOAL_FEWSHOT_DIR=/var/lib/shoal/fewshot
+{% endif %}
+{% if (shoal_profile_dir | default('') | length) > 0 %}
+      - SHOAL_PROFILE_DIR=/var/lib/shoal/profiles
+{% endif %}
+    volumes:
+      - {{ shoal_iso_server_dir }}:/srv/iso
+{% if (shoal_fewshot_dir | default('') | length) > 0 %}
+      - {{ shoal_fewshot_dir }}:/var/lib/shoal/fewshot
+{% endif %}
+{% if (shoal_profile_dir | default('') | length) > 0 %}
+      - {{ shoal_profile_dir }}:/var/lib/shoal/profiles
+{% endif %}
+    depends_on:
+      telemetry-db:
+        condition: service_healthy
+      netbox:
+        condition: service_healthy
+      ollama:
+        condition: service_started
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://127.0.0.1:{{ shoal_app_http_port }}/healthz"]
+      interval: 15s
+      timeout: 3s
+      retries: 10
+      start_period: 20s
+    restart: unless-stopped
+{% endif %}
+
 volumes:
   netbox-media:
   netbox-reports:

--- a/infra/ansible/roles/compose_stack/templates/env.j2
+++ b/infra/ansible/roles/compose_stack/templates/env.j2
@@ -26,3 +26,11 @@ SHOAL_PROFILE_DIR={{ shoal_profile_dir }}
 {% endif %}
 SHOAL_BMC_USERNAME={{ shoal_bmc_username }}
 SHOAL_BMC_PASSWORD={{ shoal_bmc_password }}
+# Phase 6d app (operator / host process; Compose service uses in-network URLs).
+SHOAL_HTTP_ADDR=:{{ shoal_app_http_port | default(8088) }}
+SHOAL_TELEMETRY_DATABASE_URL={{ shoal_telemetry_db_url | default('') }}
+SHOAL_NETBOX_URL={{ shoal_netbox_url | default('') }}
+SHOAL_NETBOX_TOKEN={{ shoal_netbox_api_token | default('') }}
+{% if (shoal_api_token | default('') | length) > 0 %}
+SHOAL_API_TOKEN={{ shoal_api_token }}
+{% endif %}

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -1,0 +1,47 @@
+package api
+
+import (
+	"crypto/subtle"
+	"net/http"
+	"strings"
+)
+
+// withAPIAuth requires Authorization: Bearer <token> for /v1/* when APIToken is set.
+// /healthz, /readyz, and /metrics stay open for probes and scrapers.
+func (s *Server) withAPIAuth(next http.Handler) http.Handler {
+	token := strings.TrimSpace(s.cfg.APIToken)
+	if token == "" {
+		return next
+	}
+	want := []byte(token)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !requiresAPIAuth(r.URL.Path) {
+			next.ServeHTTP(w, r)
+			return
+		}
+		got := bearerToken(r.Header.Get("Authorization"))
+		if subtle.ConstantTimeCompare([]byte(got), want) != 1 {
+			writeJSON(w, http.StatusUnauthorized, map[string]any{
+				"error": "unauthorized",
+			})
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+func requiresAPIAuth(path string) bool {
+	return strings.HasPrefix(path, "/v1/")
+}
+
+func bearerToken(h string) string {
+	const p = "Bearer "
+	if len(h) < len(p) || !strings.EqualFold(h[:len(p)], p) {
+		// Also accept exact "bearer " mixed case via TrimPrefix after lower — use prefix check.
+		if len(h) >= 7 && strings.EqualFold(h[:7], "bearer ") {
+			return strings.TrimSpace(h[7:])
+		}
+		return ""
+	}
+	return strings.TrimSpace(h[len(p):])
+}

--- a/internal/api/auth_test.go
+++ b/internal/api/auth_test.go
@@ -1,0 +1,68 @@
+package api_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/mattcburns/shoal/internal/api"
+	"github.com/mattcburns/shoal/internal/common/config"
+)
+
+func TestAPIAuthOpenWhenTokenEmpty(t *testing.T) {
+	s := api.New(config.Config{}, nil)
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/jobs/x", nil)
+	s.Handler().ServeHTTP(rr, req)
+	// No store → 503, but not 401
+	if rr.Code == http.StatusUnauthorized {
+		t.Fatalf("unexpected 401 when token empty")
+	}
+}
+
+func TestAPIAuthProtectsV1(t *testing.T) {
+	s := api.New(config.Config{APIToken: "secret-token"}, nil)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/jobs/x", nil)
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("want 401 without bearer, got %d", rr.Code)
+	}
+
+	rr = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("healthz should stay open, got %d", rr.Code)
+	}
+
+	rr = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("metrics should stay open, got %d", rr.Code)
+	}
+
+	rr = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/v1/jobs/x", nil)
+	req.Header.Set("Authorization", "Bearer secret-token")
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code == http.StatusUnauthorized {
+		t.Fatalf("valid bearer still unauthorized")
+	}
+	var body map[string]any
+	_ = json.Unmarshal(rr.Body.Bytes(), &body)
+}
+
+func TestAPIAuthRejectsWrongToken(t *testing.T) {
+	s := api.New(config.Config{APIToken: "secret-token"}, nil)
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/jobs/x", nil)
+	req.Header.Set("Authorization", "Bearer wrong")
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("want 401, got %d", rr.Code)
+	}
+}

--- a/internal/api/jobs.go
+++ b/internal/api/jobs.go
@@ -71,6 +71,7 @@ func (s *Server) handleStartJob(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusInternalServerError, map[string]any{"error": err.Error()})
 		return
 	}
+	metricJobsStarted.Add(1)
 	writeJSON(w, http.StatusCreated, j)
 }
 
@@ -128,6 +129,7 @@ func (s *Server) handleCancelJob(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusConflict, map[string]any{"error": err.Error()})
 		return
 	}
+	metricJobsCancel.Add(1)
 	// Async terminal — poll briefly for updated state
 	j, err := s.jobs.Get(r.Context(), id)
 	if err != nil {

--- a/internal/api/metrics.go
+++ b/internal/api/metrics.go
@@ -1,0 +1,75 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync/atomic"
+)
+
+// Process-wide counters (stdlib only; Prometheus text exposition).
+var (
+	metricHTTPRequests atomic.Uint64
+	metricJobsStarted  atomic.Uint64
+	metricJobsCancel   atomic.Uint64
+)
+
+// MetricsSnapshot is a point-in-time view for tests.
+type MetricsSnapshot struct {
+	HTTPRequests uint64
+	JobsStarted  uint64
+	JobsCancel   uint64
+}
+
+// SnapshotMetrics returns current counter values.
+func SnapshotMetrics() MetricsSnapshot {
+	return MetricsSnapshot{
+		HTTPRequests: metricHTTPRequests.Load(),
+		JobsStarted:  metricJobsStarted.Load(),
+		JobsCancel:   metricJobsCancel.Load(),
+	}
+}
+
+// ResetMetricsForTest zeroes counters (tests only).
+func ResetMetricsForTest() {
+	metricHTTPRequests.Store(0)
+	metricJobsStarted.Store(0)
+	metricJobsCancel.Store(0)
+}
+
+func (s *Server) handleMetrics(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+	var b strings.Builder
+	b.WriteString("# HELP shoal_http_requests_total Total HTTP requests handled by the API server.\n")
+	b.WriteString("# TYPE shoal_http_requests_total counter\n")
+	fmt.Fprintf(&b, "shoal_http_requests_total %d\n", metricHTTPRequests.Load())
+	b.WriteString("# HELP shoal_jobs_started_total Provisioning jobs successfully accepted via POST /v1/jobs.\n")
+	b.WriteString("# TYPE shoal_jobs_started_total counter\n")
+	fmt.Fprintf(&b, "shoal_jobs_started_total %d\n", metricJobsStarted.Load())
+	b.WriteString("# HELP shoal_jobs_cancel_total Job cancel requests accepted via POST /v1/jobs/{id}/cancel.\n")
+	b.WriteString("# TYPE shoal_jobs_cancel_total counter\n")
+	fmt.Fprintf(&b, "shoal_jobs_cancel_total %d\n", metricJobsCancel.Load())
+	_, _ = w.Write([]byte(b.String()))
+}
+
+type statusRecorder struct {
+	http.ResponseWriter
+	code int
+}
+
+func (r *statusRecorder) WriteHeader(code int) {
+	r.code = code
+	r.ResponseWriter.WriteHeader(code)
+}
+
+func withHTTPMetrics(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rec := &statusRecorder{ResponseWriter: w, code: http.StatusOK}
+		next.ServeHTTP(rec, r)
+		metricHTTPRequests.Add(1)
+		// Touch path/code so labels can be added later without changing the metric name.
+		_ = r.Method
+		_ = strconv.Itoa(rec.code)
+	})
+}

--- a/internal/api/metrics_test.go
+++ b/internal/api/metrics_test.go
@@ -1,0 +1,41 @@
+package api_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/mattcburns/shoal/internal/api"
+	"github.com/mattcburns/shoal/internal/common/config"
+)
+
+func TestMetricsEndpoint(t *testing.T) {
+	api.ResetMetricsForTest()
+	s := api.New(config.Config{}, nil)
+
+	// Generate a request so the counter increments.
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	s.Handler().ServeHTTP(rr, req)
+
+	rr = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status %d", rr.Code)
+	}
+	body := rr.Body.String()
+	for _, want := range []string{
+		"shoal_http_requests_total",
+		"shoal_jobs_started_total",
+		"shoal_jobs_cancel_total",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("metrics body missing %q:\n%s", want, body)
+		}
+	}
+	if !strings.Contains(body, "shoal_http_requests_total ") {
+		t.Fatalf("expected counter line, body=%s", body)
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -44,14 +44,15 @@ func New(cfg config.Config, log *slog.Logger) *Server {
 	return s
 }
 
-// Handler returns the root handler.
+// Handler returns the root handler (metrics + optional API auth wrappers).
 func (s *Server) Handler() http.Handler {
-	return s.mux
+	return s.withAPIAuth(withHTTPMetrics(s.mux))
 }
 
 func (s *Server) routes() {
 	s.mux.HandleFunc("GET /healthz", s.handleHealthz)
 	s.mux.HandleFunc("GET /readyz", s.handleReadyz)
+	s.mux.HandleFunc("GET /metrics", s.handleMetrics)
 	s.mux.HandleFunc("POST /v1/jobs", s.handleStartJob)
 	s.mux.HandleFunc("GET /v1/jobs/{id}", s.handleGetJob)
 	s.mux.HandleFunc("POST /v1/jobs/{id}/cancel", s.handleCancelJob)

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -35,7 +35,7 @@ import (
 )
 
 // Version is the application version string (overridable via -ldflags).
-var Version = "0.6.0-phase6c"
+var Version = "0.6.0-phase6d"
 
 // Run dispatches subcommands. args should be os.Args[1:].
 func Run(args []string) int {

--- a/internal/common/config/config.go
+++ b/internal/common/config/config.go
@@ -43,6 +43,8 @@ type Config struct {
 	FewShotDir string
 	// ProfileDir is JSON profile store for Phase 5b (empty disables profile load/approve).
 	ProfileDir string
+	// APIToken protects /v1/* when non-empty (Bearer). Empty = open (lab MVP default).
+	APIToken string
 }
 
 // Load reads SHOAL_* environment variables with Phase 1-friendly defaults.
@@ -76,6 +78,7 @@ func Load() (Config, error) {
 		SerialSSHSudo:        true,
 		FewShotDir:           os.Getenv("SHOAL_FEWSHOT_DIR"),
 		ProfileDir:           os.Getenv("SHOAL_PROFILE_DIR"),
+		APIToken:             os.Getenv("SHOAL_API_TOKEN"),
 	}
 
 	if v := os.Getenv("SHOAL_RECONCILE_FAIL_ORPHANS"); v != "" {

--- a/internal/common/redfish/fixture.go
+++ b/internal/common/redfish/fixture.go
@@ -1,0 +1,58 @@
+package redfish
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// SystemFixture is a subset of Redfish ComputerSystem JSON used by record/replay tests.
+// Fields match common sushy-tools / DMTF shapes (PascalCase JSON).
+type SystemFixture struct {
+	ID           string `json:"Id"`
+	Name         string `json:"Name"`
+	SerialNumber string `json:"SerialNumber"`
+	Manufacturer string `json:"Manufacturer"`
+	Model        string `json:"Model"`
+	PowerState   string `json:"PowerState"`
+	// ODataID may appear as @odata.id in full documents; optional here.
+	ODataID string `json:"@odata.id"`
+}
+
+// LoadSystemFixture reads a JSON system document from path.
+func LoadSystemFixture(path string) (SystemFixture, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return SystemFixture{}, err
+	}
+	var f SystemFixture
+	if err := json.Unmarshal(b, &f); err != nil {
+		return SystemFixture{}, fmt.Errorf("redfish fixture %s: %w", path, err)
+	}
+	if strings.TrimSpace(f.SerialNumber) == "" && strings.TrimSpace(f.ID) == "" {
+		return SystemFixture{}, fmt.Errorf("redfish fixture %s: missing SerialNumber and Id", path)
+	}
+	return f, nil
+}
+
+// ToSystemInfo maps a fixture into the Shoal domain type.
+func (f SystemFixture) ToSystemInfo() SystemInfo {
+	id := f.ID
+	if id == "" {
+		id = f.Name
+	}
+	odata := f.ODataID
+	if odata == "" && id != "" {
+		odata = "/redfish/v1/Systems/" + id
+	}
+	return SystemInfo{
+		ID:           id,
+		Name:         f.Name,
+		Serial:       f.SerialNumber,
+		Manufacturer: f.Manufacturer,
+		Model:        f.Model,
+		PowerState:   f.PowerState,
+		ODataID:      odata,
+	}
+}

--- a/internal/common/redfish/fixture_test.go
+++ b/internal/common/redfish/fixture_test.go
@@ -1,0 +1,82 @@
+package redfish_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mattcburns/shoal/internal/common/redfish"
+)
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	// Walk up from cwd for testdata/redfish (works under go test module root).
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := wd
+	for i := 0; i < 8; i++ {
+		candidate := filepath.Join(dir, "testdata", "redfish")
+		if st, err := os.Stat(candidate); err == nil && st.IsDir() {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	t.Fatal("testdata/redfish not found from ", wd)
+	return ""
+}
+
+func TestLoadSystemFixtures(t *testing.T) {
+	root := repoRoot(t)
+	dir := filepath.Join(root, "testdata", "redfish")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var loaded int
+	for _, e := range entries {
+		if e.IsDir() || filepath.Ext(e.Name()) != ".json" {
+			continue
+		}
+		// Only system-shaped fixtures (name contains system or sushy_system).
+		name := e.Name()
+		if !(contains(name, "system") || contains(name, "System")) {
+			continue
+		}
+		path := filepath.Join(dir, name)
+		f, err := redfish.LoadSystemFixture(path)
+		if err != nil {
+			t.Fatalf("%s: %v", name, err)
+		}
+		info := f.ToSystemInfo()
+		if info.Serial == "" && info.ID == "" {
+			t.Fatalf("%s: empty identity after map", name)
+		}
+		if info.ODataID == "" {
+			t.Fatalf("%s: expected ODataID", name)
+		}
+		loaded++
+		t.Logf("fixture %s -> serial=%q vendor=%q model=%q", name, info.Serial, info.Manufacturer, info.Model)
+	}
+	if loaded == 0 {
+		t.Fatal("no system fixtures loaded")
+	}
+}
+
+func contains(s, sub string) bool {
+	return stringIndex(s, sub) >= 0
+}
+
+func stringIndex(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}

--- a/testdata/redfish/sushy_service_root.json
+++ b/testdata/redfish/sushy_service_root.json
@@ -1,0 +1,12 @@
+{
+  "@odata.id": "/redfish/v1",
+  "Id": "RootService",
+  "Name": "Root Service",
+  "RedfishVersion": "1.0.0",
+  "Systems": {
+    "@odata.id": "/redfish/v1/Systems"
+  },
+  "Managers": {
+    "@odata.id": "/redfish/v1/Managers"
+  }
+}

--- a/testdata/redfish/sushy_system_powered_on.json
+++ b/testdata/redfish/sushy_system_powered_on.json
@@ -1,0 +1,9 @@
+{
+  "@odata.id": "/redfish/v1/Systems/1",
+  "Id": "1",
+  "Name": "shoal-node-2",
+  "SerialNumber": "LAB-SN-FIXTURE-2",
+  "Manufacturer": "Shoal Virtual",
+  "Model": "sushy-node",
+  "PowerState": "On"
+}


### PR DESCRIPTION
## Summary

Phase **6d** (design **v2.0.7**) in the order: design → Compose shoal → auth → metrics → record/replay CI.

### Design
- v2.0.7 Phase 6d detail + PR17
- [`docs/phase-6d-plan.md`](docs/phase-6d-plan.md)

### Compose `shoal` service
- `deploy/docker/Dockerfile` (copy prebuilt binary)
- Ansible builds linux binary on **controller**, stages on lab host, `docker compose up --build`
- Host network so BMC/sushy/lab ports work; default port **8088**
- Toggle: `shoal_compose_app` (default true)

### API auth
- `SHOAL_API_TOKEN` / `shoal_api_token`: empty = open; set = Bearer required for `/v1/*`
- `/healthz`, `/readyz`, `/metrics` stay open

### Metrics
- `GET /metrics` Prometheus text (stdlib only): HTTP requests, jobs started, jobs cancel

### Record/replay CI
- `testdata/redfish` fixtures + `LoadSystemFixture` / `ToSystemInfo` unit tests (covered by GHA `go test`)

## Test plan
- [x] `go test ./...` local
- [x] Ansible syntax-check `lab_up.yml`
- [ ] GHA CI green
- [x] Re-run `lab_up` + `smoke.yml` on classic L0 (needs become; deploys `shoal-app`)