### PR TITLE
feat(deploy): multi-stage M1 stage runner skeleton

### DIFF
--- a/docs/multi-stage-provisioning-design.md
+++ b/docs/multi-stage-provisioning-design.md
@@ -800,7 +800,7 @@ Version media URLs when content changes (sushy cache lesson from 7a).
 | Slice | Deliverable | AC |
 |-------|-------------|-----|
 | **M0** | This design merged | Docs only |
-| **M1** | Stage runner skeleton; single-stage compat with 7a image-write | 7a still green |
+| **M1** | Stage runner skeleton; single-stage compat with 7a image-write | **Implemented** (single `os_install` stage; job fields + API) |
 | **M2** | Prep v1: wipe + `PREP_*` + handoff to image-write Ubuntu | Nested E2E |
 | **M3** | Offline seed preference #1 then #2: **second_media**, else **config_drive**, for Ubuntu NoCloud | Lab or hardware AC; no HTTP seed |
 | **M4** | Flatcar offline Ignition (same preference order) | Documented AC |

--- a/internal/cli/deploy.go
+++ b/internal/cli/deploy.go
@@ -70,6 +70,8 @@ func cmdDeployRun(args []string) int {
 	ubuntuISO := fs.String("ubuntu-iso", os.Getenv("SHOAL_UBUNTU_ISO"), "Ubuntu live-server ISO (legacy remaster)")
 	cloudImg := fs.String("ubuntu-cloud-img", os.Getenv("SHOAL_UBUNTU_CLOUD_IMG"), "Ubuntu cloud image for autoinstall build (preferred)")
 	isoHostname := fs.String("iso-hostname", "", "autoinstall hostname when building")
+	installStrategy := fs.String("install-strategy", "", "simulate|image_write (M1); reserved: scripted_iso|operator_iso")
+	prep := fs.String("prep", "", "prep policy (M1: empty or skip only)")
 	sshHost := fs.String("serial-ssh-host", cfg.SerialSSHHost, "SSH host for nested libvirt serial (VM mode)")
 	sshUser := fs.String("serial-ssh-user", cfg.SerialSSHUser, "SSH user for serial delegate")
 	sshKey := fs.String("serial-ssh-key", cfg.SerialSSHKey, "SSH private key for serial delegate")
@@ -118,6 +120,8 @@ func cmdDeployRun(args []string) int {
 		ISOInstallTarget: *isoTarget,
 		ISOUbuntuBase:    *ubuntuISO,
 		ISOHostname:      *isoHostname,
+		InstallStrategy:  *installStrategy,
+		Prep:             *prep,
 	}
 	// Cloud image is passed via env for the builder (StartJobRequest has no field yet for 7a.1).
 	if strings.TrimSpace(*cloudImg) != "" {

--- a/internal/common/models/models.go
+++ b/internal/common/models/models.go
@@ -65,6 +65,43 @@ const (
 	StateFailed       LifecycleState = "failed"
 )
 
+// Install strategy values (multi-stage design; M1 uses image_write / simulate).
+const (
+	InstallStrategySimulate    = "simulate"
+	InstallStrategyImageWrite  = "image_write"
+	InstallStrategyScriptedISO = "scripted_iso" // reserved; not expanded in M1
+	InstallStrategyOperatorISO = "operator_iso" // reserved; not expanded in M1
+)
+
+// Job stage kinds.
+const (
+	JobStageKindPrep      = "prep"
+	JobStageKindOSInstall = "os_install"
+	JobStageKindVerify    = "verify"
+)
+
+// Job stage runtime states.
+const (
+	JobStageStatePending = "pending"
+	JobStageStateRunning = "running"
+	JobStageStateDone    = "done"
+	JobStageStateFailed  = "failed"
+)
+
+// JobStage is one step in a multi-stage provisioning job (design M1+).
+type JobStage struct {
+	ID           string `json:"id"`
+	Kind         string `json:"kind"` // prep | os_install | verify
+	Strategy     string `json:"strategy,omitempty"`
+	Family       string `json:"family,omitempty"`
+	MediaURL     string `json:"media_url,omitempty"`
+	SeedMediaURL string `json:"seed_media_url,omitempty"`
+	SeedDelivery string `json:"seed_delivery,omitempty"`
+	State        string `json:"state"` // pending | running | done | failed
+	Phase        string `json:"phase,omitempty"`
+	Error        string `json:"error,omitempty"`
+}
+
 // ProvisioningJob is durable job state (JobStore / Postgres jobs table).
 type ProvisioningJob struct {
 	ID            string         `json:"id"`
@@ -86,6 +123,12 @@ type ProvisioningJob struct {
 	// CredentialRef is the secrets-backend key (never a password). Required for
 	// out-of-process cancel/orphan cleanup when SHOAL_SECRETS_DIR is shared.
 	CredentialRef string `json:"credential_ref,omitempty"`
+	// CurrentStage is the active stage id (multi-stage design M1+).
+	CurrentStage string `json:"current_stage,omitempty"`
+	// InstallStrategy is the primary OS install strategy for the job.
+	InstallStrategy string `json:"install_strategy,omitempty"`
+	// Stages is the expanded stage list (derived at Start; durable snapshot).
+	Stages []JobStage `json:"stages,omitempty"`
 }
 
 // RawAssetInput is Discover ingest (API/CLI).
@@ -196,6 +239,10 @@ type StartJobRequest struct {
 	ISOUbuntuBase string `json:"iso_ubuntu_base,omitempty"`
 	// ISOHostname is the autoinstall identity hostname (Phase 7a).
 	ISOHostname string `json:"iso_hostname,omitempty"`
+	// InstallStrategy is optional: simulate | image_write (M1). Other values reserved.
+	InstallStrategy string `json:"install_strategy,omitempty"`
+	// Prep is optional prep policy. M1 only allows empty or "skip"; wipe_only/full rejected.
+	Prep string `json:"prep,omitempty"`
 }
 
 // CancelJobRequest cancels an in-flight provisioning job.

--- a/internal/common/telemetry/schema.sql
+++ b/internal/common/telemetry/schema.sql
@@ -24,6 +24,11 @@ CREATE TABLE IF NOT EXISTS jobs (
 ALTER TABLE jobs ADD COLUMN IF NOT EXISTS system_id TEXT;
 ALTER TABLE jobs ADD COLUMN IF NOT EXISTS credential_ref TEXT;
 
+-- Multi-stage provisioning M1: stage runner metadata
+ALTER TABLE jobs ADD COLUMN IF NOT EXISTS current_stage TEXT;
+ALTER TABLE jobs ADD COLUMN IF NOT EXISTS install_strategy TEXT;
+ALTER TABLE jobs ADD COLUMN IF NOT EXISTS stages_json TEXT;
+
 CREATE TABLE IF NOT EXISTS events (
   id TEXT PRIMARY KEY,
   device_id TEXT NOT NULL,

--- a/internal/common/validate/validate.go
+++ b/internal/common/validate/validate.go
@@ -160,6 +160,18 @@ func StartJobRequest(r models.StartJobRequest) error {
 	if !hasUserPass && !hasRef {
 		return fmt.Errorf("validate: bmc credentials or credential_ref is required")
 	}
+	if s := strings.TrimSpace(r.InstallStrategy); s != "" {
+		switch s {
+		case models.InstallStrategySimulate, models.InstallStrategyImageWrite,
+			models.InstallStrategyScriptedISO, models.InstallStrategyOperatorISO:
+			// ok (scripted/operator reserved; expand may reject later)
+		default:
+			return fmt.Errorf("validate: unknown install_strategy %q", s)
+		}
+	}
+	if p := strings.TrimSpace(strings.ToLower(r.Prep)); p != "" && p != "skip" {
+		return fmt.Errorf("validate: prep %q not implemented (M1 allows only skip)", r.Prep)
+	}
 	return nil
 }
 

--- a/internal/common/validate/validate_test.go
+++ b/internal/common/validate/validate_test.go
@@ -86,4 +86,14 @@ func TestStartJobRequest(t *testing.T) {
 	if err := validate.StartJobRequest(build); err != nil {
 		t.Fatal(err)
 	}
+	// M1: prep wipe not allowed
+	prep := good
+	prep.Prep = "wipe_only"
+	if err := validate.StartJobRequest(prep); err == nil {
+		t.Fatal("expected prep wipe error")
+	}
+	prep.Prep = "skip"
+	if err := validate.StartJobRequest(prep); err != nil {
+		t.Fatal(err)
+	}
 }

--- a/internal/deploy/job/orchestrator.go
+++ b/internal/deploy/job/orchestrator.go
@@ -241,23 +241,34 @@ func (o *Orchestrator) Start(ctx context.Context, req models.StartJobRequest) (m
 		return models.ProvisioningJob{}, fmt.Errorf("job: resolve credentials: %w", err)
 	}
 
+	stages, err := expandStages(req)
+	if err != nil {
+		return models.ProvisioningJob{}, err
+	}
+	strategy := ""
+	if len(stages) > 0 {
+		strategy = stages[0].Strategy
+	}
+
 	profile := profileRef
 	now := time.Now().UTC()
 	sessionID := "sol-" + jobID
 	job := models.ProvisioningJob{
-		ID:            jobID,
-		DeviceID:      req.DeviceID,
-		ProfileRef:    profile,
-		State:         models.StateProvisioning,
-		Attempt:       1,
-		Phase:         "STARTING",
-		StartedAt:     &now,
-		UpdatedAt:     &now,
-		ISOURL:        req.ISOURL,
-		BMCEndpoint:   req.BMCEndpoint,
-		SystemID:      req.SystemID,
-		CredentialRef: credRef,
-		SOLSessionID:  sessionID,
+		ID:              jobID,
+		DeviceID:        req.DeviceID,
+		ProfileRef:      profile,
+		State:           models.StateProvisioning,
+		Attempt:         1,
+		Phase:           "STARTING",
+		StartedAt:       &now,
+		UpdatedAt:       &now,
+		ISOURL:          req.ISOURL,
+		BMCEndpoint:     req.BMCEndpoint,
+		SystemID:        req.SystemID,
+		CredentialRef:   credRef,
+		SOLSessionID:    sessionID,
+		InstallStrategy: strategy,
+		Stages:          stages,
 	}
 	if err := o.store.Insert(ctx, job); err != nil {
 		return models.ProvisioningJob{}, err
@@ -293,7 +304,66 @@ func (o *Orchestrator) Start(ctx context.Context, req models.StartJobRequest) (m
 	return out, nil
 }
 
+// provision runs the multi-stage job loop. M1 always has one os_install stage
+// (image_write/simulate media attach). Later slices add prep media swap.
 func (o *Orchestrator) provision(ctx context.Context, job models.ProvisioningJob, req models.StartJobRequest, cred secrets.Credential, rs *runState) error {
+	stages := job.Stages
+	if len(stages) == 0 {
+		var err error
+		stages, err = expandStages(req)
+		if err != nil {
+			return err
+		}
+	}
+	strategy := job.InstallStrategy
+	if strategy == "" && len(stages) > 0 {
+		strategy = stages[0].Strategy
+	}
+
+	for i := range stages {
+		st := stages[i]
+		stages = setStageState(stages, st.ID, models.JobStageStateRunning, "STARTING", "")
+		if err := o.store.UpdateStages(ctx, job.ID, st.ID, strategy, stages); err != nil {
+			return fmt.Errorf("persist stages: %w", err)
+		}
+		o.log.Info("stage start",
+			"job_id", job.ID,
+			"stage", st.ID,
+			"kind", st.Kind,
+			"strategy", st.Strategy,
+		)
+
+		var stageErr error
+		switch st.Kind {
+		case models.JobStageKindOSInstall:
+			stageErr = o.runOSInstallStage(ctx, job, req, cred, rs, st)
+		default:
+			stageErr = fmt.Errorf("job: stage kind %q not implemented", st.Kind)
+		}
+		if stageErr != nil {
+			stages = setStageState(stages, st.ID, models.JobStageStateFailed, "ERROR", stageErr.Error())
+			_ = o.store.UpdateStages(ctx, job.ID, st.ID, strategy, stages)
+			return stageErr
+		}
+		// M1: os_install returns after SOL watch is registered; terminal DONE is async.
+		// Mark stage running with WAITING_SOL; HandleTerminal finalizes the job.
+		stages = setStageState(stages, st.ID, models.JobStageStateRunning, "WAITING_SOL", "")
+		_ = o.store.UpdateStages(ctx, job.ID, st.ID, strategy, stages)
+	}
+	return nil
+}
+
+// runOSInstallStage attaches Virtual Media, boots once from CD, and registers SOL watch.
+// Terminal DONE is handled asynchronously via ApplyMarker → HandleTerminal (M1: job-terminal).
+func (o *Orchestrator) runOSInstallStage(ctx context.Context, job models.ProvisioningJob, req models.StartJobRequest, cred secrets.Credential, rs *runState, stage models.JobStage) error {
+	mediaURL := strings.TrimSpace(stage.MediaURL)
+	if mediaURL == "" {
+		mediaURL = strings.TrimSpace(req.ISOURL)
+	}
+	if mediaURL == "" {
+		return fmt.Errorf("os_install: media_url is empty")
+	}
+
 	bmc, err := o.newBMC(redfish.Config{
 		BaseURL:       req.BMCEndpoint,
 		Username:      cred.Username,
@@ -340,7 +410,7 @@ func (o *Orchestrator) provision(ctx context.Context, job models.ProvisioningJob
 	if mediaURI == "" {
 		return fmt.Errorf("no CD-capable virtual media slot")
 	}
-	if err := bmc.InsertVirtualMedia(ctx, mediaURI, req.ISOURL); err != nil {
+	if err := bmc.InsertVirtualMedia(ctx, mediaURI, mediaURL); err != nil {
 		return fmt.Errorf("insert media: %w", err)
 	}
 	if err := bmc.SetBootOverrideOnceCD(ctx, sys.ID); err != nil {
@@ -370,10 +440,6 @@ func (o *Orchestrator) provision(ctx context.Context, job models.ProvisioningJob
 		StartedAt:    time.Now().UTC(),
 		StallTimeout: stall,
 	}
-	// Persist sol session id via progress soft field isn't ideal; update job through transition is wrong.
-	// Use UpdateProgress for phase only; SOLSessionID stored in runState + optional store field via re-insert not available.
-	// Patch: store Transition doesn't set sol_session_id. Memory/Postgres need a SetSession helper or we encode in running map only.
-	// For status API, re-read job won't show session — acceptable for Phase 2 if we UpdateProgress detail.
 	_ = o.store.UpdateProgress(ctx, job.ID, "WAITING_SOL", nil, 0, "")
 
 	if err := o.watches.Register(ctx, session); err != nil {
@@ -384,7 +450,9 @@ func (o *Orchestrator) provision(ctx context.Context, job models.ProvisioningJob
 		"job_id", job.ID,
 		"device_id", job.DeviceID,
 		"bmc", req.BMCEndpoint,
-		"iso_url", req.ISOURL,
+		"iso_url", mediaURL,
+		"stage", stage.ID,
+		"strategy", stage.Strategy,
 		// never log password
 	)
 	return nil

--- a/internal/deploy/job/orchestrator.go
+++ b/internal/deploy/job/orchestrator.go
@@ -615,6 +615,24 @@ func (o *Orchestrator) handleTerminalOnce(ctx context.Context, jobID string, rea
 		errMsg = string(reason)
 	}
 
+	// Mark current stage terminal for accurate job status (M1+).
+	if len(job.Stages) > 0 {
+		stageID := job.CurrentStage
+		if stageID == "" {
+			stageID = job.Stages[len(job.Stages)-1].ID
+		}
+		stageState := models.JobStageStateFailed
+		stagePhase := job.Phase
+		if to == models.StateProvisioned {
+			stageState = models.JobStageStateDone
+			if stagePhase == "" {
+				stagePhase = "DONE"
+			}
+		}
+		stages := setStageState(job.Stages, stageID, stageState, stagePhase, errMsg)
+		_ = o.store.UpdateStages(context.Background(), jobID, stageID, job.InstallStrategy, stages)
+	}
+
 	// Always commit lifecycle with Background so waiters observe the terminal state
 	// even if the terminalLoop request context already expired.
 	if err := o.store.Transition(context.Background(), jobID, to, errMsg); err != nil {

--- a/internal/deploy/job/stages.go
+++ b/internal/deploy/job/stages.go
@@ -1,0 +1,74 @@
+package job
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/mattcburns/shoal/internal/common/models"
+	"github.com/mattcburns/shoal/internal/deploy/iso"
+)
+
+// expandStages derives the stage list for a StartJobRequest (multi-stage design M1).
+// M1 always returns a single os_install stage; multi-stage expansion lands in M2+.
+func expandStages(req models.StartJobRequest) ([]models.JobStage, error) {
+	if p := strings.TrimSpace(strings.ToLower(req.Prep)); p != "" && p != "skip" {
+		return nil, fmt.Errorf("job: prep %q not implemented (M1 allows only skip)", req.Prep)
+	}
+	strategy, err := resolveInstallStrategy(req)
+	if err != nil {
+		return nil, err
+	}
+	// M1: scripted_iso / operator_iso are accepted by validate but not expanded yet.
+	switch strategy {
+	case models.InstallStrategyScriptedISO, models.InstallStrategyOperatorISO:
+		return nil, fmt.Errorf("job: install_strategy %q not implemented in M1 (use image_write or simulate)", strategy)
+	}
+
+	media := strings.TrimSpace(req.ISOURL)
+	stage := models.JobStage{
+		ID:           models.JobStageKindOSInstall,
+		Kind:         models.JobStageKindOSInstall,
+		Strategy:     strategy,
+		MediaURL:     media,
+		SeedDelivery: "none",
+		State:        models.JobStageStatePending,
+	}
+	return []models.JobStage{stage}, nil
+}
+
+func resolveInstallStrategy(req models.StartJobRequest) (string, error) {
+	if s := strings.TrimSpace(req.InstallStrategy); s != "" {
+		return s, nil
+	}
+	mode := strings.TrimSpace(strings.ToLower(req.ISOInstallMode))
+	switch mode {
+	case iso.InstallModeWrite, iso.InstallModeAutoinstall:
+		return models.InstallStrategyImageWrite, nil
+	case iso.InstallModeSimulate:
+		return models.InstallStrategySimulate, nil
+	case "":
+		// Default: treat as image_write-compatible media attach (7a cloud ISO, marker write, etc.).
+		return models.InstallStrategyImageWrite, nil
+	default:
+		return models.InstallStrategyImageWrite, nil
+	}
+}
+
+// setStageState updates the stage with id in a copy of the list.
+func setStageState(stages []models.JobStage, id, state, phase, errMsg string) []models.JobStage {
+	out := make([]models.JobStage, len(stages))
+	copy(out, stages)
+	for i := range out {
+		if out[i].ID == id {
+			out[i].State = state
+			if phase != "" {
+				out[i].Phase = phase
+			}
+			if errMsg != "" {
+				out[i].Error = errMsg
+			}
+			break
+		}
+	}
+	return out
+}

--- a/internal/deploy/job/stages_test.go
+++ b/internal/deploy/job/stages_test.go
@@ -1,0 +1,81 @@
+package job
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/mattcburns/shoal/internal/common/models"
+	"github.com/mattcburns/shoal/internal/deploy/iso"
+)
+
+func TestExpandStagesSingleOSInstall(t *testing.T) {
+	stages, err := expandStages(models.StartJobRequest{
+		ISOURL:         "http://example/marker.iso",
+		ISOInstallMode: iso.InstallModeAutoinstall,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(stages) != 1 {
+		t.Fatalf("len=%d", len(stages))
+	}
+	st := stages[0]
+	if st.Kind != models.JobStageKindOSInstall || st.ID != models.JobStageKindOSInstall {
+		t.Fatalf("stage: %+v", st)
+	}
+	if st.Strategy != models.InstallStrategyImageWrite {
+		t.Fatalf("strategy=%s", st.Strategy)
+	}
+	if st.MediaURL != "http://example/marker.iso" {
+		t.Fatalf("media=%s", st.MediaURL)
+	}
+	if st.State != models.JobStageStatePending {
+		t.Fatalf("state=%s", st.State)
+	}
+}
+
+func TestExpandStagesSimulate(t *testing.T) {
+	stages, err := expandStages(models.StartJobRequest{
+		ISOURL:          "http://example/m.iso",
+		InstallStrategy: models.InstallStrategySimulate,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stages[0].Strategy != models.InstallStrategySimulate {
+		t.Fatalf("got %s", stages[0].Strategy)
+	}
+}
+
+func TestExpandStagesRejectsPrepWipe(t *testing.T) {
+	_, err := expandStages(models.StartJobRequest{
+		ISOURL: "http://example/m.iso",
+		Prep:   "wipe_only",
+	})
+	if err == nil || !strings.Contains(err.Error(), "not implemented") {
+		t.Fatalf("want not implemented, got %v", err)
+	}
+}
+
+func TestExpandStagesRejectsScriptedISO(t *testing.T) {
+	_, err := expandStages(models.StartJobRequest{
+		ISOURL:          "http://example/m.iso",
+		InstallStrategy: models.InstallStrategyScriptedISO,
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestSetStageState(t *testing.T) {
+	stages := []models.JobStage{
+		{ID: "os_install", State: models.JobStageStatePending},
+	}
+	out := setStageState(stages, "os_install", models.JobStageStateRunning, "WAITING_SOL", "")
+	if out[0].State != models.JobStageStateRunning || out[0].Phase != "WAITING_SOL" {
+		t.Fatalf("%+v", out[0])
+	}
+	if stages[0].State != models.JobStageStatePending {
+		t.Fatal("original mutated")
+	}
+}

--- a/internal/deploy/jobstore/memory.go
+++ b/internal/deploy/jobstore/memory.go
@@ -112,6 +112,23 @@ func (m *Memory) UpdateRuntime(_ context.Context, jobID string, systemID, solSes
 	return nil
 }
 
+// UpdateStages persists stage runner metadata.
+func (m *Memory) UpdateStages(_ context.Context, jobID string, currentStage, installStrategy string, stages []models.JobStage) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	j, ok := m.jobs[jobID]
+	if !ok {
+		return ErrNotFound
+	}
+	j.CurrentStage = currentStage
+	j.InstallStrategy = installStrategy
+	j.Stages = cloneStages(stages)
+	now := time.Now().UTC()
+	j.UpdatedAt = &now
+	m.jobs[jobID] = j
+	return nil
+}
+
 // Transition sets lifecycle state and optional error message.
 func (m *Memory) Transition(_ context.Context, jobID string, to models.LifecycleState, errMsg string) error {
 	m.mu.Lock()
@@ -144,5 +161,15 @@ func cloneJob(j models.ProvisioningJob) models.ProvisioningJob {
 		t := *j.UpdatedAt
 		out.UpdatedAt = &t
 	}
+	out.Stages = cloneStages(j.Stages)
+	return out
+}
+
+func cloneStages(in []models.JobStage) []models.JobStage {
+	if in == nil {
+		return nil
+	}
+	out := make([]models.JobStage, len(in))
+	copy(out, in)
 	return out
 }

--- a/internal/deploy/jobstore/memory_test.go
+++ b/internal/deploy/jobstore/memory_test.go
@@ -67,3 +67,31 @@ func TestMemoryUpdateRuntime(t *testing.T) {
 		t.Fatalf("%+v", got)
 	}
 }
+
+func TestMemoryUpdateStages(t *testing.T) {
+	ctx := context.Background()
+	s := jobstore.NewMemory()
+	if err := s.Insert(ctx, models.ProvisioningJob{
+		ID: "j3", DeviceID: "d3", State: models.StateProvisioning,
+		Stages: []models.JobStage{{ID: "os_install", Kind: "os_install", State: "pending"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	stages := []models.JobStage{{
+		ID: "os_install", Kind: "os_install", Strategy: "image_write",
+		State: "running", Phase: "WAITING_SOL", MediaURL: "http://x/y.iso",
+	}}
+	if err := s.UpdateStages(ctx, "j3", "os_install", "image_write", stages); err != nil {
+		t.Fatal(err)
+	}
+	got, err := s.Get(ctx, "j3")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.CurrentStage != "os_install" || got.InstallStrategy != "image_write" {
+		t.Fatalf("%+v", got)
+	}
+	if len(got.Stages) != 1 || got.Stages[0].State != "running" || got.Stages[0].Phase != "WAITING_SOL" {
+		t.Fatalf("stages %+v", got.Stages)
+	}
+}

--- a/internal/deploy/jobstore/postgres.go
+++ b/internal/deploy/jobstore/postgres.go
@@ -3,6 +3,7 @@ package jobstore
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
@@ -29,17 +30,22 @@ func (p *Postgres) Insert(ctx context.Context, job models.ProvisioningJob) error
 	if job.UpdatedAt == nil {
 		job.UpdatedAt = &now
 	}
-	_, err := p.db.ExecContext(ctx, `
+	stagesJSON, err := marshalStages(job.Stages)
+	if err != nil {
+		return fmt.Errorf("jobstore: stages: %w", err)
+	}
+	_, err = p.db.ExecContext(ctx, `
 INSERT INTO jobs (
   id, device_id, profile_ref, state, attempt, phase, percent, last_marker_seq,
   started_at, updated_at, error, sol_session_id, iso_url, bmc_endpoint,
-  system_id, credential_ref
-) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16)`,
+  system_id, credential_ref, current_stage, install_strategy, stages_json
+) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19)`,
 		job.ID, job.DeviceID, job.ProfileRef, string(job.State), job.Attempt,
 		nullString(job.Phase), nullInt(job.Percent), job.LastMarkerSeq,
 		job.StartedAt, job.UpdatedAt, nullString(job.Error), nullString(job.SOLSessionID),
 		nullString(job.ISOURL), nullString(job.BMCEndpoint),
 		nullString(job.SystemID), nullString(job.CredentialRef),
+		nullString(job.CurrentStage), nullString(job.InstallStrategy), nullString(stagesJSON),
 	)
 	if err != nil {
 		return fmt.Errorf("jobstore: insert: %w", err)
@@ -52,7 +58,7 @@ func (p *Postgres) Get(ctx context.Context, id string) (models.ProvisioningJob, 
 	row := p.db.QueryRowContext(ctx, `
 SELECT id, device_id, profile_ref, state, attempt, phase, percent, last_marker_seq,
        started_at, updated_at, error, sol_session_id, iso_url, bmc_endpoint,
-       system_id, credential_ref
+       system_id, credential_ref, current_stage, install_strategy, stages_json
 FROM jobs WHERE id = $1`, id)
 	j, err := scanJob(row)
 	if errors.Is(err, sql.ErrNoRows) {
@@ -69,7 +75,7 @@ func (p *Postgres) ListByState(ctx context.Context, state models.LifecycleState)
 	rows, err := p.db.QueryContext(ctx, `
 SELECT id, device_id, profile_ref, state, attempt, phase, percent, last_marker_seq,
        started_at, updated_at, error, sol_session_id, iso_url, bmc_endpoint,
-       system_id, credential_ref
+       system_id, credential_ref, current_stage, install_strategy, stages_json
 FROM jobs WHERE state = $1`, string(state))
 	if err != nil {
 		return nil, fmt.Errorf("jobstore: list: %w", err)
@@ -127,6 +133,30 @@ WHERE id = $1`, jobID, systemID, solSessionID, credentialRef, now)
 	return nil
 }
 
+// UpdateStages persists stage runner metadata.
+func (p *Postgres) UpdateStages(ctx context.Context, jobID string, currentStage, installStrategy string, stages []models.JobStage) error {
+	stagesJSON, err := marshalStages(stages)
+	if err != nil {
+		return fmt.Errorf("jobstore: stages: %w", err)
+	}
+	now := time.Now().UTC()
+	res, err := p.db.ExecContext(ctx, `
+UPDATE jobs SET
+  current_stage = $2,
+  install_strategy = $3,
+  stages_json = $4,
+  updated_at = $5
+WHERE id = $1`, jobID, nullString(currentStage), nullString(installStrategy), nullString(stagesJSON), now)
+	if err != nil {
+		return fmt.Errorf("jobstore: update stages: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
 // Transition sets lifecycle state.
 func (p *Postgres) Transition(ctx context.Context, jobID string, to models.LifecycleState, errMsg string) error {
 	now := time.Now().UTC()
@@ -154,13 +184,14 @@ func scanJob(row scannable) (models.ProvisioningJob, error) {
 	var j models.ProvisioningJob
 	var state string
 	var phase, errMsg, solSess, iso, bmc, sysID, credRef sql.NullString
+	var curStage, instStrat, stagesJSON sql.NullString
 	var percent sql.NullInt64
 	var started, updated sql.NullTime
 	err := row.Scan(
 		&j.ID, &j.DeviceID, &j.ProfileRef, &state, &j.Attempt,
 		&phase, &percent, &j.LastMarkerSeq,
 		&started, &updated, &errMsg, &solSess, &iso, &bmc,
-		&sysID, &credRef,
+		&sysID, &credRef, &curStage, &instStrat, &stagesJSON,
 	)
 	if err != nil {
 		return models.ProvisioningJob{}, err
@@ -199,7 +230,29 @@ func scanJob(row scannable) (models.ProvisioningJob, error) {
 	if credRef.Valid {
 		j.CredentialRef = credRef.String
 	}
+	if curStage.Valid {
+		j.CurrentStage = curStage.String
+	}
+	if instStrat.Valid {
+		j.InstallStrategy = instStrat.String
+	}
+	if stagesJSON.Valid && stagesJSON.String != "" {
+		if err := json.Unmarshal([]byte(stagesJSON.String), &j.Stages); err != nil {
+			return models.ProvisioningJob{}, fmt.Errorf("jobstore: stages_json: %w", err)
+		}
+	}
 	return j, nil
+}
+
+func marshalStages(stages []models.JobStage) (string, error) {
+	if len(stages) == 0 {
+		return "", nil
+	}
+	b, err := json.Marshal(stages)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
 }
 
 func nullString(s string) any {

--- a/internal/deploy/jobstore/store.go
+++ b/internal/deploy/jobstore/store.go
@@ -20,5 +20,7 @@ type Store interface {
 	UpdateProgress(ctx context.Context, jobID string, phase string, percent *int, seq int, errSoft string) error
 	// UpdateRuntime persists BMC runtime coordinates for cancel/orphan cleanup.
 	UpdateRuntime(ctx context.Context, jobID string, systemID, solSessionID, credentialRef string) error
+	// UpdateStages persists multi-stage runner fields (current_stage, strategy, stages list).
+	UpdateStages(ctx context.Context, jobID string, currentStage, installStrategy string, stages []models.JobStage) error
 	Transition(ctx context.Context, jobID string, to models.LifecycleState, errMsg string) error
 }


### PR DESCRIPTION
## Summary

Implements design slice **M1** from [`docs/multi-stage-provisioning-design.md`](docs/multi-stage-provisioning-design.md):

- **`expandStages`**: classic `StartJobRequest` → one `os_install` stage (`image_write` / `simulate`)
- Durable job fields: `current_stage`, `install_strategy`, `stages` (+ Postgres `stages_json`)
- Orchestrator **stage loop** + `runOSInstallStage` (behavior-compatible Virtual Media + SOL)
- Optional `install_strategy` / `prep` on request; `prep=wipe_only|full` rejected (not silent)
- CLI `-install-strategy` / `-prep`; status JSON already includes new fields

**Still deferred (M2+):** prep wipe, media swap, second_media/config_drive, operator_iso, multi-stage DONE policy.

## Test plan

- [x] `go test ./internal/deploy/... ./internal/common/validate/... ./internal/cli/...`
- [x] `go vet` on touched packages
- [x] Unit: expandStages, UpdateStages, prep validation
- [ ] Lab optional: 7a cloud-image deploy still `provisioned`