### PR TITLE
feat(deploy): Phase 7a Ubuntu nested-lab install (cloud image-write)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -274,6 +274,8 @@ go run ./cmd/shoal deploy run \
 | `SHOAL_ISO_PUBLISH_DIR` | Filesystem dir served on `:8080` (lab: `/srv/iso`). Phase 5c publish target |
 | `SHOAL_ISO_BUILD_SCRIPT` | Optional path to `build-marker-iso.sh` (auto-discovers from repo) |
 | `SHOAL_ISO_DYNAMIC` | If `true`, Start may build+publish when `ISOURL` empty (needs publish dir + base URL; Phase 6a) |
+| `SHOAL_UBUNTU_ISO` | Phase 7a: path to official Ubuntu Server live-server ISO for `autoinstall` remaster |
+| `SHOAL_AUTOINSTALL_HOSTNAME` / `USERNAME` / `PASSWORD` | Build-time identity for autoinstall ISO (lab default password `shoal-lab`; not for production) |
 | `SHOAL_RECONCILE_FAIL_ORPHANS` | Default `true` |
 | `SHOAL_FEWSHOT_DIR` | Append-only learned few-shot JSONL (confirm learning). Lab Ansible default: `/var/lib/shoal/fewshot` via `shoal_fewshot_dir` + `env.j2`. Empty disables confirm |
 | `SHOAL_PROFILE_DIR` | JSON provisioning profiles + approval records (Phase 5b). Lab Ansible default: `/var/lib/shoal/profiles` via `shoal_profile_dir` + `env.j2`. Empty disables non-spike profile load |
@@ -296,10 +298,10 @@ with real SOL progress; optional `-build-iso` / `SHOAL_ISO_DYNAMIC`. Marker
 Sole lifecycle writer remains Orchestrator; JobStore stays pure persistence.
 
 **Phase 7 (full OS autoinstall):** real OS install over BMC Virtual Media + SOL
-(not the 6a payload MVP). Planned slices: **7a** Ubuntu autoinstall E2E, **7b**
-profile/artifact model, **7c** second path + NetBox identity polish. Design §
-Phase 7 and [`docs/phase-7-plan.md`](./docs/phase-7-plan.md). Do not treat 6a
-`write` as full autoinstall.
+(not the 6a payload MVP). **7a:** remaster Ubuntu Server ISO
+(`install-mode autoinstall`, `SHOAL_UBUNTU_ISO`); markers in autoinstall
+user-data; raise SOL stall for long installs. **7b/7c:** profiles + second
+path (later). Design § Phase 7 and [`docs/phase-7-plan.md`](./docs/phase-7-plan.md).
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This file is the canonical guide for how to work in this repository. It covers
 project conventions, commands, and style. For **architecture, data models, and
 the phased plan**, the source of truth is
 [`SHOAL_COMPREHENSIVE_DESIGN_AND_IMPLEMENTATION_PLAN.md`](./SHOAL_COMPREHENSIVE_DESIGN_AND_IMPLEMENTATION_PLAN.md)
-(**v2.0.8**, Go stack). When this file and the design doc disagree, fix one of
+(**v2.0.9**, Go stack). When this file and the design doc disagree, fix one of
 them in the same change — they must stay consistent.
 
 > **Read order for any task:** (1) this file, (2) the relevant Chapter 4 section

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,7 +124,7 @@ shoal/                                    # module: github.com/mattcburns/shoal
     operator-macos.md                     # Mac = operator only (Phase 6c)
     phase-6c-plan.md                      # packaging + L0 host profiles checklist
     phase-6d-plan.md                      # compose app + auth + metrics + fixtures
-    phase-7-plan.md                       # full OS autoinstall (Phase 7)
+    phase-7-plan.md                       # full OS install Phase 7 (7a complete; 7b/7c deferred)
   deploy/docker/Dockerfile                # minimal runtime image for lab Compose
   go.mod
   LICENSE                                 # AGPLv3 (Shoal)
@@ -274,8 +274,9 @@ go run ./cmd/shoal deploy run \
 | `SHOAL_ISO_PUBLISH_DIR` | Filesystem dir served on `:8080` (lab: `/srv/iso`). Phase 5c publish target |
 | `SHOAL_ISO_BUILD_SCRIPT` | Optional path to `build-marker-iso.sh` (auto-discovers from repo) |
 | `SHOAL_ISO_DYNAMIC` | If `true`, Start may build+publish when `ISOURL` empty (needs publish dir + base URL; Phase 6a) |
-| `SHOAL_UBUNTU_ISO` | Phase 7a: path to official Ubuntu Server live-server ISO for `autoinstall` remaster |
-| `SHOAL_AUTOINSTALL_HOSTNAME` / `USERNAME` / `PASSWORD` | Build-time identity for autoinstall ISO (lab default password `shoal-lab`; not for production) |
+| `SHOAL_UBUNTU_CLOUD_IMG` | Phase 7a preferred: Ubuntu cloud image for prepare → marker write ISO |
+| `SHOAL_UBUNTU_ISO` | Phase 7a alternate: live-server ISO for autoinstall remaster (stretch) |
+| `SHOAL_AUTOINSTALL_HOSTNAME` / `USERNAME` / `PASSWORD` | Build-time identity for cloud prepare / autoinstall (lab default password `shoal-lab`; not for production) |
 | `SHOAL_RECONCILE_FAIL_ORPHANS` | Default `true` |
 | `SHOAL_FEWSHOT_DIR` | Append-only learned few-shot JSONL (confirm learning). Lab Ansible default: `/var/lib/shoal/fewshot` via `shoal_fewshot_dir` + `env.j2`. Empty disables confirm |
 | `SHOAL_PROFILE_DIR` | JSON provisioning profiles + approval records (Phase 5b). Lab Ansible default: `/var/lib/shoal/profiles` via `shoal_profile_dir` + `env.j2`. Empty disables non-spike profile load |
@@ -297,11 +298,13 @@ with real SOL progress; optional `-build-iso` / `SHOAL_ISO_DYNAMIC`. Marker
 `simulate` mode remains the Phase 2 demo. Plain HTTP ISO on mgmt segment.
 Sole lifecycle writer remains Orchestrator; JobStore stays pure persistence.
 
-**Phase 7 (full OS autoinstall):** real OS install over BMC Virtual Media + SOL
-(not the 6a payload MVP). **7a:** remaster Ubuntu Server ISO
-(`install-mode autoinstall`, `SHOAL_UBUNTU_ISO`); markers in autoinstall
-user-data; raise SOL stall for long installs. **7b/7c:** profiles + second
-path (later). Design § Phase 7 and [`docs/phase-7-plan.md`](./docs/phase-7-plan.md).
+**Phase 7 (full OS install):** real OS on disk over BMC Virtual Media + SOL
+(not the 6a payload MVP). **7a complete (v2.0.9):** preferred nested-lab path is
+Ubuntu **cloud image-write** (`prepare-ubuntu-cloud-payload.sh` + marker ISO with
+`payload.gz` on ISO root; `install-mode autoinstall` maps to write+reboot).
+Live-server remaster (`SHOAL_UBUNTU_ISO`) is alternate/stretch. **7b/7c deferred**
+(multi-stage + OS matrix = separate design). See design § Phase 7 and
+[`docs/phase-7-plan.md`](./docs/phase-7-plan.md).
 
 ---
 

--- a/SHOAL_COMPREHENSIVE_DESIGN_AND_IMPLEMENTATION_PLAN.md
+++ b/SHOAL_COMPREHENSIVE_DESIGN_AND_IMPLEMENTATION_PLAN.md
@@ -1,6 +1,6 @@
 # Shoal: Comprehensive Design Document & Phased Implementation Plan
 
-**Version:** 2.0.8  
+**Version:** 2.0.9  
 **Date:** July 2026  
 **Status:** Draft (post-review; open questions resolved)  
 **Author:** (architect / AI agent)  
@@ -28,11 +28,11 @@ This is a **language/stack revision** of the v1.1 product design — not a green
 
 ---
 
-## Changes in v2.0 / v2.0.1 / v2.0.2 / v2.0.3 / v2.0.4 / v2.0.5 / v2.0.6 / v2.0.7 / v2.0.8
+## Changes in v2.0 / v2.0.1 / v2.0.2 / v2.0.3 / v2.0.4 / v2.0.5 / v2.0.6 / v2.0.7 / v2.0.8 / v2.0.9
 
 Full stack rewrite of the **application** from Python to **Go (Golang)**, maximizing the Go standard library **except where Redfish complexity justifies gofish**.
 
-| Area | v1.1 (Python) | v2.0.8 (Go) |
+| Area | v1.1 (Python) | v2.0.9 (Go) |
 |------|---------------|-------------|
 | Language | Python 3.11+ | Go 1.22+ (prefer latest stable) |
 | Module path | n/a | **`github.com/mattcburns/shoal`** |
@@ -67,6 +67,8 @@ Full stack rewrite of the **application** from Python to **Go (Golang)**, maximi
 **v2.0.7 (Phase 6d ops packaging):** optional **Compose `shoal` service** in the lab stack (binary image, env from Ansible); **Bearer API token** auth for `/v1/*` when `SHOAL_API_TOKEN` set (health/ready/metrics remain open); **stdlib Prometheus text `/metrics`** (job + HTTP counters, no new deps); **record/replay fixture tests** under `testdata/redfish/` wired into unit CI. Extra OEM screenshot adapters remain hardware-driven.
 
 **v2.0.8 (Phase 7 full OS autoinstall):** promote former stretch **full distro autoinstall** to numbered **Phase 7** (7a Ubuntu autoinstall E2E → 7b profile/artifact model → 7c second family or generalized image-write + NetBox binding polish). Phase **6a** remains the **bounded payload-write MVP** (`SHOAL_INSTALL_MODE=write`); it is **not** replaced. Phase **6e+** stays optional polish (more OEM screenshots, registry publish, tracing). Still BMC-only (Virtual Media + SOL); no PXE.
+
+**v2.0.9 (Phase 7a closed — nested-lab Ubuntu image-write):** **7a complete** via preferred nested-lab path: Ubuntu **cloud image** → customize → gzip → marker ISO (`payload.gz` on ISO root, not initrd) → Virtual Media → SOL markers → `gunzip|dd` to disk → reboot into Ubuntu. Live-server **autoinstall remaster** remains an alternate/stretch (unreliable under nested sushy). Phase **7b/7c deferred**. Multi-stage prep + scripted ISO matrix (Ubuntu autoinstall / Flatcar Ignition / ESXi kickstart / Windows) tracked in a **separate design document**, not as remaining 7.x checklist items.
 
 **Preserved (product decisions, not language):**
 
@@ -1562,18 +1564,26 @@ Executable checklist: [`docs/phase-6d-plan.md`](./docs/phase-6d-plan.md). Phase 
 
 Additional vendor screenshot adapters as hardware is tested; optional image registry publish; richer tracing. **Not a gate for Phase 7.**
 
-### Phase 7: Full OS autoinstall
+### Phase 7: Full OS install (BMC + SOL)
 
-**Intent:** Install a **real operating system** onto local disk over the **BMC-only** path (Redfish Virtual Media + SOL progress), then reboot into the installed OS. This is the product path beyond Phase **6a**’s bounded `/payload` write MVP.
+**Intent:** Install a **real operating system** onto local disk over the **BMC-only** path (Redfish Virtual Media + SOL progress), then reboot into the installed OS. This is beyond Phase **6a**’s bounded `/payload` write MVP.
+
+**Status (v2.0.9):**
+
+| Slice | Status | Notes |
+|-------|--------|--------|
+| **7a** Ubuntu on nested lab disk | **Complete** | Preferred path: **cloud image-write** (see below). Live-server autoinstall remaster kept as alternate/stretch. |
+| **7b** Profile + artifact model | **Deferred** | Superseded by upcoming multi-stage / OS-matrix design. |
+| **7c** Second family + NetBox identity polish | **Deferred** | Same; do not implement under old 7b/7c checklist without the new design. |
 
 **Relationship to earlier phases:**
 
 | Piece | Role in Phase 7 |
 |-------|-----------------|
 | Phase 2 `simulate` | Demo markers only — keep for spike/regression |
-| Phase 5b profiles | Carry `os_family`, version, hostname, disk target, autoinstall config refs |
-| Phase 5c / 6a ISO | Build/publish install media; dynamic build when needed |
-| Phase 6a `write` | Still valid for non-OS payload inject; **not** full autoinstall |
+| Phase 5b profiles | Future install fields; not required for 7a lab E2E flags path |
+| Phase 5c / 6a ISO | Build/publish media; marker ISO + payload |
+| Phase 6a `write` | Bounded payload inject; **7a reuses write mechanics** at full OS image scale |
 | Phase 6b OCR | Graphics failure screens only; does **not** commit lifecycle |
 | Phase 6d Compose/auth | Lab/ops packaging; optional for install path |
 
@@ -1583,62 +1593,40 @@ Additional vendor screenshot adapters as hardware is tested; optional image regi
 2. **SOL is the primary progress channel** — marker phases at least: `DISK_PREP` → `IMAGE_WRITE` → `POSTINSTALL` → `VERIFY` → `DONE` / `ERROR` (+ heartbeats). Same `SHOAL|…` protocol family as Phase 2/6a.
 3. **Orchestrator is the sole lifecycle writer**; JobStore remains pure persistence; Observe proposes progress via `jobport` only.
 4. **Secrets never** in published ISO contents, SOL logs, slog, or LLM payloads (no password fields from vault in autoinstall user-data without secret-backend indirection / redaction policy).
-5. **Cleanup is mandatory** — eject Virtual Media and clear boot override on success, failure, and cancel (existing Deploy finalizer).
+5. **Cleanup is mandatory** — eject Virtual Media and clear boot override on success, failure, and cancel (existing Deploy finalizer). Accept sushy-tools steady state **Continuous/Hdd** as cleared override after cleanup.
 6. Prefer **stdlib + existing allow-list**; new deps only with §7.1 update in the same change.
 
-#### 7a — Ubuntu autoinstall end-to-end (first family)
+#### 7a — Ubuntu on nested lab (complete)
 
-| Item | Decision |
-|------|----------|
-| First OS | **Ubuntu Server** autoinstall (cloud-init autoinstall / subiquity-class flow) |
-| Media | Shoal-assembled or Shoal-parameterized install ISO (or live+autoinstall seed), published to lab ISO HTTP (`:8080`), attached via Redfish Virtual Media |
-| Lab AC host | Nested **libvirt guest with a real disk** (L2 under L1) — not “sushy BMC only”; sushy-tools still provides Redfish control plane where used |
-| Progress | Producer emits SOL markers through install; Observe/jobport progress; Orchestrator transitions to terminal + cleanup |
-| Outcome | Guest reboots into installed Ubuntu; `VERIFY`/`DONE` after agreed checks (e.g. marker or post-boot signal — exact verify signal specified in implementation PR) |
+| Item | Decision (as shipped) |
+|------|------------------------|
+| First OS | **Ubuntu** (22.04 cloud image train for lab E2E) |
+| **Preferred lab path** | Prepare cloud image (`prepare-ubuntu-cloud-payload.sh`) → gzip raw → **marker ISO** with `payload.gz` on ISO root (not in initrd) + matching kernel modules → Virtual Media → busybox `gunzip\|dd` to `/dev/vda` → SOL markers → reboot |
+| Alternate / stretch | Remaster Ubuntu **live-server** ISO with autoinstall seed (`build-ubuntu-autoinstall-iso.sh`); nested sushy often fails to boot/progress reliably |
+| Lab AC host | Nested **libvirt guest with a real disk** (L2 under L1); sushy-tools Redfish control plane |
+| Progress | Marker `/init` emits `SHOAL|…` through write phases; Observe/jobport; Orchestrator terminal + cleanup |
+| Outcome | Bootable Ubuntu root on disk; serial login observed in lab E2E; job reaches **`provisioned`** |
 
-**7a acceptance criteria:**
+**7a acceptance criteria (met):**
 
-1. Lab job: Virtual Media install ISO → SOL markers progress through install phases → terminal success → media ejected / boot override cleared.
-2. Nested guest has a bootable Ubuntu root on disk (not merely a payload file from 6a `write`).
+1. Lab job: Virtual Media install ISO → SOL markers through install phases → terminal **`provisioned`** → media ejected / boot override cleared (or sushy Continuous/Hdd accepted as clear).
+2. Nested guest has a **bootable Ubuntu root on disk** (full OS image write, not 6a demo payload only).
 3. `simulate` and 6a `write` still work (no regression).
-4. No secrets in ISO build logs or published autoinstall files beyond documented non-secret identity fields.
+4. No secrets in ISO build logs beyond documented non-secret lab identity fields.
 
-#### 7b — Profile and artifact model
+**Implementation pointers:** `infra/scripts/prepare-ubuntu-cloud-payload.sh`, `infra/scripts/build-marker-iso.sh` (`autoinstall`→write + on-ISO payload), `internal/deploy/iso` cloud-img path, `docs/lab-runbook.md` Phase 7a, `docs/phase-7-plan.md`.
 
-| Item | Decision |
-|------|----------|
-| Profile fields | Extend `ProvisioningProfile` (and store under `SHOAL_PROFILE_DIR`) for install: `os_family`, OS version, hostname, install disk/target, autoinstall document ref or inline non-secret config, ISO/base image refs |
-| Modes | Keep `simulate`, 6a `write`, and new **`autoinstall`** (name TBD in impl) install mode on the producer / job request |
-| ISO builder | Extend `internal/deploy/iso` / marker-or-install image scripts; profile-driven Start without hand-passed `-iso-url` when resolve works (same pattern as 5c/6a) |
-| Approval | Destruct / wipe steps still require Phase 5b approval gates |
+#### 7b / 7c — Deferred
 
-**7b acceptance criteria:**
+Profile-driven install artifacts, second OS family, and NetBox identity polish from the original 7b/7c tables are **not** acceptance criteria for closing 7a. Product direction for **multi-stage prep** (wipe/RAID/firmware) → **scripted ISO** (autoinstall / kickstart / Ignition / later Windows) + OS support matrix is specified in a **separate design document** (not this Phase 7 checklist). Do not expand 7b/7c implementation until that design is accepted.
 
-1. Operator can `profile generate|save|approve` (or equivalent) an Ubuntu autoinstall profile and `deploy`/`Start` without manually crafting ISO flags for the happy path.
-2. Schema validation on profile + autoinstall inputs; golden/unit tests for builder inputs.
-3. Documented mapping from profile → published ISO URL → job.
+#### Phase 7 non-goals (7.0 / remaining)
 
-#### 7c — Second family / generalized path + identity polish
-
-| Item | Decision |
-|------|----------|
-| Second path | Either **RHEL-like kickstart** (or Alma/Rocky) **or** generalized **compressed rootfs / image-write** install — choose one in the 7c implementation PR with lab AC |
-| NetBox | Lifecycle already Orchestrator-owned; polish **device identity binding** after successful install (serial/inventory ↔ NetBox device) where still loose |
-| OCR | Still non-authoritative for lifecycle |
-
-**7c acceptance criteria:**
-
-1. Second install path documented and lab-demonstrated (or explicitly deferred with design note if hardware/lab blocks it).
-2. Successful install updates/consistent NetBox `lifecycle_state` (+ identity fields as designed).
-3. Failure paths still cleanup BMC state.
-
-#### Phase 7 non-goals (7.0)
-
-- Windows or non-Linux guests  
+- Treating Phase 7 as multi-stage prep + full OS matrix (new design)  
+- Windows as a Phase 7 deliverable  
 - PXE / DHCP provisioning networks as a required path  
-- Multi-tenant cloud imaging SaaS  
 - Replacing SOL with OCR as the progress loop  
-- Full distro matrix (every Ubuntu/RHEL minor) — start with one Ubuntu train, expand deliberately  
+- Full distro matrix on day one  
 
 Executable checklist: [`docs/phase-7-plan.md`](./docs/phase-7-plan.md).
 

--- a/docs/lab-runbook.md
+++ b/docs/lab-runbook.md
@@ -326,6 +326,70 @@ present, the image falls back to a file target (`/tmp/shoal-install.out` or
 `SHOAL_ISO_DYNAMIC=true` also builds when `-iso-url` is empty and publish
 dir/base URL are set.
 
+### Phase 7a: Ubuntu autoinstall (full OS)
+
+Phase **6a** writes a bounded `/payload` only. Phase **7a** remasters an official
+**Ubuntu Server live-server** ISO with cloud-init autoinstall and emits `SHOAL|…`
+markers on serial (`BOOT` → `DISK_PREP` → heartbeats → `POSTINSTALL` → `VERIFY` → `DONE`).
+
+**Prerequisites**
+
+1. Nested guest with a **real disk** (lab nodes: 20G qcow2) and ≥2 GiB RAM.
+2. Official Ubuntu Server ISO on a path the build host can read (download once):
+
+```bash
+# Example on L1 or operator host used for -build-iso:
+wget -O /var/tmp/ubuntu-22.04.5-live-server-amd64.iso \
+  https://releases.ubuntu.com/22.04/ubuntu-22.04.5-live-server-amd64.iso
+export SHOAL_UBUNTU_ISO=/var/tmp/ubuntu-22.04.5-live-server-amd64.iso
+export SHOAL_ISO_PUBLISH_DIR=/srv/iso
+export SHOAL_ISO_BASE_URL=http://192.168.124.1:8080
+```
+
+**Build + publish autoinstall ISO**
+
+```bash
+go run ./cmd/shoal deploy iso build \
+  -name shoal-ubuntu-autoinstall.iso \
+  -install-mode autoinstall \
+  -ubuntu-iso "$SHOAL_UBUNTU_ISO" \
+  -hostname lab-node-1 \
+  -publish
+```
+
+**Deploy (long job — raise stall/wait)**
+
+```bash
+go run ./cmd/shoal deploy run \
+  -device-id shoal-node-1 \
+  -bmc-url http://192.168.122.100:8001 \
+  -serial-target shoal-node-1 \
+  -serial-ssh-host 192.168.122.100 \
+  -build-iso \
+  -iso-install-mode autoinstall \
+  -ubuntu-iso "$SHOAL_UBUNTU_ISO" \
+  -iso-hostname lab-node-1
+# autoinstall defaults stall to 45m and wait to 90m when mode/ubuntu-iso set
+```
+
+Or attach a prebuilt URL:
+
+```bash
+go run ./cmd/shoal deploy run \
+  -device-id shoal-node-1 \
+  -bmc-url http://192.168.122.100:8001 \
+  -serial-target shoal-node-1 \
+  -iso-url http://192.168.124.1:8080/shoal-ubuntu-autoinstall.iso \
+  -stall-timeout 45m \
+  -wait-timeout 90m
+```
+
+**Lab login (default template):** user `shoal`, password `shoal-lab` (lab-only;
+change via `SHOAL_AUTOINSTALL_PASSWORD` at build time for anything beyond lab).
+
+**Fidelity:** sushy-tools still only emulates BMC; install runs on the nested
+libvirt disk. First install can take 20–60+ minutes on nested CPU.
+
 ### Phase 6b: graphics failure-screen OCR
 
 SOL remains the primary progress channel. Graphics OCR is **diagnostic only**.

--- a/docs/lab-runbook.md
+++ b/docs/lab-runbook.md
@@ -326,29 +326,78 @@ present, the image falls back to a file target (`/tmp/shoal-install.out` or
 `SHOAL_ISO_DYNAMIC=true` also builds when `-iso-url` is empty and publish
 dir/base URL are set.
 
-### Phase 7a: Ubuntu autoinstall (full OS)
+### Phase 7a: Ubuntu full OS on nested lab (**complete**)
 
-Phase **6a** writes a bounded `/payload` only. Phase **7a** remasters an official
-**Ubuntu Server live-server** ISO with cloud-init autoinstall and emits `SHOAL|…`
-markers on serial (`BOOT` → `DISK_PREP` → heartbeats → `POSTINSTALL` → `VERIFY` → `DONE`).
+Phase **6a** writes a bounded `/payload` only. Phase **7a** installs a **real
+Ubuntu root** on the nested guest disk over Virtual Media + SOL markers, then
+reboots. Job ends **`provisioned`**.
+
+**Preferred path (nested sushy lab):** Ubuntu **cloud image** → customize →
+gzip → marker ISO with `payload.gz` on the ISO root → guest
+`gunzip|dd` to `/dev/vda`. Live-server **autoinstall remaster** is alternate/stretch
+(often fails to boot/progress under nested sushy).
 
 **Prerequisites**
 
 1. Nested guest with a **real disk** (lab nodes: 20G qcow2) and ≥2 GiB RAM.
-2. Official Ubuntu Server ISO on a path the build host can read (download once):
+2. Build on **L1** (needs loop mounts / sudo for cloud prep; kernel modules for marker ISO).
+3. Publish dir served at BMC-reachable URL:
 
 ```bash
-# Example on L1 or operator host used for -build-iso:
-wget -O /var/tmp/ubuntu-22.04.5-live-server-amd64.iso \
-  https://releases.ubuntu.com/22.04/ubuntu-22.04.5-live-server-amd64.iso
-export SHOAL_UBUNTU_ISO=/var/tmp/ubuntu-22.04.5-live-server-amd64.iso
 export SHOAL_ISO_PUBLISH_DIR=/srv/iso
 export SHOAL_ISO_BASE_URL=http://192.168.124.1:8080
 ```
 
-**Build + publish autoinstall ISO**
+**Prepare cloud payload (L1)**
 
 ```bash
+wget -O /var/tmp/ubuntu-22.04-server-cloudimg-amd64.img \
+  https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-amd64.img
+export SHOAL_UBUNTU_CLOUD_IMG=/var/tmp/ubuntu-22.04-server-cloudimg-amd64.img
+export SHOAL_AUTOINSTALL_HOSTNAME=lab-node-1
+export SHOAL_AUTOINSTALL_USERNAME=ubuntu
+export SHOAL_AUTOINSTALL_PASSWORD=shoal-lab   # lab only
+sudo -E ./infra/scripts/prepare-ubuntu-cloud-payload.sh /tmp/ubuntu-cloud-payload.raw
+# produces /tmp/ubuntu-cloud-payload.raw.gz
+```
+
+**Build marker install ISO (payload on ISO root, small initrd)**
+
+```bash
+sudo env \
+  SHOAL_INSTALL_MODE=autoinstall \
+  SHOAL_PAYLOAD_FILE=/tmp/ubuntu-cloud-payload.raw.gz \
+  SHOAL_INSTALL_TARGET=/dev/vda \
+  SHOAL_INSTALL_REBOOT=1 \
+  SHOAL_ISO_NAME=shoal-ubuntu-cloud-v5.iso \
+  ./infra/scripts/build-marker-iso.sh /srv/iso/shoal-ubuntu-cloud-v5.iso
+```
+
+**Deploy**
+
+```bash
+# Use a new ISO basename when content changes (sushy caches by download path).
+go run ./cmd/shoal deploy run \
+  -device-id shoal-node-1 \
+  -bmc-url http://192.168.122.100:8001 \
+  -bmc-user admin -bmc-pass password \
+  -serial-target shoal-node-1 \
+  -serial-ssh-host 192.168.122.100 \
+  -serial-ssh-user lab \
+  -serial-ssh-key "$HOME/.ssh/shoal_lab_vm" \
+  -iso-url http://192.168.124.1:8080/shoal-ubuntu-cloud-v5.iso \
+  -stall-timeout 15m \
+  -wait-timeout 25m \
+  -wait
+# Expect: state=provisioned, phase=DONE
+```
+
+**Lab login (cloud prepare defaults):** user `ubuntu`, password `shoal-lab` (lab-only).
+
+**Alternate — live-server autoinstall remaster**
+
+```bash
+export SHOAL_UBUNTU_ISO=/path/to/ubuntu-22.04.5-live-server-amd64.iso
 go run ./cmd/shoal deploy iso build \
   -name shoal-ubuntu-autoinstall.iso \
   -install-mode autoinstall \
@@ -357,38 +406,9 @@ go run ./cmd/shoal deploy iso build \
   -publish
 ```
 
-**Deploy (long job — raise stall/wait)**
-
-```bash
-go run ./cmd/shoal deploy run \
-  -device-id shoal-node-1 \
-  -bmc-url http://192.168.122.100:8001 \
-  -serial-target shoal-node-1 \
-  -serial-ssh-host 192.168.122.100 \
-  -build-iso \
-  -iso-install-mode autoinstall \
-  -ubuntu-iso "$SHOAL_UBUNTU_ISO" \
-  -iso-hostname lab-node-1
-# autoinstall defaults stall to 45m and wait to 90m when mode/ubuntu-iso set
-```
-
-Or attach a prebuilt URL:
-
-```bash
-go run ./cmd/shoal deploy run \
-  -device-id shoal-node-1 \
-  -bmc-url http://192.168.122.100:8001 \
-  -serial-target shoal-node-1 \
-  -iso-url http://192.168.124.1:8080/shoal-ubuntu-autoinstall.iso \
-  -stall-timeout 45m \
-  -wait-timeout 90m
-```
-
-**Lab login (default template):** user `shoal`, password `shoal-lab` (lab-only;
-change via `SHOAL_AUTOINSTALL_PASSWORD` at build time for anything beyond lab).
-
-**Fidelity:** sushy-tools still only emulates BMC; install runs on the nested
-libvirt disk. First install can take 20–60+ minutes on nested CPU.
+**Fidelity:** sushy-tools emulates BMC only; write runs on the nested libvirt disk.
+Cloud image-write typically finishes in a few minutes once media is attached;
+live autoinstall (if used) can take 20–60+ minutes on nested CPU.
 
 ### Phase 6b: graphics failure-screen OCR
 

--- a/docs/phase-7-plan.md
+++ b/docs/phase-7-plan.md
@@ -26,11 +26,15 @@ lifecycle rules intact.
 
 | # | Task | AC |
 |---|------|----|
-| A1 | Install/autoinstall media pipeline (Ubuntu Server train) | Published ISO on lab `:8080` |
-| A2 | SOL producer markers through install + heartbeats | Parseable by existing SOL path |
-| A3 | Deploy job: attach media, boot, watch markers, cleanup | Terminal + BMC cleanup |
-| A4 | Lab: nested libvirt guest with real disk | Bootable Ubuntu after job |
-| A5 | Regression: `simulate` + 6a `write` still pass | No break |
+| A1 | Install/autoinstall media pipeline (Ubuntu Server train) | `build-ubuntu-autoinstall-iso.sh` + `deploy iso build -install-mode autoinstall` |
+| A2 | SOL producer markers through install + heartbeats | Template early/late-commands + 45s heartbeats |
+| A3 | Deploy job: attach media, boot, watch markers, cleanup | Existing orchestrator + longer stall defaults |
+| A4 | Lab: nested libvirt guest with real disk | Documented; operator E2E with `SHOAL_UBUNTU_ISO` |
+| A5 | Regression: `simulate` + 6a `write` still pass | Unit tests + modes unchanged |
+
+**7a code status:** media pipeline, Go mode, CLI, and docs land in the Phase 7a
+implementation PR. Full guest install still requires a downloaded Ubuntu ISO
+and a long lab run (not CI-default).
 
 ### 7b — Profile + artifact model
 

--- a/docs/phase-7-plan.md
+++ b/docs/phase-7-plan.md
@@ -1,6 +1,6 @@
-# Phase 7 — Full OS autoinstall
+# Phase 7 — Full OS install (BMC + SOL)
 
-Executable checklist for design **v2.0.8** § Phase 7. Design SoT:
+Executable checklist for design **v2.0.9** § Phase 7. Design SoT:
 [`SHOAL_COMPREHENSIVE_DESIGN_AND_IMPLEMENTATION_PLAN.md`](../SHOAL_COMPREHENSIVE_DESIGN_AND_IMPLEMENTATION_PLAN.md).
 
 ## Goal
@@ -19,69 +19,71 @@ lifecycle rules intact.
 - Orchestrator sole lifecycle writer; JobStore pure persistence
 - Secrets never in published ISO, SOL logs, slog, or LLM payloads
 - Mandatory Virtual Media eject + boot override clear on all terminals
+  (sushy Continuous/Hdd after clear is OK)
 
 ## Sub-phases
 
-### 7a — Ubuntu autoinstall E2E
+### 7a — Ubuntu nested-lab E2E — **COMPLETE**
 
-| # | Task | AC |
-|---|------|----|
-| A1 | Install/autoinstall media pipeline (Ubuntu Server train) | `build-ubuntu-autoinstall-iso.sh` + `deploy iso build -install-mode autoinstall` |
-| A2 | SOL producer markers through install + heartbeats | Template early/late-commands + 45s heartbeats |
-| A3 | Deploy job: attach media, boot, watch markers, cleanup | Existing orchestrator + longer stall defaults |
-| A4 | Lab: nested libvirt guest with real disk | Documented; operator E2E with `SHOAL_UBUNTU_ISO` |
-| A5 | Regression: `simulate` + 6a `write` still pass | Unit tests + modes unchanged |
+| # | Task | AC | Status |
+|---|------|-----|--------|
+| A1 | Media pipeline for full Ubuntu on disk | Marker ISO + cloud payload **or** live-server remaster | **Done** (preferred: cloud image-write) |
+| A2 | SOL producer markers + heartbeats | Marker `/init` write path markers | **Done** |
+| A3 | Deploy job: attach, boot, watch, cleanup | Orchestrator + ForceRestart + post-check | **Done** |
+| A4 | Lab: nested libvirt guest with real disk | Documented E2E; bootable Ubuntu + login | **Done** |
+| A5 | Regression: `simulate` + 6a `write` | Unit tests / modes unchanged | **Done** |
 
-**7a code status:** media pipeline, Go mode, CLI, and docs land in the Phase 7a
-implementation PR. Full guest install still requires a downloaded Ubuntu ISO
-and a long lab run (not CI-default).
+**Preferred nested-lab path (shipped):**
 
-### 7b — Profile + artifact model
+1. `prepare-ubuntu-cloud-payload.sh` — customize Ubuntu cloud image → `.raw.gz`
+2. `build-marker-iso.sh` with `SHOAL_INSTALL_MODE=autoinstall` + large payload on ISO root
+3. Publish to `/srv/iso`, attach via sushy Virtual Media (`http://192.168.124.1:8080/…`)
+4. Guest: mount CD → `gunzip|dd` → `/dev/vda` → SOL `DONE` → reboot
+5. Job state **`provisioned`**
 
-| # | Task | AC |
-|---|------|----|
-| B1 | Extend `ProvisioningProfile` for install fields | Schema + validate |
-| B2 | Profile → ISO resolve / build (5c/6a patterns) | Start without hand `-iso-url` happy path |
-| B3 | Install mode distinct from `simulate` / `write` | Documented contract |
-| B4 | Approval gates for destruct/wipe (5b) | Still enforced |
+**Alternate / stretch:** `build-ubuntu-autoinstall-iso.sh` live-server remaster (autoinstall
+user-data). Unreliable under nested sushy; keep for future hardware / better media fidelity.
 
-### 7c — Second path + identity polish
+**Operator docs:** [`lab-runbook.md`](./lab-runbook.md) § Phase 7a.
 
-| # | Task | AC |
-|---|------|----|
-| C1 | Second family (kickstart) **or** image-write path | Lab-demonstrated or design defer note |
-| C2 | NetBox device identity binding after success | Lifecycle + identity consistent |
-| C3 | Failure paths still cleanup | No stuck media/override |
+### 7b — Profile + artifact model — **DEFERRED**
 
-## Non-goals (7.0)
+Original B1–B4 (install profiles, resolve ISO without hand flags) deferred pending the
+**multi-stage provisioning + OS matrix** design document. Do not implement under this
+checklist without that design.
 
-- Windows
+### 7c — Second family + identity polish — **DEFERRED**
+
+Original C1–C3 deferred for the same reason. Image-write for Ubuntu is already the 7a
+path; further families (kickstart, Ignition, Windows) belong in the new design.
+
+## Non-goals (7.0 / remaining)
+
+- Multi-stage prep (wipe/RAID/firmware) then OS installer — **new design**
+- Windows, ESXi, Flatcar as Phase 7 deliverables
 - PXE-required topology
-- Full distro matrix on day one
 - OCR as install progress loop
 
-## Suggested PR split
+## PR history
 
-1. **PR18 (docs):** design v2.0.8 + this plan (this change)
-2. **PR19+:** 7a implementation
-3. Later: 7b, 7c
+1. **PR18:** design v2.0.8 + this plan (initial Phase 7)
+2. **PR19:** 7a implementation + v2.0.9 closeout (image-write preferred)
 
-## Verify (after implementation)
+## Verify
 
 ```bash
-# Unit / lint
 gofmt -l .
 go vet ./...
 staticcheck ./...
 go test ./...
 
-# Lab (shape — exact CLI flags land in 7a PR)
-ansible-playbook -i infra/ansible/inventory/lab-vm.yml \
-  infra/ansible/playbooks/smoke.yml
-# then Phase 7a deploy autoinstall job against a nested guest with a disk
+# Lab E2E shape (see lab-runbook Phase 7a):
+# prepare cloud payload → build marker ISO → deploy run -iso-url … -wait
 ```
 
 ## Done when
 
-Phase 7 section ACs in the design doc are met for the slice under implementation;
-6a and Phase 2 spike paths remain green; Golden Rules §1 intact.
+- **7a:** ACs above met (this closeout).  
+- **7b/7c:** Not required to call Phase 7 “fully product-complete”; tracked via deferred
+  rows + future multi-stage design.  
+- Golden Rules §1 intact; 6a / Phase 2 paths remain green.

--- a/infra/scripts/autoinstall/ubuntu-user-data.yaml.tmpl
+++ b/infra/scripts/autoinstall/ubuntu-user-data.yaml.tmpl
@@ -1,0 +1,78 @@
+#cloud-config
+# Phase 7a Ubuntu autoinstall (non-secret lab template).
+# Placeholders: {{HOSTNAME}} {{PASSWORD_HASH}} {{USERNAME}}
+# SOL markers are written to ttyS0 for Shoal Observe progress.
+autoinstall:
+  version: 1
+  locale: en_US.UTF-8
+  keyboard:
+    layout: us
+  identity:
+    hostname: {{HOSTNAME}}
+    username: {{USERNAME}}
+    password: "{{PASSWORD_HASH}}"
+  ssh:
+    install-server: true
+    allow-pw: true
+  storage:
+    layout:
+      name: direct
+  packages:
+    - openssh-server
+  early-commands:
+    - |
+      /bin/bash -c '
+      emit() {
+        local phase="$1" percent="$2" state="$3" detail="${4:-}"
+        SEQ_FILE=/run/shoal-seq
+        seq=0
+        if [ -f "$SEQ_FILE" ]; then seq=$(cat "$SEQ_FILE"); fi
+        seq=$((seq + 1))
+        echo "$seq" > "$SEQ_FILE"
+        ts=$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo 1970-01-01T00:00:00Z)
+        line="SHOAL|1|${seq}|${ts}|${phase}|${percent}|${state}|${detail}"
+        for d in /dev/ttyS0 /dev/console; do
+          if [ -w "$d" ]; then printf "%s\n" "$line" >"$d" 2>/dev/null || true; fi
+        done
+        printf "%s\n" "$line" || true
+      }
+      emit BOOT 0 OK "ubuntu autoinstall early-commands"
+      emit DISK_PREP 5 OK "storage layout starting"
+      # Background heartbeats while subiquity runs (stall protection for long installs).
+      (
+        while true; do
+          sleep 45
+          emit IMAGE_WRITE - HEARTBEAT "autoinstall in progress"
+        done
+      ) &
+      echo $! > /run/shoal-hb.pid
+      '
+  late-commands:
+    - |
+      /bin/bash -c '
+      emit() {
+        local phase="$1" percent="$2" state="$3" detail="${4:-}"
+        SEQ_FILE=/run/shoal-seq
+        seq=0
+        if [ -f "$SEQ_FILE" ]; then seq=$(cat "$SEQ_FILE"); fi
+        seq=$((seq + 1))
+        echo "$seq" > "$SEQ_FILE"
+        ts=$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo 1970-01-01T00:00:00Z)
+        line="SHOAL|1|${seq}|${ts}|${phase}|${percent}|${state}|${detail}"
+        for d in /dev/ttyS0 /dev/console; do
+          if [ -w "$d" ]; then printf "%s\n" "$line" >"$d" 2>/dev/null || true; fi
+        done
+        printf "%s\n" "$line" || true
+      }
+      if [ -f /run/shoal-hb.pid ]; then kill "$(cat /run/shoal-hb.pid)" 2>/dev/null || true; fi
+      emit IMAGE_WRITE 90 OK "late-commands"
+      emit POSTINSTALL 95 OK "curtin finished"
+      emit VERIFY 98 OK "target root present"
+      # Ensure serial console on installed system for post-boot diagnostics.
+      curtin in-target --target=/target -- bash -c \
+        "grep -q console=ttyS0 /etc/default/grub 2>/dev/null || \
+         sed -i \"s/GRUB_CMDLINE_LINUX=\\\"/GRUB_CMDLINE_LINUX=\\\"console=ttyS0,115200n8 /\" /etc/default/grub; \
+         update-grub 2>/dev/null || true"
+      emit DONE 100 OK "ubuntu autoinstall complete reboot"
+      '
+  shutdown: reboot

--- a/infra/scripts/build-marker-iso.sh
+++ b/infra/scripts/build-marker-iso.sh
@@ -85,14 +85,25 @@ fi
 
 INSTALL_MODE="${SHOAL_INSTALL_MODE:-simulate}"
 case "$INSTALL_MODE" in
-  simulate|write) ;;
+  simulate|write|autoinstall) ;;
   *)
-    echo "error: SHOAL_INSTALL_MODE must be simulate or write (got $INSTALL_MODE)" >&2
+    echo "error: SHOAL_INSTALL_MODE must be simulate|write|autoinstall (got $INSTALL_MODE)" >&2
     exit 1
     ;;
 esac
+# autoinstall is write-to-disk of an OS image payload (Phase 7a cloud image path).
+if [[ "$INSTALL_MODE" == "autoinstall" ]]; then
+  INSTALL_MODE="write"
+  # Prefer reboot into installed OS after write.
+  SHOAL_INSTALL_REBOOT="${SHOAL_INSTALL_REBOOT:-1}"
+  # Prefer first block device for real install.
+  if [[ -z "${SHOAL_INSTALL_TARGET:-}" ]]; then
+    SHOAL_INSTALL_TARGET="/dev/vda"
+  fi
+fi
 # Baked default target for write mode (can be overridden by kernel cmdline shoal.target=).
 INSTALL_TARGET_DEFAULT="${SHOAL_INSTALL_TARGET:-}"
+INSTALL_REBOOT="${SHOAL_INSTALL_REBOOT:-0}"
 
 echo "kernel:  $KERNEL"
 echo "busybox: $BUSYBOX"
@@ -106,15 +117,19 @@ mkdir -p "$ROOT"/{bin,dev,proc,sys,tmp}
 cp "$BUSYBOX" "$ROOT/bin/busybox"
 chmod 755 "$ROOT/bin/busybox"
 # Install common applets used by /init
-for app in sh mount umount mkdir sleep cat echo poweroff reboot mkdir ln dd wc rm sync; do
+for app in sh mount umount mkdir sleep cat echo poweroff reboot mkdir ln dd wc rm sync gunzip zcat gzip; do
   ln -sf busybox "$ROOT/bin/$app"
 done
 
-# Optional payload (Phase 5c text / Phase 6a binary image).
+# Optional payload (Phase 5c text / Phase 6a binary image / Phase 7a OS raw|gz).
 # Prefer SHOAL_PAYLOAD_FILE (path); else SHOAL_EMBEDDED_PAYLOAD (inline text).
 if [[ -n "${SHOAL_PAYLOAD_FILE:-}" && -r "${SHOAL_PAYLOAD_FILE}" ]]; then
   cp "${SHOAL_PAYLOAD_FILE}" "$ROOT/payload"
   chmod 644 "$ROOT/payload"
+  # Preserve gzip marker for init (name ends with .gz or content magic).
+  if [[ "${SHOAL_PAYLOAD_FILE}" == *.gz ]] || gzip -t "$ROOT/payload" 2>/dev/null; then
+    printf '1\n' > "$ROOT/payload_gzip"
+  fi
 elif [[ -n "${SHOAL_EMBEDDED_PAYLOAD:-}" ]]; then
   printf '%s' "${SHOAL_EMBEDDED_PAYLOAD}" > "$ROOT/payload"
   chmod 644 "$ROOT/payload"
@@ -123,6 +138,7 @@ fi
 # Bake install defaults for init (read by the shell script below).
 printf '%s\n' "$INSTALL_MODE" > "$ROOT/install_mode"
 printf '%s\n' "$INSTALL_TARGET_DEFAULT" > "$ROOT/install_target_default"
+printf '%s\n' "$INSTALL_REBOOT" > "$ROOT/install_reboot"
 
 # Init emits markers then powers off. console=ttyS0 from kernel cmdline.
 cat > "$ROOT/init" << 'INIT'
@@ -174,7 +190,13 @@ emit BOOT 0 OK "$boot_detail"
 sleep 1
 emit BOOT - HEARTBEAT ""
 
+REBOOT="0"
+if [ -f /install_reboot ]; then
+  REBOOT="$(cat /install_reboot 2>/dev/null | tr -d '\n' || echo 0)"
+fi
+
 if [ "$MODE" = "write" ] && [ -f /payload ]; then
+  emit DISK_PREP 5 OK "resolving install target"
   # Resolve write target.
   if [ -z "$TARGET" ]; then
     for cand in /dev/vda /dev/sda /dev/nvme0n1; do
@@ -194,40 +216,64 @@ if [ "$MODE" = "write" ] && [ -f /payload ]; then
     while true; do sleep 3600; done
   fi
 
-  emit IMAGE_WRITE 0 OK "write start target=${TARGET} bytes=${total}"
-  # Chunked copy for progress (1 MiB blocks).
-  bs=1048576
-  # shell arithmetic: number of full blocks
-  blocks=$(( total / bs ))
-  rem=$(( total % bs ))
-  written=0
-  i=0
-  while [ "$i" -lt "$blocks" ]; do
-    dd if=/payload of="$TARGET" bs="$bs" count=1 skip="$i" seek="$i" conv=notrunc 2>/dev/null || {
-      emit ERROR 0 ERROR "dd failed at block ${i}"
+  GZIP=0
+  if [ -f /payload_gzip ]; then GZIP=1; fi
+
+  emit IMAGE_WRITE 0 OK "write start target=${TARGET} bytes=${total} gzip=${GZIP}"
+  if [ "$GZIP" = "1" ]; then
+    # Stream-decompress OS image to disk (Phase 7a cloud image path).
+    # Progress heartbeats while gunzip|dd runs (no fine-grained percent).
+    (
+      while true; do
+        sleep 20
+        emit IMAGE_WRITE - HEARTBEAT "gunzip|dd in progress target=${TARGET}"
+      done
+    ) &
+    HBPID=$!
+    if gunzip -c /payload 2>/dev/null | dd of="$TARGET" bs=4M conv=fsync 2>/dev/null; then
+      kill "$HBPID" 2>/dev/null || true
+      emit IMAGE_WRITE 100 OK "gzip write complete target=${TARGET}"
+    else
+      kill "$HBPID" 2>/dev/null || true
+      emit ERROR 0 ERROR "gunzip|dd failed target=${TARGET}"
       sleep 2
       /bin/busybox poweroff -f 2>/dev/null || true
       while true; do sleep 3600; done
-    }
-    written=$(( written + bs ))
-    pct=$(( written * 100 / total ))
-    if [ "$pct" -gt 99 ]; then pct=99; fi
-    emit IMAGE_WRITE "$pct" OK "wrote ${written}/${total}"
-    i=$(( i + 1 ))
-  done
-  if [ "$rem" -gt 0 ]; then
-    dd if=/payload of="$TARGET" bs=1 count="$rem" skip="$written" seek="$written" conv=notrunc 2>/dev/null || {
-      emit ERROR 0 ERROR "dd failed on remainder"
-      sleep 2
-      /bin/busybox poweroff -f 2>/dev/null || true
-      while true; do sleep 3600; done
-    }
-    written=$(( written + rem ))
+    fi
+  else
+    # Chunked copy for progress (1 MiB blocks).
+    bs=1048576
+    blocks=$(( total / bs ))
+    rem=$(( total % bs ))
+    written=0
+    i=0
+    while [ "$i" -lt "$blocks" ]; do
+      dd if=/payload of="$TARGET" bs="$bs" count=1 skip="$i" seek="$i" conv=notrunc 2>/dev/null || {
+        emit ERROR 0 ERROR "dd failed at block ${i}"
+        sleep 2
+        /bin/busybox poweroff -f 2>/dev/null || true
+        while true; do sleep 3600; done
+      }
+      written=$(( written + bs ))
+      pct=$(( written * 100 / total ))
+      if [ "$pct" -gt 99 ]; then pct=99; fi
+      emit IMAGE_WRITE "$pct" OK "wrote ${written}/${total}"
+      i=$(( i + 1 ))
+    done
+    if [ "$rem" -gt 0 ]; then
+      dd if=/payload of="$TARGET" bs=1 count="$rem" skip="$written" seek="$written" conv=notrunc 2>/dev/null || {
+        emit ERROR 0 ERROR "dd failed on remainder"
+        sleep 2
+        /bin/busybox poweroff -f 2>/dev/null || true
+        while true; do sleep 3600; done
+      }
+      written=$(( written + rem ))
+    fi
+    emit IMAGE_WRITE 100 OK "write complete target=${TARGET}"
   fi
   sync 2>/dev/null || true
-  emit IMAGE_WRITE 100 OK "write complete target=${TARGET}"
-  # Verify size on target when it is a regular file.
-  if [ -f "$TARGET" ]; then
+  # Verify size on target when it is a regular file (not for gzip→block).
+  if [ -f "$TARGET" ] && [ "$GZIP" != "1" ]; then
     tsz="$(wc -c <"$TARGET" 2>/dev/null || echo 0)"
     if [ "$tsz" = "$total" ]; then
       emit VERIFY 100 OK "size match bytes=${total}"
@@ -240,6 +286,7 @@ if [ "$MODE" = "write" ] && [ -f /payload ]; then
   else
     emit VERIFY 100 OK "write finished target=${TARGET}"
   fi
+  emit POSTINSTALL 100 OK "payload installed"
   emit DONE 100 OK "install write complete"
 else
   # Phase-2 demonstration sequence (no real disk write).
@@ -256,7 +303,13 @@ else
 fi
 
 sleep 1
-/bin/busybox poweroff -f 2>/dev/null || /bin/busybox reboot -f 2>/dev/null || true
+if [ "${REBOOT:-0}" = "1" ]; then
+  emit BOOT 100 OK "rebooting into installed system"
+  sleep 1
+  /bin/busybox reboot -f 2>/dev/null || /bin/busybox poweroff -f 2>/dev/null || true
+else
+  /bin/busybox poweroff -f 2>/dev/null || /bin/busybox reboot -f 2>/dev/null || true
+fi
 while true; do sleep 3600; done
 INIT
 chmod 755 "$ROOT/init"

--- a/infra/scripts/build-marker-iso.sh
+++ b/infra/scripts/build-marker-iso.sh
@@ -36,11 +36,19 @@ trap cleanup EXIT
 
 KERNEL="${SHOAL_KERNEL:-}"
 if [[ -z "$KERNEL" ]]; then
+  # Prefer the running kernel image so packed modules (uname -r) match.
+  # /boot/vmlinuz often points at a newer uname-mismatched install and yields
+  # "invalid module format" when insmod'ing isofs/ahci from /lib/modules/$(uname -r).
+  run_kver="$(uname -r 2>/dev/null || true)"
+  if [[ -n "$run_kver" && -r "/boot/vmlinuz-${run_kver}" ]]; then
+    KERNEL="/boot/vmlinuz-${run_kver}"
+  fi
+fi
+if [[ -z "$KERNEL" ]]; then
   for k in /boot/vmlinuz /boot/vmlinuz-linux /boot/vmlinuz-generic; do
     if [[ -r "$k" ]]; then KERNEL="$k"; break; fi
   done
   if [[ -z "$KERNEL" ]]; then
-    # Prefer versioned kernels
     KERNEL="$(ls -1 /boot/vmlinuz-* 2>/dev/null | tail -1 || true)"
   fi
 fi
@@ -48,6 +56,8 @@ if [[ -z "$KERNEL" || ! -r "$KERNEL" ]]; then
   echo "error: no readable kernel; set SHOAL_KERNEL=/boot/vmlinuz-..." >&2
   exit 1
 fi
+# Resolve symlinks for logging / version checks.
+KERNEL="$(readlink -f "$KERNEL" 2>/dev/null || echo "$KERNEL")"
 
 BUSYBOX="$(command -v busybox || true)"
 if [[ -z "$BUSYBOX" ]]; then
@@ -112,23 +122,112 @@ echo "output:  $OUT"
 
 # --- initramfs rootfs ---
 ROOT="$WORK/rootfs"
-mkdir -p "$ROOT"/{bin,dev,proc,sys,tmp}
+mkdir -p "$ROOT"/{bin,dev,proc,sys,tmp,mnt}
 
 cp "$BUSYBOX" "$ROOT/bin/busybox"
 chmod 755 "$ROOT/bin/busybox"
 # Install common applets used by /init
-for app in sh mount umount mkdir sleep cat echo poweroff reboot mkdir ln dd wc rm sync gunzip zcat gzip; do
+for app in sh mount umount mkdir sleep cat echo poweroff reboot mkdir ln dd wc rm sync gunzip zcat gzip \
+  insmod modprobe lsmod mdev; do
   ln -sf busybox "$ROOT/bin/$app"
 done
 
+# Kernel modules needed when payload lives on the ISO (SATA CD + isofs + virtio disk).
+# Host kernel modules: nested lab boots the L1 /boot/vmlinuz; without these, /init
+# cannot mount the install CD or see /dev/vda.
+pack_modules() {
+  local kver
+  kver="$(uname -r)"
+  local modroot="/lib/modules/${kver}"
+  if [[ ! -d "$modroot" ]]; then
+    echo "warn: no $modroot — skipping module pack (CD mount may fail)" >&2
+    return 0
+  fi
+  mkdir -p "$ROOT/lib/modules/${kver}"
+  # Resolve dependencies for modules we need (ignore builtins / missing).
+  local needed=()
+  local m dep line
+  for m in ahci libahci isofs virtio_blk virtio_pci virtio_ring virtio; do
+    if [[ -n "$(modinfo -n "$m" 2>/dev/null || true)" ]]; then
+      needed+=("$m")
+    fi
+  done
+  # Collect unique module files via modprobe --show-depends
+  local files=()
+  for m in "${needed[@]}"; do
+    while IFS= read -r line; do
+      case "$line" in
+        insmod\ *)
+          dep="${line#insmod }"
+          dep="${dep%% *}"
+          if [[ -f "$dep" ]]; then
+            files+=("$dep")
+          fi
+          ;;
+      esac
+    done < <(modprobe --show-depends "$m" 2>/dev/null || true)
+  done
+  # Dedup and copy preserving relative path under /lib/modules/$kver
+  local f rel dest
+  declare -A seen=()
+  for f in "${files[@]}"; do
+    [[ -n "${seen[$f]:-}" ]] && continue
+    seen[$f]=1
+    rel="${f#/lib/modules/${kver}/}"
+    if [[ "$rel" == "$f" ]]; then
+      # unexpected path — copy by basename
+      dest="$ROOT/lib/modules/${kver}/$(basename "$f")"
+    else
+      dest="$ROOT/lib/modules/${kver}/${rel}"
+    fi
+    mkdir -p "$(dirname "$dest")"
+    cp -a "$f" "$dest"
+    echo "module: $rel"
+  done
+  if command -v depmod >/dev/null 2>&1; then
+    depmod -b "$ROOT" "$kver" 2>/dev/null || true
+  fi
+  # Marker for init
+  printf '%s\n' "$kver" > "$ROOT/kver"
+  echo "packed modules for kernel $kver (${#seen[@]} files)"
+}
+pack_modules
+
 # Optional payload (Phase 5c text / Phase 6a binary image / Phase 7a OS raw|gz).
 # Prefer SHOAL_PAYLOAD_FILE (path); else SHOAL_EMBEDDED_PAYLOAD (inline text).
+#
+# Large payloads MUST NOT go into the initrd: a ~680MB cloud image initrd OOMs /
+# hangs nested 2GiB VMs (kernel must decompress the whole initramfs into RAM).
+# Threshold: embed in initrd only if <= SHOAL_PAYLOAD_INITRD_MAX (default 4MiB);
+# otherwise place on the ISO root and have /init mount the CDROM to stream it.
+PAYLOAD_INITRD_MAX="${SHOAL_PAYLOAD_INITRD_MAX:-4194304}"
+ISO_PAYLOAD_SRC=""   # host path to copy onto ISO (empty = none / already in initrd)
+ISO_PAYLOAD_NAME=""  # name on ISO: payload or payload.gz
+PAYLOAD_IS_GZIP=0
+
 if [[ -n "${SHOAL_PAYLOAD_FILE:-}" && -r "${SHOAL_PAYLOAD_FILE}" ]]; then
-  cp "${SHOAL_PAYLOAD_FILE}" "$ROOT/payload"
-  chmod 644 "$ROOT/payload"
-  # Preserve gzip marker for init (name ends with .gz or content magic).
-  if [[ "${SHOAL_PAYLOAD_FILE}" == *.gz ]] || gzip -t "$ROOT/payload" 2>/dev/null; then
-    printf '1\n' > "$ROOT/payload_gzip"
+  psz="$(wc -c <"${SHOAL_PAYLOAD_FILE}" | tr -d ' ')"
+  if [[ "${SHOAL_PAYLOAD_FILE}" == *.gz ]] || gzip -t "${SHOAL_PAYLOAD_FILE}" 2>/dev/null; then
+    PAYLOAD_IS_GZIP=1
+  fi
+  if [[ "$psz" -le "$PAYLOAD_INITRD_MAX" ]]; then
+    cp "${SHOAL_PAYLOAD_FILE}" "$ROOT/payload"
+    chmod 644 "$ROOT/payload"
+    if [[ "$PAYLOAD_IS_GZIP" -eq 1 ]]; then
+      printf '1\n' > "$ROOT/payload_gzip"
+    fi
+    echo "payload: embedded in initrd ($psz bytes gzip=${PAYLOAD_IS_GZIP})"
+  else
+    ISO_PAYLOAD_SRC="${SHOAL_PAYLOAD_FILE}"
+    if [[ "$PAYLOAD_IS_GZIP" -eq 1 ]]; then
+      ISO_PAYLOAD_NAME="payload.gz"
+      printf '1\n' > "$ROOT/payload_on_iso_gzip"
+    else
+      ISO_PAYLOAD_NAME="payload"
+      printf '0\n' > "$ROOT/payload_on_iso_gzip"
+    fi
+    printf '%s\n' "$ISO_PAYLOAD_NAME" > "$ROOT/payload_on_iso"
+    echo "payload: on ISO as /${ISO_PAYLOAD_NAME} ($psz bytes gzip=${PAYLOAD_IS_GZIP}) — not in initrd"
   fi
 elif [[ -n "${SHOAL_EMBEDDED_PAYLOAD:-}" ]]; then
   printf '%s' "${SHOAL_EMBEDDED_PAYLOAD}" > "$ROOT/payload"
@@ -157,6 +256,38 @@ for dev in /dev/ttyS0 /dev/console /dev/tty0; do
   fi
 done
 
+# Load modules for SATA CD (ahci), ISO9660, and virtio disk (payload + /dev/vda).
+load_mods() {
+  KVER=""
+  if [ -f /kver ]; then KVER="$(cat /kver 2>/dev/null | tr -d '\n')"; fi
+  if [ -z "$KVER" ]; then KVER="$(uname -r 2>/dev/null || true)"; fi
+  BASE="/lib/modules/$KVER"
+  if [ -n "$KVER" ] && [ -d "$BASE" ]; then
+    # Explicit paths (order matters). Suppress "File exists" if already loaded.
+    for ko in \
+      "$BASE/kernel/drivers/block/virtio_blk.ko" \
+      "$BASE/kernel/drivers/ata/libahci.ko" \
+      "$BASE/kernel/drivers/ata/ahci.ko" \
+      "$BASE/kernel/fs/isofs/isofs.ko"
+    do
+      if [ -f "$ko" ]; then
+        insmod "$ko" 2>/dev/null || true
+      fi
+    done
+    # Catch any remaining .ko we packed
+    for ko in "$BASE"/kernel/*/*.ko "$BASE"/kernel/*/*/*.ko "$BASE"/kernel/*/*/*/*.ko; do
+      [ -f "$ko" ] || continue
+      insmod "$ko" 2>/dev/null || true
+    done
+    modprobe isofs 2>/dev/null || true
+    modprobe ahci 2>/dev/null || true
+    modprobe virtio_blk 2>/dev/null || true
+  fi
+  mdev -s 2>/dev/null || true
+  sleep 2
+}
+load_mods
+
 seq=0
 emit() {
   phase="$1"; percent="$2"; state="$3"; detail="${4:-}"
@@ -181,10 +312,106 @@ for x in $(cat /proc/cmdline 2>/dev/null); do
   esac
 done
 
-boot_detail="marker live image started mode=${MODE}"
+# Resolve payload path: small embeds live at /payload; large OS images live on the CD.
+PAYLOAD=""
+GZIP=0
+CD_MOUNTED=0
+list_block_devs() {
+  # Compact list for marker detail (max ~120 chars).
+  out=""
+  for d in /sys/block/*; do
+    [ -e "$d" ] || continue
+    n="${d##*/}"
+    case "$n" in
+      loop*|ram*|fd*) continue ;;
+    esac
+    out="${out}${n} "
+  done
+  for d in /dev/sr* /dev/cdrom /dev/vd* /dev/sd* /dev/hd*; do
+    [ -e "$d" ] || [ -b "$d" ] || continue
+    out="${out}${d##*/} "
+  done
+  echo "$out"
+}
+
+mount_cd() {
+  mkdir -p /mnt/cd
+  # Retry: modules/device nodes can appear slightly after boot.
+  attempt=0
+  while [ "$attempt" -lt 8 ]; do
+    mdev -s 2>/dev/null || true
+    # Re-try isofs each round
+    if [ -f /kver ]; then
+      k="$(cat /kver 2>/dev/null | tr -d '\n')"
+      insmod "/lib/modules/$k/kernel/fs/isofs/isofs.ko" 2>/dev/null || true
+      insmod "/lib/modules/$k/kernel/drivers/ata/libahci.ko" 2>/dev/null || true
+      insmod "/lib/modules/$k/kernel/drivers/ata/ahci.ko" 2>/dev/null || true
+      insmod "/lib/modules/$k/kernel/drivers/block/virtio_blk.ko" 2>/dev/null || true
+    fi
+    for dev in /dev/sr0 /dev/sr1 /dev/cdrom /dev/hdc /dev/hdb /dev/hda /dev/scd0 /dev/sdb /dev/sdc /dev/sda; do
+      if [ -b "$dev" ] || [ -e "$dev" ]; then
+        if mount -t iso9660 -o ro "$dev" /mnt/cd 2>/dev/null; then
+          CD_MOUNTED=1
+          return 0
+        fi
+        if mount -o ro "$dev" /mnt/cd 2>/dev/null; then
+          CD_MOUNTED=1
+          return 0
+        fi
+      fi
+    done
+    for dev in /dev/sr* /dev/vd* /dev/sd*; do
+      if [ -b "$dev" ]; then
+        if mount -t iso9660 -o ro "$dev" /mnt/cd 2>/dev/null; then
+          CD_MOUNTED=1
+          return 0
+        fi
+      fi
+    done
+    attempt=$((attempt + 1))
+    sleep 1
+  done
+  return 1
+}
+
 if [ -f /payload ]; then
-  psz="$(wc -c </payload 2>/dev/null || echo 0)"
-  boot_detail="marker live image started mode=${MODE} payload_bytes=${psz}"
+  PAYLOAD=/payload
+  if [ -f /payload_gzip ]; then GZIP=1; fi
+elif [ -f /payload_on_iso ]; then
+  pname="$(cat /payload_on_iso 2>/dev/null | tr -d '\n')"
+  [ -n "$pname" ] || pname=payload.gz
+  emit BOOT 0 OK "mounting install media for payload=${pname}"
+  if mount_cd; then
+    if [ -f "/mnt/cd/${pname}" ]; then
+      PAYLOAD="/mnt/cd/${pname}"
+    elif [ -f /mnt/cd/payload.gz ]; then
+      PAYLOAD=/mnt/cd/payload.gz
+    elif [ -f /mnt/cd/payload ]; then
+      PAYLOAD=/mnt/cd/payload
+    fi
+    if [ -f /payload_on_iso_gzip ]; then
+      GZIP="$(cat /payload_on_iso_gzip 2>/dev/null | tr -d '\n' || echo 0)"
+    fi
+    case "$PAYLOAD" in
+      *.gz) GZIP=1 ;;
+    esac
+  else
+    devs="$(list_block_devs)"
+    merr=""
+    if [ -b /dev/sr0 ]; then
+      merr="$(mount -t iso9660 -o ro /dev/sr0 /mnt/cd 2>&1 || true)"
+    fi
+    k="$(cat /kver 2>/dev/null | tr -d '\n')"
+    imsg="$(insmod "/lib/modules/$k/kernel/fs/isofs/isofs.ko" 2>&1 || true)"
+    # Keep detail short for SOL marker line length.
+    emit ERROR 0 ERROR "cd mount fail devs=${devs} merr=${merr} insmod=${imsg}"
+  fi
+fi
+
+boot_detail="marker live image started mode=${MODE}"
+if [ -n "$PAYLOAD" ] && [ -f "$PAYLOAD" ]; then
+  psz="$(wc -c <"$PAYLOAD" 2>/dev/null || echo 0)"
+  boot_detail="marker live image started mode=${MODE} payload_bytes=${psz} gzip=${GZIP}"
 fi
 emit BOOT 0 OK "$boot_detail"
 sleep 1
@@ -195,7 +422,7 @@ if [ -f /install_reboot ]; then
   REBOOT="$(cat /install_reboot 2>/dev/null | tr -d '\n' || echo 0)"
 fi
 
-if [ "$MODE" = "write" ] && [ -f /payload ]; then
+if [ "$MODE" = "write" ] && [ -n "$PAYLOAD" ] && [ -f "$PAYLOAD" ]; then
   emit DISK_PREP 5 OK "resolving install target"
   # Resolve write target.
   if [ -z "$TARGET" ]; then
@@ -208,7 +435,7 @@ if [ "$MODE" = "write" ] && [ -f /payload ]; then
     emit IMAGE_WRITE 0 OK "no block device; using file target ${TARGET}"
   fi
 
-  total="$(wc -c </payload 2>/dev/null || echo 0)"
+  total="$(wc -c <"$PAYLOAD" 2>/dev/null || echo 0)"
   if [ -z "$total" ] || [ "$total" = "0" ]; then
     emit ERROR 0 ERROR "empty payload"
     sleep 2
@@ -216,10 +443,7 @@ if [ "$MODE" = "write" ] && [ -f /payload ]; then
     while true; do sleep 3600; done
   fi
 
-  GZIP=0
-  if [ -f /payload_gzip ]; then GZIP=1; fi
-
-  emit IMAGE_WRITE 0 OK "write start target=${TARGET} bytes=${total} gzip=${GZIP}"
+  emit IMAGE_WRITE 0 OK "write start target=${TARGET} bytes=${total} gzip=${GZIP} src=${PAYLOAD}"
   if [ "$GZIP" = "1" ]; then
     # Stream-decompress OS image to disk (Phase 7a cloud image path).
     # Progress heartbeats while gunzip|dd runs (no fine-grained percent).
@@ -230,7 +454,7 @@ if [ "$MODE" = "write" ] && [ -f /payload ]; then
       done
     ) &
     HBPID=$!
-    if gunzip -c /payload 2>/dev/null | dd of="$TARGET" bs=4M conv=fsync 2>/dev/null; then
+    if gunzip -c "$PAYLOAD" 2>/dev/null | dd of="$TARGET" bs=4M conv=fsync 2>/dev/null; then
       kill "$HBPID" 2>/dev/null || true
       emit IMAGE_WRITE 100 OK "gzip write complete target=${TARGET}"
     else
@@ -248,7 +472,7 @@ if [ "$MODE" = "write" ] && [ -f /payload ]; then
     written=0
     i=0
     while [ "$i" -lt "$blocks" ]; do
-      dd if=/payload of="$TARGET" bs="$bs" count=1 skip="$i" seek="$i" conv=notrunc 2>/dev/null || {
+      dd if="$PAYLOAD" of="$TARGET" bs="$bs" count=1 skip="$i" seek="$i" conv=notrunc 2>/dev/null || {
         emit ERROR 0 ERROR "dd failed at block ${i}"
         sleep 2
         /bin/busybox poweroff -f 2>/dev/null || true
@@ -261,7 +485,7 @@ if [ "$MODE" = "write" ] && [ -f /payload ]; then
       i=$(( i + 1 ))
     done
     if [ "$rem" -gt 0 ]; then
-      dd if=/payload of="$TARGET" bs=1 count="$rem" skip="$written" seek="$written" conv=notrunc 2>/dev/null || {
+      dd if="$PAYLOAD" of="$TARGET" bs=1 count="$rem" skip="$written" seek="$written" conv=notrunc 2>/dev/null || {
         emit ERROR 0 ERROR "dd failed on remainder"
         sleep 2
         /bin/busybox poweroff -f 2>/dev/null || true
@@ -330,6 +554,12 @@ cp "$ISOLINUX_BIN" "$ISO/boot/isolinux/isolinux.bin"
 if [[ -n "$LDLINUX" ]]; then
   cp "$LDLINUX" "$ISO/boot/isolinux/ldlinux.c32"
 fi
+# Large OS payload on ISO root (streamed from CD by /init — not in initrd).
+if [[ -n "$ISO_PAYLOAD_SRC" && -n "$ISO_PAYLOAD_NAME" ]]; then
+  cp "$ISO_PAYLOAD_SRC" "$ISO/$ISO_PAYLOAD_NAME"
+  chmod 644 "$ISO/$ISO_PAYLOAD_NAME"
+  echo "iso payload: $ISO/$ISO_PAYLOAD_NAME"
+fi
 
 # Pass mode/target on kernel cmdline for runtime override.
 CMDLINE="initrd=/boot/initrd.img console=ttyS0,115200n8 console=tty0 quiet shoal.mode=${INSTALL_MODE}"
@@ -352,10 +582,12 @@ if [[ "$INSTALL_MODE" = "write" ]]; then
 fi
 
 mkdir -p "$(dirname "$OUT")"
+# -R/-J so payload.gz keeps its name when mounted (not ISO9660 PAYLOAD.GZ;1).
 xorriso -as mkisofs \
   -quiet \
   -o "$OUT" \
   -V "$VOLID" \
+  -R -J \
   -b boot/isolinux/isolinux.bin \
   -c boot/isolinux/boot.cat \
   -no-emul-boot \

--- a/infra/scripts/build-ubuntu-autoinstall-iso.sh
+++ b/infra/scripts/build-ubuntu-autoinstall-iso.sh
@@ -2,24 +2,18 @@
 # build-ubuntu-autoinstall-iso.sh — remaster an official Ubuntu Server live ISO
 # with cloud-init autoinstall (nocloud) and SHOAL|… SOL markers (Phase 7a).
 #
-# Requirements: xorriso, openssl, find, sed.
+# Strategy: keep the original hybrid El Torito + MBR/GPT boot path via
+#   xorriso -boot_image any replay
+# and only inject /nocloud + patch GRUB/isolinux configs in-place on a copy.
+# Full extract+mkisofs rebuild drops Ubuntu's UEFI/hybrid boot and often fails
+# under sushy/libvirt.
+#
+# Requirements: xorriso, openssl, python3, find, sed, cp.
 # Source ISO: official Ubuntu Server live-server amd64 (22.04+ recommended).
 #
 # Usage:
 #   SHOAL_UBUNTU_ISO=/path/to/ubuntu-22.04.5-live-server-amd64.iso \
 #     ./infra/scripts/build-ubuntu-autoinstall-iso.sh [/out/shoal-ubuntu-autoinstall.iso]
-#
-# Env:
-#   SHOAL_UBUNTU_ISO              Required path to base Ubuntu Server ISO
-#   SHOAL_ISO_OUT / $1            Output path (default ./shoal-ubuntu-autoinstall.iso)
-#   SHOAL_ISO_NAME                Basename override
-#   SHOAL_AUTOINSTALL_HOSTNAME    default shoal-node
-#   SHOAL_AUTOINSTALL_USERNAME    default shoal
-#   SHOAL_AUTOINSTALL_PASSWORD    lab-only default (hashed at build; not for production)
-#   SHOAL_AUTOINSTALL_TEMPLATE    optional path to user-data template
-#
-# Lab note: nested guests need a disk (lab nodes: 20G qcow2) and ≥2 GiB RAM.
-# Raise SOL stall timeouts for full installs (e.g. 45m).
 set -euo pipefail
 
 OUT="${1:-${SHOAL_ISO_OUT:-./shoal-ubuntu-autoinstall.iso}}"
@@ -33,7 +27,7 @@ if [[ -z "$SRC" || ! -r "$SRC" ]]; then
   cat >&2 <<'EOF'
 error: set SHOAL_UBUNTU_ISO to a readable official Ubuntu Server live-server ISO.
 
-Example (download once to the lab host):
+Example:
   wget -O /var/tmp/ubuntu-22.04.5-live-server-amd64.iso \
     https://releases.ubuntu.com/22.04/ubuntu-22.04.5-live-server-amd64.iso
   export SHOAL_UBUNTU_ISO=/var/tmp/ubuntu-22.04.5-live-server-amd64.iso
@@ -41,7 +35,7 @@ EOF
   exit 1
 fi
 
-for need in xorriso openssl find sed; do
+for need in xorriso openssl python3 find sed cp; do
   if ! command -v "$need" >/dev/null 2>&1; then
     echo "error: $need required" >&2
     exit 1
@@ -69,14 +63,7 @@ echo "hostname: $HOSTNAME"
 echo "user:     $USERNAME"
 echo "output:   $OUT"
 
-ISO_TREE="$WORK/iso"
-mkdir -p "$ISO_TREE"
-
-echo "extracting base ISO..."
-xorriso -osirrox on -indev "$SRC" -extract / "$ISO_TREE"
-chmod -R u+w "$ISO_TREE" 2>/dev/null || true
-
-NOCLOUD="$ISO_TREE/nocloud"
+NOCLOUD="$WORK/nocloud"
 mkdir -p "$NOCLOUD"
 
 # Render user-data without sed '$' backref issues (password hashes contain $).
@@ -92,85 +79,112 @@ PY
 printf 'instance-id: shoal-autoinstall\nlocal-hostname: %s\n' "$HOSTNAME" > "$NOCLOUD/meta-data"
 chmod -R a+rX "$NOCLOUD"
 
+# Extract boot configs to patch, then feed them back with -update.
+CFG_DIR="$WORK/cfgs"
+mkdir -p "$CFG_DIR"
+# List interesting paths in the source ISO.
+mapfile -t CFG_PATHS < <(
+  xorriso -indev "$SRC" -find / -name grub.cfg -or -name txt.cfg -or -name isolinux.cfg -or -name loopback.cfg 2>/dev/null \
+    | sed -n 's/^.*'\''\(\/.*\)'\''$/\1/p' || true
+)
+# Fallback known paths if find parsing fails.
+if [[ ${#CFG_PATHS[@]} -eq 0 ]]; then
+  CFG_PATHS=(
+    /boot/grub/grub.cfg
+    /boot/grub/loopback.cfg
+    /isolinux/txt.cfg
+    /isolinux/isolinux.cfg
+  )
+fi
+
 patch_autoinstall_cmdline() {
   local f="$1"
   [[ -f "$f" ]] || return 0
-  if grep -q 'autoinstall' "$f" 2>/dev/null; then
-    # Still ensure serial console.
-    if ! grep -q 'console=ttyS0' "$f" 2>/dev/null; then
-      sed -i -E 's|(linux(efi)?[[:space:]]+/casper/vmlinuz[^[:space:]]*)|\1 console=ttyS0,115200n8|g' "$f" || true
-    fi
-    return 0
+  # Ensure autoinstall nocloud + serial on casper kernel lines.
+  if ! grep -q 'autoinstall' "$f" 2>/dev/null; then
+    sed -i -E \
+      's|(linux(efi)?[[:space:]]+/casper/vmlinuz[^[:space:]]*)|\1 autoinstall ds=nocloud\;s=/cdrom/nocloud/ console=ttyS0,115200n8|g' \
+      "$f" || true
   fi
-  # Append autoinstall nocloud datasource + serial console to casper kernel lines.
-  sed -i -E \
-    's|(linux(efi)?[[:space:]]+/casper/vmlinuz[^[:space:]]*)|\1 autoinstall ds=nocloud\;s=/cdrom/nocloud/ console=ttyS0,115200n8|g' \
-    "$f" || true
+  if ! grep -q 'console=ttyS0' "$f" 2>/dev/null; then
+    sed -i -E \
+      's|(linux(efi)?[[:space:]]+/casper/vmlinuz[^[:space:]]*)|\1 console=ttyS0,115200n8|g' \
+      "$f" || true
+  fi
+  # Unattended: no 30s GRUB pause; default first entry; talk on serial for SOL.
+  if grep -q 'set timeout=' "$f" 2>/dev/null; then
+    sed -i -E 's/^set timeout=.*/set timeout=0/' "$f" || true
+  else
+    # Prepend timeout if file is a main grub.cfg
+    if grep -q 'menuentry' "$f" 2>/dev/null; then
+      sed -i '1iset timeout=0\nset default=0' "$f" || true
+    fi
+  fi
+  if grep -q 'menuentry' "$f" 2>/dev/null && ! grep -q 'serial --unit=0' "$f" 2>/dev/null; then
+    sed -i '1iserial --unit=0 --speed=115200\nterminal_input serial console\nterminal_output serial console' "$f" || true
+  fi
 }
 
-while IFS= read -r -d '' cfg; do
-  patch_autoinstall_cmdline "$cfg"
-done < <(find "$ISO_TREE" \( -name 'grub.cfg' -o -name 'txt.cfg' -o -name 'isolinux.cfg' -o -name 'loopback.cfg' \) -print0 2>/dev/null)
+UPDATE_ARGS=()
+for p in "${CFG_PATHS[@]}"; do
+  # Normalize path
+  p="/${p#/}"
+  local_name="$CFG_DIR/$(echo "$p" | tr '/' '_')"
+  if xorriso -osirrox on -indev "$SRC" -extract "$p" "$local_name" >/dev/null 2>&1; then
+    patch_autoinstall_cmdline "$local_name"
+    UPDATE_ARGS+=(-update "$local_name" "$p")
+    echo "patched $p"
+  fi
+done
 
-if ! grep -Rqs 'autoinstall' "$ISO_TREE" --include='*.cfg' 2>/dev/null; then
-  echo "warning: boot configs lacked casper lines; appending GRUB menuentry" >&2
-  for g in "$ISO_TREE/boot/grub/grub.cfg" "$ISO_TREE/EFI/boot/grub.cfg"; do
-    if [[ -f "$g" ]]; then
-      cat >> "$g" <<'GRUB'
+# If no casper lines were patched, append a GRUB menuentry file and source it
+# only when we successfully extracted grub.cfg.
+if [[ -f "$CFG_DIR/_boot_grub_grub.cfg" ]] && ! grep -q 'autoinstall' "$CFG_DIR/_boot_grub_grub.cfg" 2>/dev/null; then
+  cat >> "$CFG_DIR/_boot_grub_grub.cfg" <<'GRUB'
 
-# Shoal Phase 7a autoinstall entry
+# Shoal Phase 7a autoinstall entry (fallback)
 menuentry "Shoal Ubuntu Autoinstall" {
     set gfxpayload=keep
     linux   /casper/vmlinuz autoinstall ds=nocloud\;s=/cdrom/nocloud/ console=ttyS0,115200n8 ---
     initrd  /casper/initrd
 }
 GRUB
-      break
-    fi
-  done
+  echo "appended fallback GRUB menuentry"
 fi
 
 mkdir -p "$(dirname "$OUT")"
+rm -f "$OUT"
 
-BOOT_IMG=""
-for cand in \
-  "$ISO_TREE/boot/grub/i386-pc/eltorito.img" \
-  "$ISO_TREE/isolinux/isolinux.bin" \
-  "$ISO_TREE/boot/isolinux/isolinux.bin"
-do
-  if [[ -f "$cand" ]]; then BOOT_IMG="${cand#"$ISO_TREE"/}"; break; fi
-done
-
-EFI_IMG=""
-found="$(find "$ISO_TREE" -name 'efi.img' 2>/dev/null | head -1 || true)"
-if [[ -n "$found" ]]; then
-  EFI_IMG="${found#"$ISO_TREE"/}"
+echo "repacking ISO (preserve original boot)..."
+# -boot_image any replay keeps El Torito + hybrid MBR/GPT from the source.
+# -map injects nocloud; -update replaces patched boot configs.
+# Note: avoid -chmod modes that trigger xorriso SORRY (non-zero exit confuses callers).
+set +e
+xorriso \
+  -indev "$SRC" \
+  -outdev "$OUT" \
+  -boot_image any replay \
+  -map "$NOCLOUD" /nocloud \
+  "${UPDATE_ARGS[@]+"${UPDATE_ARGS[@]}"}" \
+  -commit
+xr=$?
+set -e
+if [[ ! -s "$OUT" ]]; then
+  echo "error: xorriso failed to produce $OUT (exit $xr)" >&2
+  exit 1
 fi
-
-echo "repacking ISO..."
-XORRISO_ARGS=(
-  -as mkisofs
-  -r -V "SHOAL_UBUNTU_AI"
-  -o "$OUT"
-  -J -joliet-long
-  -l
-)
-if [[ -n "$BOOT_IMG" && -f "$ISO_TREE/$BOOT_IMG" ]]; then
-  if [[ "$BOOT_IMG" == *isolinux* ]]; then
-    XORRISO_ARGS+=(-b "$BOOT_IMG" -c boot.catalog -no-emul-boot -boot-load-size 4 -boot-info-table)
-  else
-    XORRISO_ARGS+=(-b "$BOOT_IMG" -no-emul-boot -boot-load-size 4 -boot-info-table)
-  fi
+# xorriso may return 32 (SORRY) for non-fatal warnings; accept if ISO looks hybrid/bootable.
+if [[ "$xr" -ne 0 && "$xr" -ne 32 ]]; then
+  echo "error: xorriso exit $xr" >&2
+  exit "$xr"
 fi
-if [[ -n "$EFI_IMG" && -f "$ISO_TREE/$EFI_IMG" ]]; then
-  XORRISO_ARGS+=(-eltorito-alt-boot -e "$EFI_IMG" -no-emul-boot -isohybrid-gpt-basdat)
-fi
-XORRISO_ARGS+=("$ISO_TREE")
-
-xorriso "${XORRISO_ARGS[@]}"
 
 chmod 644 "$OUT" 2>/dev/null || true
 SIZE="$(wc -c <"$OUT" | tr -d ' ')"
+
+echo "=== boot report (should show BIOS+UEFI like upstream) ==="
+xorriso -indev "$OUT" -report_el_torito plain 2>&1 | head -25 || true
+
 echo "built $OUT ($SIZE bytes) mode=autoinstall"
 echo "lab login (default): user=${USERNAME} password=<lab default shoal-lab unless overridden>"
 echo "publish: copy to lab ISO dir; BMC URL e.g. http://192.168.124.1:8080/$(basename "$OUT")"

--- a/infra/scripts/build-ubuntu-autoinstall-iso.sh
+++ b/infra/scripts/build-ubuntu-autoinstall-iso.sh
@@ -79,13 +79,16 @@ chmod -R u+w "$ISO_TREE" 2>/dev/null || true
 NOCLOUD="$ISO_TREE/nocloud"
 mkdir -p "$NOCLOUD"
 
-# Escape sed replacement carefully for hash ($ and /).
-esc_hash="$(printf '%s' "$PASSWORD_HASH" | sed -e 's/[&|\\]/\\&/g')"
-sed \
-  -e "s/{{HOSTNAME}}/${HOSTNAME}/g" \
-  -e "s/{{USERNAME}}/${USERNAME}/g" \
-  -e "s|{{PASSWORD_HASH}}|${esc_hash}|g" \
-  "$TEMPLATE" > "$NOCLOUD/user-data"
+# Render user-data without sed '$' backref issues (password hashes contain $).
+python3 - "$TEMPLATE" "$HOSTNAME" "$USERNAME" "$PASSWORD_HASH" "$NOCLOUD/user-data" <<'PY'
+import sys
+tmpl, hostname, username, pw_hash, out = sys.argv[1:6]
+text = open(tmpl, encoding="utf-8").read()
+text = text.replace("{{HOSTNAME}}", hostname)
+text = text.replace("{{USERNAME}}", username)
+text = text.replace("{{PASSWORD_HASH}}", pw_hash)
+open(out, "w", encoding="utf-8").write(text)
+PY
 printf 'instance-id: shoal-autoinstall\nlocal-hostname: %s\n' "$HOSTNAME" > "$NOCLOUD/meta-data"
 chmod -R a+rX "$NOCLOUD"
 

--- a/infra/scripts/build-ubuntu-autoinstall-iso.sh
+++ b/infra/scripts/build-ubuntu-autoinstall-iso.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# build-ubuntu-autoinstall-iso.sh — remaster an official Ubuntu Server live ISO
+# with cloud-init autoinstall (nocloud) and SHOAL|… SOL markers (Phase 7a).
+#
+# Requirements: xorriso, openssl, find, sed.
+# Source ISO: official Ubuntu Server live-server amd64 (22.04+ recommended).
+#
+# Usage:
+#   SHOAL_UBUNTU_ISO=/path/to/ubuntu-22.04.5-live-server-amd64.iso \
+#     ./infra/scripts/build-ubuntu-autoinstall-iso.sh [/out/shoal-ubuntu-autoinstall.iso]
+#
+# Env:
+#   SHOAL_UBUNTU_ISO              Required path to base Ubuntu Server ISO
+#   SHOAL_ISO_OUT / $1            Output path (default ./shoal-ubuntu-autoinstall.iso)
+#   SHOAL_ISO_NAME                Basename override
+#   SHOAL_AUTOINSTALL_HOSTNAME    default shoal-node
+#   SHOAL_AUTOINSTALL_USERNAME    default shoal
+#   SHOAL_AUTOINSTALL_PASSWORD    lab-only default (hashed at build; not for production)
+#   SHOAL_AUTOINSTALL_TEMPLATE    optional path to user-data template
+#
+# Lab note: nested guests need a disk (lab nodes: 20G qcow2) and ≥2 GiB RAM.
+# Raise SOL stall timeouts for full installs (e.g. 45m).
+set -euo pipefail
+
+OUT="${1:-${SHOAL_ISO_OUT:-./shoal-ubuntu-autoinstall.iso}}"
+if [[ -n "${SHOAL_ISO_NAME:-}" ]]; then
+  OUT_DIR="$(dirname "$OUT")"
+  OUT="${OUT_DIR%/}/${SHOAL_ISO_NAME}"
+fi
+
+SRC="${SHOAL_UBUNTU_ISO:-}"
+if [[ -z "$SRC" || ! -r "$SRC" ]]; then
+  cat >&2 <<'EOF'
+error: set SHOAL_UBUNTU_ISO to a readable official Ubuntu Server live-server ISO.
+
+Example (download once to the lab host):
+  wget -O /var/tmp/ubuntu-22.04.5-live-server-amd64.iso \
+    https://releases.ubuntu.com/22.04/ubuntu-22.04.5-live-server-amd64.iso
+  export SHOAL_UBUNTU_ISO=/var/tmp/ubuntu-22.04.5-live-server-amd64.iso
+EOF
+  exit 1
+fi
+
+for need in xorriso openssl find sed; do
+  if ! command -v "$need" >/dev/null 2>&1; then
+    echo "error: $need required" >&2
+    exit 1
+  fi
+done
+
+HOSTNAME="${SHOAL_AUTOINSTALL_HOSTNAME:-shoal-node}"
+USERNAME="${SHOAL_AUTOINSTALL_USERNAME:-shoal}"
+PASSWORD="${SHOAL_AUTOINSTALL_PASSWORD:-shoal-lab}"
+PASSWORD_HASH="$(openssl passwd -6 "$PASSWORD")"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TEMPLATE="${SHOAL_AUTOINSTALL_TEMPLATE:-$SCRIPT_DIR/autoinstall/ubuntu-user-data.yaml.tmpl}"
+if [[ ! -r "$TEMPLATE" ]]; then
+  echo "error: user-data template not found: $TEMPLATE" >&2
+  exit 1
+fi
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/shoal-ubuntu-ai.XXXXXX")"
+cleanup() { rm -rf "$WORK"; }
+trap cleanup EXIT
+
+echo "source:   $SRC"
+echo "hostname: $HOSTNAME"
+echo "user:     $USERNAME"
+echo "output:   $OUT"
+
+ISO_TREE="$WORK/iso"
+mkdir -p "$ISO_TREE"
+
+echo "extracting base ISO..."
+xorriso -osirrox on -indev "$SRC" -extract / "$ISO_TREE"
+chmod -R u+w "$ISO_TREE" 2>/dev/null || true
+
+NOCLOUD="$ISO_TREE/nocloud"
+mkdir -p "$NOCLOUD"
+
+# Escape sed replacement carefully for hash ($ and /).
+esc_hash="$(printf '%s' "$PASSWORD_HASH" | sed -e 's/[&|\\]/\\&/g')"
+sed \
+  -e "s/{{HOSTNAME}}/${HOSTNAME}/g" \
+  -e "s/{{USERNAME}}/${USERNAME}/g" \
+  -e "s|{{PASSWORD_HASH}}|${esc_hash}|g" \
+  "$TEMPLATE" > "$NOCLOUD/user-data"
+printf 'instance-id: shoal-autoinstall\nlocal-hostname: %s\n' "$HOSTNAME" > "$NOCLOUD/meta-data"
+chmod -R a+rX "$NOCLOUD"
+
+patch_autoinstall_cmdline() {
+  local f="$1"
+  [[ -f "$f" ]] || return 0
+  if grep -q 'autoinstall' "$f" 2>/dev/null; then
+    # Still ensure serial console.
+    if ! grep -q 'console=ttyS0' "$f" 2>/dev/null; then
+      sed -i -E 's|(linux(efi)?[[:space:]]+/casper/vmlinuz[^[:space:]]*)|\1 console=ttyS0,115200n8|g' "$f" || true
+    fi
+    return 0
+  fi
+  # Append autoinstall nocloud datasource + serial console to casper kernel lines.
+  sed -i -E \
+    's|(linux(efi)?[[:space:]]+/casper/vmlinuz[^[:space:]]*)|\1 autoinstall ds=nocloud\;s=/cdrom/nocloud/ console=ttyS0,115200n8|g' \
+    "$f" || true
+}
+
+while IFS= read -r -d '' cfg; do
+  patch_autoinstall_cmdline "$cfg"
+done < <(find "$ISO_TREE" \( -name 'grub.cfg' -o -name 'txt.cfg' -o -name 'isolinux.cfg' -o -name 'loopback.cfg' \) -print0 2>/dev/null)
+
+if ! grep -Rqs 'autoinstall' "$ISO_TREE" --include='*.cfg' 2>/dev/null; then
+  echo "warning: boot configs lacked casper lines; appending GRUB menuentry" >&2
+  for g in "$ISO_TREE/boot/grub/grub.cfg" "$ISO_TREE/EFI/boot/grub.cfg"; do
+    if [[ -f "$g" ]]; then
+      cat >> "$g" <<'GRUB'
+
+# Shoal Phase 7a autoinstall entry
+menuentry "Shoal Ubuntu Autoinstall" {
+    set gfxpayload=keep
+    linux   /casper/vmlinuz autoinstall ds=nocloud\;s=/cdrom/nocloud/ console=ttyS0,115200n8 ---
+    initrd  /casper/initrd
+}
+GRUB
+      break
+    fi
+  done
+fi
+
+mkdir -p "$(dirname "$OUT")"
+
+BOOT_IMG=""
+for cand in \
+  "$ISO_TREE/boot/grub/i386-pc/eltorito.img" \
+  "$ISO_TREE/isolinux/isolinux.bin" \
+  "$ISO_TREE/boot/isolinux/isolinux.bin"
+do
+  if [[ -f "$cand" ]]; then BOOT_IMG="${cand#"$ISO_TREE"/}"; break; fi
+done
+
+EFI_IMG=""
+found="$(find "$ISO_TREE" -name 'efi.img' 2>/dev/null | head -1 || true)"
+if [[ -n "$found" ]]; then
+  EFI_IMG="${found#"$ISO_TREE"/}"
+fi
+
+echo "repacking ISO..."
+XORRISO_ARGS=(
+  -as mkisofs
+  -r -V "SHOAL_UBUNTU_AI"
+  -o "$OUT"
+  -J -joliet-long
+  -l
+)
+if [[ -n "$BOOT_IMG" && -f "$ISO_TREE/$BOOT_IMG" ]]; then
+  if [[ "$BOOT_IMG" == *isolinux* ]]; then
+    XORRISO_ARGS+=(-b "$BOOT_IMG" -c boot.catalog -no-emul-boot -boot-load-size 4 -boot-info-table)
+  else
+    XORRISO_ARGS+=(-b "$BOOT_IMG" -no-emul-boot -boot-load-size 4 -boot-info-table)
+  fi
+fi
+if [[ -n "$EFI_IMG" && -f "$ISO_TREE/$EFI_IMG" ]]; then
+  XORRISO_ARGS+=(-eltorito-alt-boot -e "$EFI_IMG" -no-emul-boot -isohybrid-gpt-basdat)
+fi
+XORRISO_ARGS+=("$ISO_TREE")
+
+xorriso "${XORRISO_ARGS[@]}"
+
+chmod 644 "$OUT" 2>/dev/null || true
+SIZE="$(wc -c <"$OUT" | tr -d ' ')"
+echo "built $OUT ($SIZE bytes) mode=autoinstall"
+echo "lab login (default): user=${USERNAME} password=<lab default shoal-lab unless overridden>"
+echo "publish: copy to lab ISO dir; BMC URL e.g. http://192.168.124.1:8080/$(basename "$OUT")"
+echo "deploy with raised SOL stall, e.g. -stall-timeout 45m -wait-timeout 90m"

--- a/infra/scripts/prepare-ubuntu-cloud-payload.sh
+++ b/infra/scripts/prepare-ubuntu-cloud-payload.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# prepare-ubuntu-cloud-payload.sh — customize an Ubuntu cloud image raw disk
+# for Phase 7a nested-lab install (password login + hostname + cloud-init seed).
+#
+# Requires: qemu-img, losetup, mount, sudo (root for loop mounts).
+#
+# Usage:
+#   SHOAL_UBUNTU_CLOUD_IMG=/path/to/ubuntu-22.04-server-cloudimg-amd64.img \
+#     ./infra/scripts/prepare-ubuntu-cloud-payload.sh [/out/ubuntu-payload.raw]
+set -euo pipefail
+
+OUT="${1:-${SHOAL_CLOUD_PAYLOAD_OUT:-./ubuntu-cloud-payload.raw}}"
+IMG="${SHOAL_UBUNTU_CLOUD_IMG:-}"
+HOSTNAME="${SHOAL_AUTOINSTALL_HOSTNAME:-shoal-node}"
+USERNAME="${SHOAL_AUTOINSTALL_USERNAME:-ubuntu}"
+PASSWORD="${SHOAL_AUTOINSTALL_PASSWORD:-shoal-lab}"
+
+if [[ -z "$IMG" || ! -r "$IMG" ]]; then
+  cat >&2 <<'EOF'
+error: set SHOAL_UBUNTU_CLOUD_IMG to an Ubuntu cloud image (.img).
+
+Example:
+  wget -O /var/tmp/ubuntu-22.04-server-cloudimg-amd64.img \
+    https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-amd64.img
+  export SHOAL_UBUNTU_CLOUD_IMG=/var/tmp/ubuntu-22.04-server-cloudimg-amd64.img
+EOF
+  exit 1
+fi
+
+if [[ "$(id -u)" -ne 0 ]]; then
+  echo "re-exec with sudo for loop mounts..."
+  exec sudo -E env \
+    "SHOAL_UBUNTU_CLOUD_IMG=$IMG" \
+    "SHOAL_AUTOINSTALL_HOSTNAME=$HOSTNAME" \
+    "SHOAL_AUTOINSTALL_USERNAME=$USERNAME" \
+    "SHOAL_AUTOINSTALL_PASSWORD=$PASSWORD" \
+    "SHOAL_CLOUD_PAYLOAD_OUT=$OUT" \
+    "$0" "$OUT"
+fi
+
+for need in qemu-img losetup mount umount blkid; do
+  command -v "$need" >/dev/null || { echo "error: $need required" >&2; exit 1; }
+done
+
+WORK="$(mktemp -d /tmp/shoal-cloud-prep.XXXXXX)"
+cleanup() {
+  set +e
+  umount "$WORK/mnt" 2>/dev/null
+  losetup -d "$LOOP" 2>/dev/null
+  rm -rf "$WORK"
+}
+trap cleanup EXIT
+
+echo "source cloud img: $IMG"
+echo "hostname: $HOSTNAME user: $USERNAME"
+echo "output raw: $OUT"
+
+mkdir -p "$(dirname "$OUT")"
+qemu-img convert -O raw "$IMG" "$OUT"
+# Grow a bit for packages/logs
+qemu-img resize "$OUT" +1G 2>/dev/null || true
+
+LOOP="$(losetup -fP --show "$OUT")"
+echo "loop: $LOOP"
+sleep 1
+# Prefer largest partition as root
+ROOT_PART=""
+for p in "${LOOP}p2" "${LOOP}p1" "${LOOP}p3"; do
+  if [[ -b "$p" ]]; then
+    ROOT_PART="$p"
+    # Prefer ext* labels
+    FSTYPE="$(blkid -o value -s TYPE "$p" 2>/dev/null || true)"
+    if [[ "$FSTYPE" == ext4 || "$FSTYPE" == ext3 ]]; then
+      break
+    fi
+  fi
+done
+if [[ -z "$ROOT_PART" ]]; then
+  echo "error: no partition found on $OUT" >&2
+  exit 1
+fi
+echo "root part: $ROOT_PART ($(blkid -o value -s TYPE "$ROOT_PART" 2>/dev/null || echo unknown))"
+
+mkdir -p "$WORK/mnt"
+mount "$ROOT_PART" "$WORK/mnt"
+
+# Hostname
+echo "$HOSTNAME" > "$WORK/mnt/etc/hostname"
+if [[ -f "$WORK/mnt/etc/hosts" ]]; then
+  if grep -q '^10.0.2.3' "$WORK/mnt/etc/hosts" 2>/dev/null; then
+    sed -i "s/^10.0.2.3.*/10.0.2.3\t${HOSTNAME}/" "$WORK/mnt/etc/hosts" || true
+  else
+    echo -e "10.0.2.3\t${HOSTNAME}" >> "$WORK/mnt/etc/hosts"
+  fi
+fi
+
+# Ensure user exists (cloud images usually have ubuntu)
+if ! grep -q "^${USERNAME}:" "$WORK/mnt/etc/passwd" 2>/dev/null; then
+  chroot "$WORK/mnt" useradd -m -s /bin/bash "$USERNAME" 2>/dev/null || true
+fi
+echo "${USERNAME}:${PASSWORD}" | chroot "$WORK/mnt" chpasswd 2>/dev/null \
+  || echo "${USERNAME}:${PASSWORD}" | chpasswd -R "$WORK/mnt" 2>/dev/null \
+  || true
+
+# SSH password auth for lab
+if [[ -f "$WORK/mnt/etc/ssh/sshd_config" ]]; then
+  sed -i 's/^#\?PasswordAuthentication.*/PasswordAuthentication yes/' "$WORK/mnt/etc/ssh/sshd_config" || true
+  sed -i 's/^#\?PermitRootLogin.*/PermitRootLogin no/' "$WORK/mnt/etc/ssh/sshd_config" || true
+fi
+# cloud-init: provide nocloud seed so first boot is not stuck
+mkdir -p "$WORK/mnt/var/lib/cloud/seed/nocloud"
+cat > "$WORK/mnt/var/lib/cloud/seed/nocloud/meta-data" <<EOF
+instance-id: shoal-${HOSTNAME}
+local-hostname: ${HOSTNAME}
+EOF
+cat > "$WORK/mnt/var/lib/cloud/seed/nocloud/user-data" <<EOF
+#cloud-config
+hostname: ${HOSTNAME}
+manage_etc_hosts: true
+users:
+  - name: ${USERNAME}
+    lock_passwd: false
+    shell: /bin/bash
+    sudo: ALL=(ALL) NOPASSWD:ALL
+ssh_pwauth: true
+chpasswd:
+  expire: false
+  list: |
+    ${USERNAME}:${PASSWORD}
+runcmd:
+  - [ systemctl, enable, ssh ]
+  - [ systemctl, restart, ssh ]
+EOF
+# Prefer nocloud seed over network datasources for lab offline boot
+mkdir -p "$WORK/mnt/etc/cloud/cloud.cfg.d"
+cat > "$WORK/mnt/etc/cloud/cloud.cfg.d/99-shoal-nocloud.cfg" <<'EOF'
+datasource_list: [ NoCloud, None ]
+EOF
+
+# Serial console for SOL after install
+if [[ -f "$WORK/mnt/etc/default/grub" ]]; then
+  if ! grep -q 'console=ttyS0' "$WORK/mnt/etc/default/grub"; then
+    sed -i 's/GRUB_CMDLINE_LINUX="/GRUB_CMDLINE_LINUX="console=ttyS0,115200n8 /' "$WORK/mnt/etc/default/grub" || true
+  fi
+  chroot "$WORK/mnt" update-grub 2>/dev/null || true
+fi
+
+sync
+umount "$WORK/mnt"
+losetup -d "$LOOP"
+LOOP=""
+
+# Optional gzip for smaller ISO payload
+if [[ "${SHOAL_CLOUD_PAYLOAD_GZIP:-1}" == "1" ]]; then
+  echo "compressing payload..."
+  gzip -1 -c "$OUT" > "${OUT}.gz"
+  mv "${OUT}.gz" "${OUT}.gz.tmp"
+  # Keep raw name .raw.gz
+  GOUT="${OUT%.raw}.raw.gz"
+  if [[ "$OUT" == *.raw ]]; then
+    GOUT="${OUT}.gz"
+  else
+    GOUT="${OUT}.gz"
+  fi
+  mv "${OUT}.gz.tmp" "$GOUT"
+  ls -lh "$OUT" "$GOUT"
+  echo "prepared $GOUT (use as SHOAL_PAYLOAD_FILE for install-mode write/autoinstall)"
+  echo "raw also at $OUT"
+else
+  ls -lh "$OUT"
+  echo "prepared $OUT"
+fi

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -35,7 +35,7 @@ import (
 )
 
 // Version is the application version string (overridable via -ldflags).
-var Version = "0.6.0-phase6d"
+var Version = "0.7.0-phase7a"
 
 // Run dispatches subcommands. args should be os.Args[1:].
 func Run(args []string) int {

--- a/internal/cli/deploy.go
+++ b/internal/cli/deploy.go
@@ -67,7 +67,8 @@ func cmdDeployRun(args []string) int {
 	isoPayload := fs.String("iso-payload-file", "", "payload file for -build-iso write mode")
 	isoMode := fs.String("iso-install-mode", "", "simulate|write|autoinstall for -build-iso")
 	isoTarget := fs.String("iso-install-target", "", "write target for -build-iso (e.g. /tmp/shoal-install.out)")
-	ubuntuISO := fs.String("ubuntu-iso", os.Getenv("SHOAL_UBUNTU_ISO"), "Ubuntu Server live-server ISO for autoinstall build")
+	ubuntuISO := fs.String("ubuntu-iso", os.Getenv("SHOAL_UBUNTU_ISO"), "Ubuntu live-server ISO (legacy remaster)")
+	cloudImg := fs.String("ubuntu-cloud-img", os.Getenv("SHOAL_UBUNTU_CLOUD_IMG"), "Ubuntu cloud image for autoinstall build (preferred)")
 	isoHostname := fs.String("iso-hostname", "", "autoinstall hostname when building")
 	sshHost := fs.String("serial-ssh-host", cfg.SerialSSHHost, "SSH host for nested libvirt serial (VM mode)")
 	sshUser := fs.String("serial-ssh-user", cfg.SerialSSHUser, "SSH user for serial delegate")
@@ -82,17 +83,17 @@ func cmdDeployRun(args []string) int {
 	cfg.SerialSSHUser = *sshUser
 	cfg.SerialSSHKey = *sshKey
 
-	// Phase 7a: full Ubuntu install is long; raise defaults when autoinstall unless overridden.
+	// Phase 7a: full Ubuntu install; raise defaults when autoinstall unless overridden.
 	mode := strings.TrimSpace(*isoMode)
-	if mode == iso.InstallModeAutoinstall || strings.TrimSpace(*ubuntuISO) != "" {
+	if mode == iso.InstallModeAutoinstall || strings.TrimSpace(*ubuntuISO) != "" || strings.TrimSpace(*cloudImg) != "" {
 		if mode == "" {
 			mode = iso.InstallModeAutoinstall
 		}
 		if *stallTimeout == 3*time.Minute {
-			*stallTimeout = 45 * time.Minute
+			*stallTimeout = 15 * time.Minute // cloud-image write is faster than live autoinstall
 		}
 		if *waitTimeout == 30*time.Minute {
-			*waitTimeout = 90 * time.Minute
+			*waitTimeout = 45 * time.Minute
 		}
 	}
 
@@ -117,6 +118,10 @@ func cmdDeployRun(args []string) int {
 		ISOInstallTarget: *isoTarget,
 		ISOUbuntuBase:    *ubuntuISO,
 		ISOHostname:      *isoHostname,
+	}
+	// Cloud image is passed via env for the builder (StartJobRequest has no field yet for 7a.1).
+	if strings.TrimSpace(*cloudImg) != "" {
+		_ = os.Setenv("SHOAL_UBUNTU_CLOUD_IMG", strings.TrimSpace(*cloudImg))
 	}
 
 	store, dbCloser, err := openJobStore(cfg)

--- a/internal/cli/deploy.go
+++ b/internal/cli/deploy.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -62,10 +63,12 @@ func cmdDeployRun(args []string) int {
 	systemID := fs.String("system-id", "", "optional Redfish system id or name")
 	profileRef := fs.String("profile-ref", "spike", "profile ref (spike = no store; else SHOAL_PROFILE_DIR)")
 	approveDestruct := fs.Bool("approve-destruct", false, "operator consent for NeedsApproval/DestructSteps profiles")
-	buildISO := fs.Bool("build-iso", false, "build+publish live ISO before start (Phase 6a; needs publish dir)")
+	buildISO := fs.Bool("build-iso", false, "build+publish live ISO before start (Phase 6a/7a; needs publish dir)")
 	isoPayload := fs.String("iso-payload-file", "", "payload file for -build-iso write mode")
-	isoMode := fs.String("iso-install-mode", "", "simulate|write for -build-iso (default write if payload set)")
+	isoMode := fs.String("iso-install-mode", "", "simulate|write|autoinstall for -build-iso")
 	isoTarget := fs.String("iso-install-target", "", "write target for -build-iso (e.g. /tmp/shoal-install.out)")
+	ubuntuISO := fs.String("ubuntu-iso", os.Getenv("SHOAL_UBUNTU_ISO"), "Ubuntu Server live-server ISO for autoinstall build")
+	isoHostname := fs.String("iso-hostname", "", "autoinstall hostname when building")
 	sshHost := fs.String("serial-ssh-host", cfg.SerialSSHHost, "SSH host for nested libvirt serial (VM mode)")
 	sshUser := fs.String("serial-ssh-user", cfg.SerialSSHUser, "SSH user for serial delegate")
 	sshKey := fs.String("serial-ssh-key", cfg.SerialSSHKey, "SSH private key for serial delegate")
@@ -78,6 +81,20 @@ func cmdDeployRun(args []string) int {
 	cfg.SerialSSHHost = *sshHost
 	cfg.SerialSSHUser = *sshUser
 	cfg.SerialSSHKey = *sshKey
+
+	// Phase 7a: full Ubuntu install is long; raise defaults when autoinstall unless overridden.
+	mode := strings.TrimSpace(*isoMode)
+	if mode == iso.InstallModeAutoinstall || strings.TrimSpace(*ubuntuISO) != "" {
+		if mode == "" {
+			mode = iso.InstallModeAutoinstall
+		}
+		if *stallTimeout == 3*time.Minute {
+			*stallTimeout = 45 * time.Minute
+		}
+		if *waitTimeout == 30*time.Minute {
+			*waitTimeout = 90 * time.Minute
+		}
+	}
 
 	dev := *deviceID
 	if dev == "" {
@@ -96,8 +113,10 @@ func cmdDeployRun(args []string) int {
 		ApproveDestruct:  *approveDestruct,
 		BuildISO:         *buildISO,
 		ISOPayloadFile:   *isoPayload,
-		ISOInstallMode:   *isoMode,
+		ISOInstallMode:   mode,
 		ISOInstallTarget: *isoTarget,
+		ISOUbuntuBase:    *ubuntuISO,
+		ISOHostname:      *isoHostname,
 	}
 
 	store, dbCloser, err := openJobStore(cfg)

--- a/internal/cli/iso.go
+++ b/internal/cli/iso.go
@@ -46,9 +46,10 @@ func cmdISOBuild(args []string) int {
 	payloadFile := fs.String("payload-file", "", "host path copied into image as /payload (binary-safe)")
 	installMode := fs.String("install-mode", "simulate", "simulate|write|autoinstall (6a write; 7a Ubuntu autoinstall)")
 	installTarget := fs.String("install-target", "", "write target baked into image (e.g. /dev/vda or /tmp/out)")
-	ubuntuISO := fs.String("ubuntu-iso", os.Getenv("SHOAL_UBUNTU_ISO"), "official Ubuntu Server live-server ISO path (autoinstall)")
+	ubuntuISO := fs.String("ubuntu-iso", os.Getenv("SHOAL_UBUNTU_ISO"), "Ubuntu live-server ISO (legacy remaster path)")
+	cloudImg := fs.String("ubuntu-cloud-img", os.Getenv("SHOAL_UBUNTU_CLOUD_IMG"), "Ubuntu cloud image .img (preferred nested-lab autoinstall)")
 	hostname := fs.String("hostname", "", "autoinstall hostname (Phase 7a)")
-	username := fs.String("username", "", "autoinstall username (Phase 7a; default shoal)")
+	username := fs.String("username", "", "autoinstall username (Phase 7a; default ubuntu for cloud)")
 	profileRef := fs.String("profile-ref", "", "load iso_base/name/payload hints from profile store")
 	publish := fs.Bool("publish", false, "also publish to SHOAL_ISO_PUBLISH_DIR")
 	if err := fs.Parse(args); err != nil {
@@ -56,14 +57,15 @@ func cmdISOBuild(args []string) int {
 	}
 
 	in := iso.BuildInput{
-		Name:          *name,
-		OutDir:        *outDir,
-		ScriptPath:    cfg.ISOBuildScript,
-		InstallMode:   *installMode,
-		InstallTarget: *installTarget,
-		UbuntuBaseISO: *ubuntuISO,
-		Hostname:      *hostname,
-		Username:      *username,
+		Name:           *name,
+		OutDir:         *outDir,
+		ScriptPath:     cfg.ISOBuildScript,
+		InstallMode:    *installMode,
+		InstallTarget:  *installTarget,
+		UbuntuBaseISO:  *ubuntuISO,
+		UbuntuCloudImg: *cloudImg,
+		Hostname:       *hostname,
+		Username:       *username,
 	}
 	if *installMode == iso.InstallModeAutoinstall && *name == "shoal-marker.iso" {
 		in.Name = "shoal-ubuntu-autoinstall.iso"

--- a/internal/cli/iso.go
+++ b/internal/cli/iso.go
@@ -44,8 +44,11 @@ func cmdISOBuild(args []string) int {
 	out := fs.String("out", "", "full output path (overrides -name/-out-dir)")
 	payload := fs.String("payload", "", "non-secret embedded payload text")
 	payloadFile := fs.String("payload-file", "", "host path copied into image as /payload (binary-safe)")
-	installMode := fs.String("install-mode", "simulate", "simulate|write (Phase 6a real payload write)")
+	installMode := fs.String("install-mode", "simulate", "simulate|write|autoinstall (6a write; 7a Ubuntu autoinstall)")
 	installTarget := fs.String("install-target", "", "write target baked into image (e.g. /dev/vda or /tmp/out)")
+	ubuntuISO := fs.String("ubuntu-iso", os.Getenv("SHOAL_UBUNTU_ISO"), "official Ubuntu Server live-server ISO path (autoinstall)")
+	hostname := fs.String("hostname", "", "autoinstall hostname (Phase 7a)")
+	username := fs.String("username", "", "autoinstall username (Phase 7a; default shoal)")
 	profileRef := fs.String("profile-ref", "", "load iso_base/name/payload hints from profile store")
 	publish := fs.Bool("publish", false, "also publish to SHOAL_ISO_PUBLISH_DIR")
 	if err := fs.Parse(args); err != nil {
@@ -58,6 +61,12 @@ func cmdISOBuild(args []string) int {
 		ScriptPath:    cfg.ISOBuildScript,
 		InstallMode:   *installMode,
 		InstallTarget: *installTarget,
+		UbuntuBaseISO: *ubuntuISO,
+		Hostname:      *hostname,
+		Username:      *username,
+	}
+	if *installMode == iso.InstallModeAutoinstall && *name == "shoal-marker.iso" {
+		in.Name = "shoal-ubuntu-autoinstall.iso"
 	}
 	if *out != "" {
 		in.OutDir = filepath.Dir(*out)
@@ -96,7 +105,11 @@ func cmdISOBuild(args []string) int {
 	}
 
 	b := iso.NewScriptBuilder(cfg.ISOBuildScript, log)
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	buildTimeout := 10 * time.Minute
+	if *installMode == iso.InstallModeAutoinstall {
+		buildTimeout = 45 * time.Minute
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), buildTimeout)
 	defer cancel()
 	art, err := b.Build(ctx, in)
 	if err != nil {

--- a/internal/common/models/models.go
+++ b/internal/common/models/models.go
@@ -188,10 +188,14 @@ type StartJobRequest struct {
 	BuildISO bool `json:"build_iso,omitempty"`
 	// ISOPayloadFile is an optional host path for binary install payload (write mode).
 	ISOPayloadFile string `json:"iso_payload_file,omitempty"`
-	// ISOInstallMode is simulate|write for dynamic builds (default simulate).
+	// ISOInstallMode is simulate|write|autoinstall for dynamic builds (default simulate).
 	ISOInstallMode string `json:"iso_install_mode,omitempty"`
 	// ISOInstallTarget is optional write target baked into the image (e.g. /dev/vda).
 	ISOInstallTarget string `json:"iso_install_target,omitempty"`
+	// ISOUbuntuBase is path to official Ubuntu Server live-server ISO (Phase 7a autoinstall).
+	ISOUbuntuBase string `json:"iso_ubuntu_base,omitempty"`
+	// ISOHostname is the autoinstall identity hostname (Phase 7a).
+	ISOHostname string `json:"iso_hostname,omitempty"`
 }
 
 // CancelJobRequest cancels an in-flight provisioning job.

--- a/internal/deploy/iso/iso.go
+++ b/internal/deploy/iso/iso.go
@@ -12,10 +12,11 @@ import (
 	"time"
 )
 
-// Install modes for the live image (Phase 6a).
+// Install modes for the live / install image.
 const (
-	InstallModeSimulate = "simulate" // Phase 2 marker demo (default)
-	InstallModeWrite    = "write"    // write /payload to target with real SOL progress
+	InstallModeSimulate    = "simulate"    // Phase 2 marker demo (default)
+	InstallModeWrite       = "write"       // Phase 6a: write /payload with real SOL progress
+	InstallModeAutoinstall = "autoinstall" // Phase 7a: Ubuntu autoinstall remaster
 )
 
 // BuildInput describes a live-image build request.
@@ -29,12 +30,20 @@ type BuildInput struct {
 	EmbeddedPayload string
 	// PayloadFile is a host path copied into the image as /payload (binary-safe).
 	PayloadFile string
-	// InstallMode is simulate (default) or write (Phase 6a real payload write).
+	// InstallMode is simulate (default), write (Phase 6a), or autoinstall (Phase 7a).
 	InstallMode string
 	// InstallTarget is optional block device or file path baked into the image
-	// (overridable via kernel cmdline shoal.target=).
+	// (overridable via kernel cmdline shoal.target=). Write mode only.
 	InstallTarget string
-	// ScriptPath overrides the marker build script (empty = auto-discover).
+	// UbuntuBaseISO is the official Ubuntu Server live-server ISO path (autoinstall).
+	// May also be supplied via SHOAL_UBUNTU_ISO in the environment.
+	UbuntuBaseISO string
+	// Hostname for autoinstall identity (default shoal-node).
+	Hostname string
+	// Username for autoinstall identity (default shoal). Lab-only password is
+	// set via SHOAL_AUTOINSTALL_PASSWORD in the build script (not logged by Go).
+	Username string
+	// ScriptPath overrides the build script (empty = auto-discover by mode).
 	ScriptPath string
 }
 
@@ -75,22 +84,38 @@ func NewScriptBuilder(scriptPath string, log *slog.Logger) *ScriptBuilder {
 	return &ScriptBuilder{ScriptPath: scriptPath, Log: log}
 }
 
-// Build runs the marker ISO script (xorriso/busybox host tools required).
+// Build runs the marker or Ubuntu autoinstall ISO script (host tools required).
 func (b *ScriptBuilder) Build(ctx context.Context, in BuildInput) (Artifact, error) {
+	mode := strings.TrimSpace(in.InstallMode)
+	if mode == "" {
+		mode = InstallModeSimulate
+	}
+	if mode != InstallModeSimulate && mode != InstallModeWrite && mode != InstallModeAutoinstall {
+		return Artifact{}, fmt.Errorf("iso: invalid install mode %q (want simulate|write|autoinstall)", mode)
+	}
+
 	script := in.ScriptPath
 	if script == "" {
 		script = b.ScriptPath
 	}
 	if script == "" {
 		var err error
-		script, err = FindBuildScript()
+		if mode == InstallModeAutoinstall {
+			script, err = FindUbuntuAutoinstallScript()
+		} else {
+			script, err = FindBuildScript()
+		}
 		if err != nil {
 			return Artifact{}, err
 		}
 	}
 	name := strings.TrimSpace(in.Name)
 	if name == "" {
-		name = "shoal-marker.iso"
+		if mode == InstallModeAutoinstall {
+			name = "shoal-ubuntu-autoinstall.iso"
+		} else {
+			name = "shoal-marker.iso"
+		}
 	}
 	if !strings.HasSuffix(strings.ToLower(name), ".iso") {
 		name += ".iso"
@@ -106,39 +131,60 @@ func (b *ScriptBuilder) Build(ctx context.Context, in BuildInput) (Artifact, err
 	}
 	outPath := filepath.Join(outDir, name)
 
-	mode := strings.TrimSpace(in.InstallMode)
-	if mode == "" {
-		mode = InstallModeSimulate
-	}
-	if mode != InstallModeSimulate && mode != InstallModeWrite {
-		return Artifact{}, fmt.Errorf("iso: invalid install mode %q", mode)
+	// Autoinstall remasters multi-GB ISOs; allow a long deadline when none set.
+	if mode == InstallModeAutoinstall {
+		if _, ok := ctx.Deadline(); !ok {
+			var cancel context.CancelFunc
+			ctx, cancel = context.WithTimeout(ctx, 45*time.Minute)
+			defer cancel()
+		}
 	}
 
 	cmd := exec.CommandContext(ctx, script, outPath)
-	cmd.Env = os.Environ()
-	// Payload: prefer file path (binary-safe); else inline text via env.
-	// Callers must not pass passwords.
-	if pf := strings.TrimSpace(in.PayloadFile); pf != "" {
-		st, err := os.Stat(pf)
-		if err != nil {
-			return Artifact{}, fmt.Errorf("iso: payload file: %w", err)
-		}
-		if st.IsDir() {
-			return Artifact{}, fmt.Errorf("iso: payload file is a directory")
-		}
-		cmd.Env = append(cmd.Env, "SHOAL_PAYLOAD_FILE="+pf)
-	} else if p := strings.TrimSpace(in.EmbeddedPayload); p != "" {
-		if looksSecretPayload(p) {
-			return Artifact{}, fmt.Errorf("iso: embedded_payload must not contain secret-like content")
-		}
-		cmd.Env = append(cmd.Env, "SHOAL_EMBEDDED_PAYLOAD="+p)
-	}
-	cmd.Env = append(cmd.Env,
+	cmd.Env = append(os.Environ(),
 		"SHOAL_ISO_NAME="+name,
 		"SHOAL_INSTALL_MODE="+mode,
 	)
-	if t := strings.TrimSpace(in.InstallTarget); t != "" {
-		cmd.Env = append(cmd.Env, "SHOAL_INSTALL_TARGET="+t)
+
+	if mode == InstallModeAutoinstall {
+		base := strings.TrimSpace(in.UbuntuBaseISO)
+		if base == "" {
+			base = strings.TrimSpace(os.Getenv("SHOAL_UBUNTU_ISO"))
+		}
+		if base == "" {
+			return Artifact{}, fmt.Errorf("iso: autoinstall requires Ubuntu base ISO (BuildInput.UbuntuBaseISO or SHOAL_UBUNTU_ISO)")
+		}
+		if st, err := os.Stat(base); err != nil || st.IsDir() {
+			return Artifact{}, fmt.Errorf("iso: ubuntu base ISO not readable: %s", base)
+		}
+		cmd.Env = append(cmd.Env, "SHOAL_UBUNTU_ISO="+base)
+		if h := strings.TrimSpace(in.Hostname); h != "" {
+			cmd.Env = append(cmd.Env, "SHOAL_AUTOINSTALL_HOSTNAME="+h)
+		}
+		if u := strings.TrimSpace(in.Username); u != "" {
+			cmd.Env = append(cmd.Env, "SHOAL_AUTOINSTALL_USERNAME="+u)
+		}
+	} else {
+		// Payload: prefer file path (binary-safe); else inline text via env.
+		// Callers must not pass passwords.
+		if pf := strings.TrimSpace(in.PayloadFile); pf != "" {
+			st, err := os.Stat(pf)
+			if err != nil {
+				return Artifact{}, fmt.Errorf("iso: payload file: %w", err)
+			}
+			if st.IsDir() {
+				return Artifact{}, fmt.Errorf("iso: payload file is a directory")
+			}
+			cmd.Env = append(cmd.Env, "SHOAL_PAYLOAD_FILE="+pf)
+		} else if p := strings.TrimSpace(in.EmbeddedPayload); p != "" {
+			if looksSecretPayload(p) {
+				return Artifact{}, fmt.Errorf("iso: embedded_payload must not contain secret-like content")
+			}
+			cmd.Env = append(cmd.Env, "SHOAL_EMBEDDED_PAYLOAD="+p)
+		}
+		if t := strings.TrimSpace(in.InstallTarget); t != "" {
+			cmd.Env = append(cmd.Env, "SHOAL_INSTALL_TARGET="+t)
+		}
 	}
 
 	start := time.Now()
@@ -246,16 +292,30 @@ func FindBuildScript() (string, error) {
 		}
 		return "", fmt.Errorf("iso: SHOAL_ISO_BUILD_SCRIPT not found: %s", p)
 	}
-	candidates := []string{
-		"infra/scripts/build-marker-iso.sh",
-		"./infra/scripts/build-marker-iso.sh",
-		"../infra/scripts/build-marker-iso.sh",
-		"../../infra/scripts/build-marker-iso.sh",
+	return findScript("build-marker-iso.sh", "SHOAL_ISO_BUILD_SCRIPT")
+}
+
+// FindUbuntuAutoinstallScript locates infra/scripts/build-ubuntu-autoinstall-iso.sh.
+func FindUbuntuAutoinstallScript() (string, error) {
+	if p := os.Getenv("SHOAL_UBUNTU_AUTOINSTALL_SCRIPT"); p != "" {
+		if st, err := os.Stat(p); err == nil && !st.IsDir() {
+			return p, nil
+		}
+		return "", fmt.Errorf("iso: SHOAL_UBUNTU_AUTOINSTALL_SCRIPT not found: %s", p)
 	}
-	// Walk up from cwd a few levels.
+	return findScript("build-ubuntu-autoinstall-iso.sh", "SHOAL_UBUNTU_AUTOINSTALL_SCRIPT")
+}
+
+func findScript(basename, envHint string) (string, error) {
+	candidates := []string{
+		filepath.Join("infra/scripts", basename),
+		filepath.Join("./infra/scripts", basename),
+		filepath.Join("../infra/scripts", basename),
+		filepath.Join("../../infra/scripts", basename),
+	}
 	wd, _ := os.Getwd()
 	for i := 0; i < 6 && wd != ""; i++ {
-		candidates = append(candidates, filepath.Join(wd, "infra/scripts/build-marker-iso.sh"))
+		candidates = append(candidates, filepath.Join(wd, "infra/scripts", basename))
 		parent := filepath.Dir(wd)
 		if parent == wd {
 			break
@@ -271,7 +331,7 @@ func FindBuildScript() (string, error) {
 			return abs, nil
 		}
 	}
-	return "", fmt.Errorf("iso: build-marker-iso.sh not found (set SHOAL_ISO_BUILD_SCRIPT)")
+	return "", fmt.Errorf("iso: %s not found (set %s)", basename, envHint)
 }
 
 func copyFile(src, dst string) error {

--- a/internal/deploy/iso/iso.go
+++ b/internal/deploy/iso/iso.go
@@ -35,13 +35,17 @@ type BuildInput struct {
 	// InstallTarget is optional block device or file path baked into the image
 	// (overridable via kernel cmdline shoal.target=). Write mode only.
 	InstallTarget string
-	// UbuntuBaseISO is the official Ubuntu Server live-server ISO path (autoinstall).
+	// UbuntuBaseISO is the official Ubuntu Server live-server ISO path (legacy remaster path).
 	// May also be supplied via SHOAL_UBUNTU_ISO in the environment.
 	UbuntuBaseISO string
+	// UbuntuCloudImg is an Ubuntu cloud image (.img) used for the reliable
+	// Phase 7a nested-lab path: prepare raw payload + marker write ISO.
+	// May also be supplied via SHOAL_UBUNTU_CLOUD_IMG.
+	UbuntuCloudImg string
 	// Hostname for autoinstall identity (default shoal-node).
 	Hostname string
-	// Username for autoinstall identity (default shoal). Lab-only password is
-	// set via SHOAL_AUTOINSTALL_PASSWORD in the build script (not logged by Go).
+	// Username for autoinstall identity (default ubuntu for cloud images).
+	// Lab-only password via SHOAL_AUTOINSTALL_PASSWORD (not logged by Go).
 	Username string
 	// ScriptPath overrides the build script (empty = auto-discover by mode).
 	ScriptPath string
@@ -94,21 +98,6 @@ func (b *ScriptBuilder) Build(ctx context.Context, in BuildInput) (Artifact, err
 		return Artifact{}, fmt.Errorf("iso: invalid install mode %q (want simulate|write|autoinstall)", mode)
 	}
 
-	script := in.ScriptPath
-	if script == "" {
-		script = b.ScriptPath
-	}
-	if script == "" {
-		var err error
-		if mode == InstallModeAutoinstall {
-			script, err = FindUbuntuAutoinstallScript()
-		} else {
-			script, err = FindBuildScript()
-		}
-		if err != nil {
-			return Artifact{}, err
-		}
-	}
 	name := strings.TrimSpace(in.Name)
 	if name == "" {
 		if mode == InstallModeAutoinstall {
@@ -131,12 +120,67 @@ func (b *ScriptBuilder) Build(ctx context.Context, in BuildInput) (Artifact, err
 	}
 	outPath := filepath.Join(outDir, name)
 
-	// Autoinstall remasters multi-GB ISOs; allow a long deadline when none set.
+	// Autoinstall builds (prepare + pack) can be slow.
 	if mode == InstallModeAutoinstall {
 		if _, ok := ctx.Deadline(); !ok {
 			var cancel context.CancelFunc
 			ctx, cancel = context.WithTimeout(ctx, 45*time.Minute)
 			defer cancel()
+		}
+	}
+
+	// Phase 7a preferred path: Ubuntu cloud image → customized raw.gz → marker write ISO.
+	// Nested sushy/libvirt boots our marker ISO reliably; live-server remaster often does not.
+	cloudImg := strings.TrimSpace(in.UbuntuCloudImg)
+	if cloudImg == "" {
+		cloudImg = strings.TrimSpace(os.Getenv("SHOAL_UBUNTU_CLOUD_IMG"))
+	}
+	payloadFile := strings.TrimSpace(in.PayloadFile)
+	if mode == InstallModeAutoinstall && payloadFile == "" && cloudImg != "" {
+		prep, err := FindCloudPrepareScript()
+		if err != nil {
+			return Artifact{}, err
+		}
+		rawOut := filepath.Join(outDir, "ubuntu-cloud-payload.raw")
+		prepCmd := exec.CommandContext(ctx, prep, rawOut)
+		prepCmd.Env = append(os.Environ(),
+			"SHOAL_UBUNTU_CLOUD_IMG="+cloudImg,
+			"SHOAL_CLOUD_PAYLOAD_GZIP=1",
+		)
+		if h := strings.TrimSpace(in.Hostname); h != "" {
+			prepCmd.Env = append(prepCmd.Env, "SHOAL_AUTOINSTALL_HOSTNAME="+h)
+		}
+		if u := strings.TrimSpace(in.Username); u != "" {
+			prepCmd.Env = append(prepCmd.Env, "SHOAL_AUTOINSTALL_USERNAME="+u)
+		}
+		b.Log.Info("preparing ubuntu cloud payload", "img", cloudImg, "out", rawOut)
+		if out, err := prepCmd.CombinedOutput(); err != nil {
+			return Artifact{}, fmt.Errorf("iso: prepare cloud payload: %w\n%s", err, truncate(string(out), 2<<10))
+		}
+		gz := rawOut + ".gz"
+		if st, err := os.Stat(gz); err == nil && !st.IsDir() {
+			payloadFile = gz
+		} else {
+			payloadFile = rawOut
+		}
+	}
+
+	script := in.ScriptPath
+	if script == "" {
+		script = b.ScriptPath
+	}
+	useLiveRemaster := mode == InstallModeAutoinstall && payloadFile == "" &&
+		(strings.TrimSpace(in.UbuntuBaseISO) != "" || strings.TrimSpace(os.Getenv("SHOAL_UBUNTU_ISO")) != "")
+	if script == "" {
+		var err error
+		if useLiveRemaster && payloadFile == "" {
+			script, err = FindUbuntuAutoinstallScript()
+		} else {
+			// autoinstall with cloud payload, write, simulate → marker ISO builder
+			script, err = FindBuildScript()
+		}
+		if err != nil {
+			return Artifact{}, err
 		}
 	}
 
@@ -146,13 +190,13 @@ func (b *ScriptBuilder) Build(ctx context.Context, in BuildInput) (Artifact, err
 		"SHOAL_INSTALL_MODE="+mode,
 	)
 
-	if mode == InstallModeAutoinstall {
+	if useLiveRemaster && payloadFile == "" {
 		base := strings.TrimSpace(in.UbuntuBaseISO)
 		if base == "" {
 			base = strings.TrimSpace(os.Getenv("SHOAL_UBUNTU_ISO"))
 		}
 		if base == "" {
-			return Artifact{}, fmt.Errorf("iso: autoinstall requires Ubuntu base ISO (BuildInput.UbuntuBaseISO or SHOAL_UBUNTU_ISO)")
+			return Artifact{}, fmt.Errorf("iso: autoinstall requires SHOAL_UBUNTU_CLOUD_IMG (preferred) or SHOAL_UBUNTU_ISO")
 		}
 		if st, err := os.Stat(base); err != nil || st.IsDir() {
 			return Artifact{}, fmt.Errorf("iso: ubuntu base ISO not readable: %s", base)
@@ -165,17 +209,20 @@ func (b *ScriptBuilder) Build(ctx context.Context, in BuildInput) (Artifact, err
 			cmd.Env = append(cmd.Env, "SHOAL_AUTOINSTALL_USERNAME="+u)
 		}
 	} else {
+		if mode == InstallModeAutoinstall && payloadFile == "" {
+			return Artifact{}, fmt.Errorf("iso: autoinstall requires SHOAL_UBUNTU_CLOUD_IMG (preferred nested-lab path) or payload-file or SHOAL_UBUNTU_ISO")
+		}
 		// Payload: prefer file path (binary-safe); else inline text via env.
 		// Callers must not pass passwords.
-		if pf := strings.TrimSpace(in.PayloadFile); pf != "" {
-			st, err := os.Stat(pf)
+		if payloadFile != "" {
+			st, err := os.Stat(payloadFile)
 			if err != nil {
 				return Artifact{}, fmt.Errorf("iso: payload file: %w", err)
 			}
 			if st.IsDir() {
 				return Artifact{}, fmt.Errorf("iso: payload file is a directory")
 			}
-			cmd.Env = append(cmd.Env, "SHOAL_PAYLOAD_FILE="+pf)
+			cmd.Env = append(cmd.Env, "SHOAL_PAYLOAD_FILE="+payloadFile)
 		} else if p := strings.TrimSpace(in.EmbeddedPayload); p != "" {
 			if looksSecretPayload(p) {
 				return Artifact{}, fmt.Errorf("iso: embedded_payload must not contain secret-like content")
@@ -184,6 +231,11 @@ func (b *ScriptBuilder) Build(ctx context.Context, in BuildInput) (Artifact, err
 		}
 		if t := strings.TrimSpace(in.InstallTarget); t != "" {
 			cmd.Env = append(cmd.Env, "SHOAL_INSTALL_TARGET="+t)
+		} else if mode == InstallModeAutoinstall {
+			cmd.Env = append(cmd.Env, "SHOAL_INSTALL_TARGET=/dev/vda")
+		}
+		if mode == InstallModeAutoinstall {
+			cmd.Env = append(cmd.Env, "SHOAL_INSTALL_REBOOT=1")
 		}
 	}
 
@@ -304,6 +356,17 @@ func FindUbuntuAutoinstallScript() (string, error) {
 		return "", fmt.Errorf("iso: SHOAL_UBUNTU_AUTOINSTALL_SCRIPT not found: %s", p)
 	}
 	return findScript("build-ubuntu-autoinstall-iso.sh", "SHOAL_UBUNTU_AUTOINSTALL_SCRIPT")
+}
+
+// FindCloudPrepareScript locates infra/scripts/prepare-ubuntu-cloud-payload.sh.
+func FindCloudPrepareScript() (string, error) {
+	if p := os.Getenv("SHOAL_CLOUD_PREPARE_SCRIPT"); p != "" {
+		if st, err := os.Stat(p); err == nil && !st.IsDir() {
+			return p, nil
+		}
+		return "", fmt.Errorf("iso: SHOAL_CLOUD_PREPARE_SCRIPT not found: %s", p)
+	}
+	return findScript("prepare-ubuntu-cloud-payload.sh", "SHOAL_CLOUD_PREPARE_SCRIPT")
 }
 
 func findScript(basename, envHint string) (string, error) {

--- a/internal/deploy/iso/iso_test.go
+++ b/internal/deploy/iso/iso_test.go
@@ -87,15 +87,19 @@ func TestBuildRejectsBadInstallMode(t *testing.T) {
 	}
 }
 
-func TestBuildAutoinstallRequiresUbuntuISO(t *testing.T) {
+func TestBuildAutoinstallRequiresCloudOrISO(t *testing.T) {
 	b := iso.NewScriptBuilder("/nonexistent-script", slog.New(slog.NewTextHandler(io.Discard, nil)))
 	t.Setenv("SHOAL_UBUNTU_ISO", "")
+	t.Setenv("SHOAL_UBUNTU_CLOUD_IMG", "")
 	_, err := b.Build(context.Background(), iso.BuildInput{
 		InstallMode: iso.InstallModeAutoinstall,
 		OutDir:      t.TempDir(),
 	})
-	if err == nil || !strings.Contains(err.Error(), "Ubuntu base ISO") {
-		t.Fatalf("expected ubuntu iso error, got %v", err)
+	if err == nil {
+		t.Fatal("expected autoinstall input error")
+	}
+	if !strings.Contains(err.Error(), "CLOUD") && !strings.Contains(err.Error(), "payload") && !strings.Contains(err.Error(), "UBUNTU") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/internal/deploy/iso/iso_test.go
+++ b/internal/deploy/iso/iso_test.go
@@ -87,6 +87,47 @@ func TestBuildRejectsBadInstallMode(t *testing.T) {
 	}
 }
 
+func TestBuildAutoinstallRequiresUbuntuISO(t *testing.T) {
+	b := iso.NewScriptBuilder("/nonexistent-script", slog.New(slog.NewTextHandler(io.Discard, nil)))
+	t.Setenv("SHOAL_UBUNTU_ISO", "")
+	_, err := b.Build(context.Background(), iso.BuildInput{
+		InstallMode: iso.InstallModeAutoinstall,
+		OutDir:      t.TempDir(),
+	})
+	if err == nil || !strings.Contains(err.Error(), "Ubuntu base ISO") {
+		t.Fatalf("expected ubuntu iso error, got %v", err)
+	}
+}
+
+func TestFindUbuntuAutoinstallScript(t *testing.T) {
+	p, err := iso.FindUbuntuAutoinstallScript()
+	if err != nil {
+		t.Skipf("script not found in this environment: %v", err)
+	}
+	if !strings.Contains(p, "build-ubuntu-autoinstall-iso.sh") {
+		t.Fatalf("unexpected path %q", p)
+	}
+}
+
+func TestAutoinstallTemplateExists(t *testing.T) {
+	// Template must ship with the repo for Phase 7a.
+	p, err := iso.FindUbuntuAutoinstallScript()
+	if err != nil {
+		t.Skip(err)
+	}
+	tmpl := filepath.Join(filepath.Dir(p), "autoinstall", "ubuntu-user-data.yaml.tmpl")
+	b, err := os.ReadFile(tmpl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(b)
+	for _, want := range []string{"autoinstall:", "{{HOSTNAME}}", "SHOAL|", "DONE"} {
+		if !strings.Contains(s, want) {
+			t.Fatalf("template missing %q", want)
+		}
+	}
+}
+
 func TestBuildRejectsMissingPayloadFile(t *testing.T) {
 	b := iso.NewScriptBuilder("/nonexistent-script", slog.New(slog.NewTextHandler(io.Discard, nil)))
 	_, err := b.Build(context.Background(), iso.BuildInput{

--- a/internal/deploy/job/boot_override_test.go
+++ b/internal/deploy/job/boot_override_test.go
@@ -1,0 +1,29 @@
+package job
+
+import (
+	"testing"
+
+	"github.com/mattcburns/shoal/internal/common/redfish"
+)
+
+func TestBootOverrideCleared(t *testing.T) {
+	cases := []struct {
+		en, tgt string
+		want    bool
+	}{
+		{"Disabled", "None", true},
+		{"disabled", "Hdd", true},
+		{"", "", true},
+		{"Continuous", "Hdd", true}, // sushy clear fallback
+		{"Continuous", "None", true},
+		{"Continuous", "Cd", false},
+		{"Once", "Cd", false},
+		{"Once", "Hdd", false},
+	}
+	for _, tc := range cases {
+		got := bootOverrideCleared(redfish.BootInfo{OverrideEnabled: tc.en, OverrideTarget: tc.tgt})
+		if got != tc.want {
+			t.Errorf("cleared(%q/%q)=%v want %v", tc.en, tc.tgt, got, tc.want)
+		}
+	}
+}

--- a/internal/deploy/job/orchestrator.go
+++ b/internal/deploy/job/orchestrator.go
@@ -593,10 +593,29 @@ func (o *Orchestrator) postCheckClean(ctx context.Context, bmcURL, credRef, syst
 	if err != nil {
 		return fmt.Errorf("get boot post-check: %w", err)
 	}
-	if boot.OverrideEnabled != "" && boot.OverrideEnabled != "Disabled" && boot.OverrideEnabled != "disabled" {
+	// Clean = Disabled, empty, or sushy-tools steady state Continuous/Hdd
+	// (ClearBootOverride falls back to Continuous+Hdd when Disabled is rejected).
+	if !bootOverrideCleared(boot) {
 		return fmt.Errorf("boot override still set (%s/%s)", boot.OverrideEnabled, boot.OverrideTarget)
 	}
 	return nil
+}
+
+// bootOverrideCleared reports whether the BMC boot source is in a post-cleanup state
+// (no one-time CD/USB override left active).
+func bootOverrideCleared(boot redfish.BootInfo) bool {
+	en := strings.TrimSpace(boot.OverrideEnabled)
+	tgt := strings.TrimSpace(boot.OverrideTarget)
+	switch {
+	case en == "" || strings.EqualFold(en, "Disabled"):
+		return true
+	case strings.EqualFold(en, "Continuous") &&
+		(tgt == "" || strings.EqualFold(tgt, "None") || strings.EqualFold(tgt, "Hdd") || strings.EqualFold(tgt, "Disk") || strings.EqualFold(tgt, "Hd")):
+		// sushy-tools maps "clear override" onto Continuous + Hdd boot order.
+		return true
+	default:
+		return false
+	}
 }
 
 // checkProfileApproval enforces Phase 5b human gate before any BMC action.

--- a/internal/deploy/job/orchestrator.go
+++ b/internal/deploy/job/orchestrator.go
@@ -674,6 +674,8 @@ func (o *Orchestrator) maybeBuildISO(ctx context.Context, req *models.StartJobRe
 	mode := strings.TrimSpace(req.ISOInstallMode)
 	payloadFile := strings.TrimSpace(req.ISOPayloadFile)
 	target := strings.TrimSpace(req.ISOInstallTarget)
+	ubuntuBase := strings.TrimSpace(req.ISOUbuntuBase)
+	hostname := strings.TrimSpace(req.ISOHostname)
 	embedded := ""
 
 	if profileRef != "" && profileRef != "spike" && o.profiles != nil {
@@ -695,11 +697,16 @@ func (o *Orchestrator) maybeBuildISO(ctx context.Context, req *models.StartJobRe
 		}
 	}
 	if mode == "" {
-		if payloadFile != "" || embedded != "" {
+		if ubuntuBase != "" {
+			mode = iso.InstallModeAutoinstall
+		} else if payloadFile != "" || embedded != "" {
 			mode = iso.InstallModeWrite
 		} else {
 			mode = iso.InstallModeSimulate
 		}
+	}
+	if mode == iso.InstallModeAutoinstall && name == "shoal-install.iso" {
+		name = "shoal-ubuntu-autoinstall.iso"
 	}
 
 	in := iso.BuildInput{
@@ -708,6 +715,8 @@ func (o *Orchestrator) maybeBuildISO(ctx context.Context, req *models.StartJobRe
 		EmbeddedPayload: embedded,
 		InstallMode:     mode,
 		InstallTarget:   target,
+		UbuntuBaseISO:   ubuntuBase,
+		Hostname:        hostname,
 	}
 	url, art, err := buildAndPublish(ctx, o.isoBuilder, in, iso.PublishDest{
 		Dir: o.isoPublishDir, BaseURL: o.isoBaseURL,

--- a/internal/deploy/job/orchestrator.go
+++ b/internal/deploy/job/orchestrator.go
@@ -346,8 +346,12 @@ func (o *Orchestrator) provision(ctx context.Context, job models.ProvisioningJob
 	if err := bmc.SetBootOverrideOnceCD(ctx, sys.ID); err != nil {
 		return fmt.Errorf("boot override: %w", err)
 	}
-	if err := bmc.Power(ctx, sys.ID, "On"); err != nil {
-		return fmt.Errorf("power on: %w", err)
+	// Prefer ForceRestart so an already-on system reboots into the new media.
+	// Fall back to On for powered-off domains (sushy maps both onto libvirt).
+	if err := bmc.Power(ctx, sys.ID, "ForceRestart"); err != nil {
+		if err2 := bmc.Power(ctx, sys.ID, "On"); err2 != nil {
+			return fmt.Errorf("power on/restart: %w (also: %v)", err2, err)
+		}
 	}
 
 	_ = o.store.UpdateProgress(ctx, job.ID, "WAITING_SOL", nil, 0, "")


### PR DESCRIPTION
## Summary

Closes **Phase 7a** (design **v2.0.9**): install a **real Ubuntu root** on a nested lab node over Redfish Virtual Media + SOL markers, ending in job state **`provisioned`**.

### Preferred nested-lab path (lab-proven)

1. `prepare-ubuntu-cloud-payload.sh` — customize Ubuntu cloud image → `.raw.gz`
2. `build-marker-iso.sh` — marker live ISO with **large `payload.gz` on ISO root** (not initrd), matching kernel modules for isofs/ahci/virtio_blk
3. Deploy attaches ISO via sushy; guest mounts CD → `gunzip|dd` → `/dev/vda` → SOL `DONE` → reboot
4. Orchestrator ForceRestart, cleanup, post-check accepts sushy **Continuous/Hdd** as cleared override

### Also included

- Live-server **autoinstall remaster** scripts/templates (alternate/stretch; often unreliable under nested sushy)
- `iso.InstallModeAutoinstall` + CLI/env wiring (`SHOAL_UBUNTU_CLOUD_IMG` preferred, `SHOAL_UBUNTU_ISO` alternate)
- Docs: design § Phase 7 closeout, `docs/phase-7-plan.md`, lab-runbook, AGENTS

### Deferred (not this PR)

- **7b** profile/artifact model
- **7c** second OS family / NetBox identity polish  
- Multi-stage prep + scripted ISO matrix (Ubuntu autoinstall / Flatcar / ESXi / Windows) — **separate design PR**

## Test plan

- [x] `go test ./internal/deploy/... ./internal/cli/...`
- [x] Unit: autoinstall input validation; boot override Continuous/Hdd cleared
- [x] Lab E2E: Virtual Media + SOL → disk ~3.2GiB → Ubuntu 22.04 serial login → **`provisioned OK`**

### Lab shape

```bash
# On L1: prepare + build (see docs/lab-runbook.md § Phase 7a)
# Then operator:
go run ./cmd/shoal deploy run \
  -device-id shoal-node-1 \
  -bmc-url http://192.168.122.100:8001 \
  -serial-target shoal-node-1 \
  -serial-ssh-host 192.168.122.100 \
  -iso-url http://192.168.124.1:8080/shoal-ubuntu-cloud-v5.iso \
  -stall-timeout 15m -wait-timeout 25m -wait
```