### PR TITLE
feat(deploy): multi-stage M2 prep wipe + stage advance

### DIFF
--- a/docs/lab-runbook.md
+++ b/docs/lab-runbook.md
@@ -410,6 +410,41 @@ go run ./cmd/shoal deploy iso build \
 Cloud image-write typically finishes in a few minutes once media is attached;
 live autoinstall (if used) can take 20–60+ minutes on nested CPU.
 
+### Multi-stage M2: prep wipe then OS install
+
+One job can run a **prep** stage (wipe disk + `PREP_*` SOL markers) then advance to
+**os_install** (cloud image-write ISO). Requires M2 binary and two media URLs.
+
+**Build prep ISO (L1):**
+
+```bash
+sudo env SHOAL_INSTALL_MODE=prep SHOAL_INSTALL_TARGET=/dev/vda \
+  SHOAL_ISO_NAME=shoal-prep.iso \
+  ./infra/scripts/build-marker-iso.sh /srv/iso/shoal-prep.iso
+```
+
+**Deploy wipe + install** (operator host; approve wipe):
+
+```bash
+go run ./cmd/shoal deploy run \
+  -device-id shoal-node-1 \
+  -bmc-url http://192.168.122.100:8001 \
+  -bmc-user admin -bmc-pass password \
+  -serial-target shoal-node-1 \
+  -serial-ssh-host 192.168.122.100 \
+  -serial-ssh-user lab \
+  -serial-ssh-key "$HOME/.ssh/shoal_lab_vm" \
+  -prep wipe_only \
+  -approve-destruct \
+  -prep-iso-url http://192.168.124.1:8080/shoal-prep.iso \
+  -iso-url http://192.168.124.1:8080/shoal-ubuntu-m1-test.iso \
+  -install-strategy image_write \
+  -stall-timeout 15m -wait-timeout 30m -wait
+```
+
+`PREP_DONE` does **not** complete the job; only the final install `DONE` yields
+`provisioned`. Status JSON shows `current_stage` moving from `prep` → `os_install`.
+
 ### Phase 6b: graphics failure-screen OCR
 
 SOL remains the primary progress channel. Graphics OCR is **diagnostic only**.

--- a/docs/multi-stage-provisioning-design.md
+++ b/docs/multi-stage-provisioning-design.md
@@ -801,7 +801,7 @@ Version media URLs when content changes (sushy cache lesson from 7a).
 |-------|-------------|-----|
 | **M0** | This design merged | Docs only |
 | **M1** | Stage runner skeleton; single-stage compat with 7a image-write | **Implemented** (single `os_install` stage; job fields + API) |
-| **M2** | Prep v1: wipe + `PREP_*` + handoff to image-write Ubuntu | Nested E2E |
+| **M2** | Prep v1: wipe + `PREP_*` + handoff to image-write Ubuntu | **Implemented** (event-driven `PREP_DONE` → os_install) |
 | **M3** | Offline seed preference #1 then #2: **second_media**, else **config_drive**, for Ubuntu NoCloud | Lab or hardware AC; no HTTP seed |
 | **M4** | Flatcar offline Ignition (same preference order) | Documented AC |
 | **M5** | **`operator_iso`** path shared by ESXi + Windows shape (attach + boot + cleanup + coarse progress) | Hardware preferred |

--- a/infra/scripts/build-marker-iso.sh
+++ b/infra/scripts/build-marker-iso.sh
@@ -95,9 +95,9 @@ fi
 
 INSTALL_MODE="${SHOAL_INSTALL_MODE:-simulate}"
 case "$INSTALL_MODE" in
-  simulate|write|autoinstall) ;;
+  simulate|write|autoinstall|prep) ;;
   *)
-    echo "error: SHOAL_INSTALL_MODE must be simulate|write|autoinstall (got $INSTALL_MODE)" >&2
+    echo "error: SHOAL_INSTALL_MODE must be simulate|write|autoinstall|prep (got $INSTALL_MODE)" >&2
     exit 1
     ;;
 esac
@@ -111,9 +111,19 @@ if [[ "$INSTALL_MODE" == "autoinstall" ]]; then
     SHOAL_INSTALL_TARGET="/dev/vda"
   fi
 fi
-# Baked default target for write mode (can be overridden by kernel cmdline shoal.target=).
+# prep: wipe install disk and emit PREP_* markers (multi-stage M2); no OS payload.
+if [[ "$INSTALL_MODE" == "prep" ]]; then
+  if [[ -z "${SHOAL_INSTALL_TARGET:-}" ]]; then
+    SHOAL_INSTALL_TARGET="/dev/vda"
+  fi
+  # Power off after wipe so orchestrator can attach OS media cleanly.
+  SHOAL_INSTALL_REBOOT="${SHOAL_INSTALL_REBOOT:-0}"
+fi
+# Baked default target for write/prep mode (overridable via kernel cmdline shoal.target=).
 INSTALL_TARGET_DEFAULT="${SHOAL_INSTALL_TARGET:-}"
 INSTALL_REBOOT="${SHOAL_INSTALL_REBOOT:-0}"
+# Wipe style for prep: discard (try blkdiscard) or zero (dd first N MiB of disk).
+PREP_WIPE_LEVEL="${SHOAL_PREP_WIPE_LEVEL:-discard}"
 
 echo "kernel:  $KERNEL"
 echo "busybox: $BUSYBOX"
@@ -238,6 +248,7 @@ fi
 printf '%s\n' "$INSTALL_MODE" > "$ROOT/install_mode"
 printf '%s\n' "$INSTALL_TARGET_DEFAULT" > "$ROOT/install_target_default"
 printf '%s\n' "$INSTALL_REBOOT" > "$ROOT/install_reboot"
+printf '%s\n' "$PREP_WIPE_LEVEL" > "$ROOT/prep_wipe_level"
 
 # Init emits markers then powers off. console=ttyS0 from kernel cmdline.
 cat > "$ROOT/init" << 'INIT'
@@ -422,6 +433,66 @@ if [ -f /install_reboot ]; then
   REBOOT="$(cat /install_reboot 2>/dev/null | tr -d '\n' || echo 0)"
 fi
 
+WIPE_LEVEL="discard"
+if [ -f /prep_wipe_level ]; then
+  WIPE_LEVEL="$(cat /prep_wipe_level 2>/dev/null | tr -d '\n' || echo discard)"
+fi
+
+if [ "$MODE" = "prep" ]; then
+  emit PREP_BOOT 0 OK "prep live image started"
+  sleep 1
+  emit PREP_BOOT - HEARTBEAT ""
+  if [ -z "$TARGET" ]; then
+    for cand in /dev/vda /dev/sda /dev/nvme0n1; do
+      if [ -b "$cand" ]; then TARGET="$cand"; break; fi
+    done
+  fi
+  if [ -z "$TARGET" ] || [ ! -b "$TARGET" ]; then
+    emit ERROR 0 ERROR "prep: no wipe target block device"
+    sleep 2
+    /bin/busybox poweroff -f 2>/dev/null || true
+    while true; do sleep 3600; done
+  fi
+  emit PREP_WIPE 10 OK "wipe start target=${TARGET} level=${WIPE_LEVEL}"
+  wiped=0
+  if [ "$WIPE_LEVEL" = "discard" ]; then
+    # busybox may not have blkdiscard; try if present
+    if command -v blkdiscard >/dev/null 2>&1; then
+      if blkdiscard -f "$TARGET" 2>/dev/null; then
+        wiped=1
+        emit PREP_WIPE 80 OK "blkdiscard ok target=${TARGET}"
+      fi
+    fi
+  fi
+  if [ "$wiped" = "0" ]; then
+    # Destroy partition table + FS superblocks (first 64 MiB) — enough for reimage.
+    emit PREP_WIPE 30 OK "zeroing start of ${TARGET}"
+    (
+      while true; do
+        sleep 10
+        emit PREP_WIPE - HEARTBEAT "zeroing ${TARGET}"
+      done
+    ) &
+    HBPID=$!
+    if dd if=/dev/zero of="$TARGET" bs=1M count=64 conv=fsync 2>/dev/null; then
+      kill "$HBPID" 2>/dev/null || true
+      emit PREP_WIPE 90 OK "zeroed 64MiB target=${TARGET}"
+    else
+      kill "$HBPID" 2>/dev/null || true
+      emit ERROR 0 ERROR "prep wipe dd failed target=${TARGET}"
+      sleep 2
+      /bin/busybox poweroff -f 2>/dev/null || true
+      while true; do sleep 3600; done
+    fi
+  fi
+  sync 2>/dev/null || true
+  emit PREP_WIPE 100 OK "wipe finished target=${TARGET}"
+  emit PREP_DONE 100 OK "prep complete ready for os install"
+  sleep 1
+  /bin/busybox poweroff -f 2>/dev/null || /bin/busybox reboot -f 2>/dev/null || true
+  while true; do sleep 3600; done
+fi
+
 if [ "$MODE" = "write" ] && [ -n "$PAYLOAD" ] && [ -f "$PAYLOAD" ]; then
   emit DISK_PREP 5 OK "resolving install target"
   # Resolve write target.
@@ -566,7 +637,6 @@ CMDLINE="initrd=/boot/initrd.img console=ttyS0,115200n8 console=tty0 quiet shoal
 if [[ -n "$INSTALL_TARGET_DEFAULT" ]]; then
   CMDLINE="${CMDLINE} shoal.target=${INSTALL_TARGET_DEFAULT}"
 fi
-
 cat > "$ISO/boot/isolinux/isolinux.cfg" << CFG
 DEFAULT shoal
 PROMPT 0
@@ -579,6 +649,8 @@ CFG
 VOLID="SHOAL_MARKER"
 if [[ "$INSTALL_MODE" = "write" ]]; then
   VOLID="SHOAL_INSTALL"
+elif [[ "$INSTALL_MODE" = "prep" ]]; then
+  VOLID="SHOAL_PREP"
 fi
 
 mkdir -p "$(dirname "$OUT")"

--- a/infra/scripts/build-marker-iso.sh
+++ b/infra/scripts/build-marker-iso.sh
@@ -488,9 +488,13 @@ if [ "$MODE" = "prep" ]; then
   sync 2>/dev/null || true
   emit PREP_WIPE 100 OK "wipe finished target=${TARGET}"
   emit PREP_DONE 100 OK "prep complete ready for os install"
-  sleep 1
-  /bin/busybox poweroff -f 2>/dev/null || /bin/busybox reboot -f 2>/dev/null || true
-  while true; do sleep 3600; done
+  # Stay powered on with heartbeats so the orchestrator can swap Virtual Media
+  # and ForceRestart into the OS install ISO without losing the serial PTY
+  # (poweroff left nested libvirt serial unusable for the next stage).
+  while true; do
+    sleep 15
+    emit PREP_DONE - HEARTBEAT "awaiting os install media swap"
+  done
 fi
 
 if [ "$MODE" = "write" ] && [ -n "$PAYLOAD" ] && [ -f "$PAYLOAD" ]; then

--- a/internal/cli/deploy.go
+++ b/internal/cli/deploy.go
@@ -71,7 +71,9 @@ func cmdDeployRun(args []string) int {
 	cloudImg := fs.String("ubuntu-cloud-img", os.Getenv("SHOAL_UBUNTU_CLOUD_IMG"), "Ubuntu cloud image for autoinstall build (preferred)")
 	isoHostname := fs.String("iso-hostname", "", "autoinstall hostname when building")
 	installStrategy := fs.String("install-strategy", "", "simulate|image_write (M1); reserved: scripted_iso|operator_iso")
-	prep := fs.String("prep", "", "prep policy (M1: empty or skip only)")
+	prep := fs.String("prep", "", "skip (default) | wipe_only (M2 multi-stage prep)")
+	prepISO := fs.String("prep-iso-url", os.Getenv("SHOAL_PREP_ISO_URL"), "BMC-reachable prep live ISO (wipe_only)")
+	wipeLevel := fs.String("wipe-level", "", "discard|zero (baked into prep ISO at build; optional)")
 	sshHost := fs.String("serial-ssh-host", cfg.SerialSSHHost, "SSH host for nested libvirt serial (VM mode)")
 	sshUser := fs.String("serial-ssh-user", cfg.SerialSSHUser, "SSH user for serial delegate")
 	sshKey := fs.String("serial-ssh-key", cfg.SerialSSHKey, "SSH private key for serial delegate")
@@ -122,6 +124,8 @@ func cmdDeployRun(args []string) int {
 		ISOHostname:      *isoHostname,
 		InstallStrategy:  *installStrategy,
 		Prep:             *prep,
+		PrepISOURL:       *prepISO,
+		WipeLevel:        *wipeLevel,
 	}
 	// Cloud image is passed via env for the builder (StartJobRequest has no field yet for 7a.1).
 	if strings.TrimSpace(*cloudImg) != "" {

--- a/internal/common/models/models.go
+++ b/internal/common/models/models.go
@@ -241,8 +241,12 @@ type StartJobRequest struct {
 	ISOHostname string `json:"iso_hostname,omitempty"`
 	// InstallStrategy is optional: simulate | image_write (M1). Other values reserved.
 	InstallStrategy string `json:"install_strategy,omitempty"`
-	// Prep is optional prep policy. M1 only allows empty or "skip"; wipe_only/full rejected.
+	// Prep is optional: skip (default) | wipe_only (M2 multi-stage prep).
 	Prep string `json:"prep,omitempty"`
+	// PrepISOURL is the BMC-reachable prep live ISO (required when prep=wipe_only unless SHOAL_PREP_ISO_URL).
+	PrepISOURL string `json:"prep_iso_url,omitempty"`
+	// WipeLevel is discard (prefer blkdiscard) or zero (dd first 64MiB). Prep only.
+	WipeLevel string `json:"wipe_level,omitempty"`
 }
 
 // CancelJobRequest cancels an in-flight provisioning job.

--- a/internal/common/validate/validate.go
+++ b/internal/common/validate/validate.go
@@ -3,6 +3,7 @@ package validate
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/mattcburns/shoal/internal/common/models"
@@ -169,8 +170,28 @@ func StartJobRequest(r models.StartJobRequest) error {
 			return fmt.Errorf("validate: unknown install_strategy %q", s)
 		}
 	}
-	if p := strings.TrimSpace(strings.ToLower(r.Prep)); p != "" && p != "skip" {
-		return fmt.Errorf("validate: prep %q not implemented (M1 allows only skip)", r.Prep)
+	prep := strings.TrimSpace(strings.ToLower(r.Prep))
+	switch prep {
+	case "", "skip":
+		// ok
+	case "wipe_only":
+		if !r.ApproveDestruct {
+			return fmt.Errorf("validate: prep wipe_only requires approve_destruct")
+		}
+		prepISO := strings.TrimSpace(r.PrepISOURL)
+		if prepISO == "" {
+			prepISO = strings.TrimSpace(os.Getenv("SHOAL_PREP_ISO_URL"))
+		}
+		if prepISO == "" {
+			return fmt.Errorf("validate: prep wipe_only requires prep_iso_url or SHOAL_PREP_ISO_URL")
+		}
+	case "full":
+		return fmt.Errorf("validate: prep full not implemented (use wipe_only)")
+	default:
+		return fmt.Errorf("validate: unknown prep %q", r.Prep)
+	}
+	if w := strings.TrimSpace(strings.ToLower(r.WipeLevel)); w != "" && w != "discard" && w != "zero" {
+		return fmt.Errorf("validate: wipe_level must be discard or zero")
 	}
 	return nil
 }

--- a/internal/common/validate/validate_test.go
+++ b/internal/common/validate/validate_test.go
@@ -86,11 +86,16 @@ func TestStartJobRequest(t *testing.T) {
 	if err := validate.StartJobRequest(build); err != nil {
 		t.Fatal(err)
 	}
-	// M1: prep wipe not allowed
+	// M2: prep wipe requires approve + prep ISO
 	prep := good
 	prep.Prep = "wipe_only"
 	if err := validate.StartJobRequest(prep); err == nil {
-		t.Fatal("expected prep wipe error")
+		t.Fatal("expected prep wipe without approve to fail")
+	}
+	prep.ApproveDestruct = true
+	prep.PrepISOURL = "http://lab:8080/shoal-prep.iso"
+	if err := validate.StartJobRequest(prep); err != nil {
+		t.Fatal(err)
 	}
 	prep.Prep = "skip"
 	if err := validate.StartJobRequest(prep); err != nil {

--- a/internal/deploy/iso/iso.go
+++ b/internal/deploy/iso/iso.go
@@ -17,6 +17,7 @@ const (
 	InstallModeSimulate    = "simulate"    // Phase 2 marker demo (default)
 	InstallModeWrite       = "write"       // Phase 6a: write /payload with real SOL progress
 	InstallModeAutoinstall = "autoinstall" // Phase 7a: Ubuntu autoinstall remaster
+	InstallModePrep        = "prep"        // M2: wipe disk + PREP_* markers
 )
 
 // BuildInput describes a live-image build request.
@@ -94,15 +95,18 @@ func (b *ScriptBuilder) Build(ctx context.Context, in BuildInput) (Artifact, err
 	if mode == "" {
 		mode = InstallModeSimulate
 	}
-	if mode != InstallModeSimulate && mode != InstallModeWrite && mode != InstallModeAutoinstall {
-		return Artifact{}, fmt.Errorf("iso: invalid install mode %q (want simulate|write|autoinstall)", mode)
+	if mode != InstallModeSimulate && mode != InstallModeWrite && mode != InstallModeAutoinstall && mode != InstallModePrep {
+		return Artifact{}, fmt.Errorf("iso: invalid install mode %q (want simulate|write|autoinstall|prep)", mode)
 	}
 
 	name := strings.TrimSpace(in.Name)
 	if name == "" {
-		if mode == InstallModeAutoinstall {
+		switch mode {
+		case InstallModeAutoinstall:
 			name = "shoal-ubuntu-autoinstall.iso"
-		} else {
+		case InstallModePrep:
+			name = "shoal-prep.iso"
+		default:
 			name = "shoal-marker.iso"
 		}
 	}
@@ -213,29 +217,34 @@ func (b *ScriptBuilder) Build(ctx context.Context, in BuildInput) (Artifact, err
 			return Artifact{}, fmt.Errorf("iso: autoinstall requires SHOAL_UBUNTU_CLOUD_IMG (preferred nested-lab path) or payload-file or SHOAL_UBUNTU_ISO")
 		}
 		// Payload: prefer file path (binary-safe); else inline text via env.
-		// Callers must not pass passwords.
-		if payloadFile != "" {
-			st, err := os.Stat(payloadFile)
-			if err != nil {
-				return Artifact{}, fmt.Errorf("iso: payload file: %w", err)
+		// Secrets must not be passed. Prep mode needs no payload.
+		if mode != InstallModePrep {
+			if payloadFile != "" {
+				st, err := os.Stat(payloadFile)
+				if err != nil {
+					return Artifact{}, fmt.Errorf("iso: payload file: %w", err)
+				}
+				if st.IsDir() {
+					return Artifact{}, fmt.Errorf("iso: payload file is a directory")
+				}
+				cmd.Env = append(cmd.Env, "SHOAL_PAYLOAD_FILE="+payloadFile)
+			} else if p := strings.TrimSpace(in.EmbeddedPayload); p != "" {
+				if looksSecretPayload(p) {
+					return Artifact{}, fmt.Errorf("iso: embedded_payload must not contain secret-like content")
+				}
+				cmd.Env = append(cmd.Env, "SHOAL_EMBEDDED_PAYLOAD="+p)
 			}
-			if st.IsDir() {
-				return Artifact{}, fmt.Errorf("iso: payload file is a directory")
-			}
-			cmd.Env = append(cmd.Env, "SHOAL_PAYLOAD_FILE="+payloadFile)
-		} else if p := strings.TrimSpace(in.EmbeddedPayload); p != "" {
-			if looksSecretPayload(p) {
-				return Artifact{}, fmt.Errorf("iso: embedded_payload must not contain secret-like content")
-			}
-			cmd.Env = append(cmd.Env, "SHOAL_EMBEDDED_PAYLOAD="+p)
 		}
 		if t := strings.TrimSpace(in.InstallTarget); t != "" {
 			cmd.Env = append(cmd.Env, "SHOAL_INSTALL_TARGET="+t)
-		} else if mode == InstallModeAutoinstall {
+		} else if mode == InstallModeAutoinstall || mode == InstallModePrep {
 			cmd.Env = append(cmd.Env, "SHOAL_INSTALL_TARGET=/dev/vda")
 		}
 		if mode == InstallModeAutoinstall {
 			cmd.Env = append(cmd.Env, "SHOAL_INSTALL_REBOOT=1")
+		}
+		if mode == InstallModePrep {
+			cmd.Env = append(cmd.Env, "SHOAL_INSTALL_REBOOT=0")
 		}
 	}
 

--- a/internal/deploy/job/orchestrator.go
+++ b/internal/deploy/job/orchestrator.go
@@ -93,6 +93,11 @@ type runState struct {
 	terminalOnce sync.Once
 	// advanceOnce ensures PREP_DONE only advances once.
 	advanceOnce sync.Once
+	// stageStarted is when the current stage's SOL watch was registered.
+	// Early stream closes (domain reboot after media swap) are retried.
+	stageStarted  time.Time
+	solReopens    int
+	maxSOLReopens int
 }
 
 type terminalEvent struct {
@@ -428,6 +433,16 @@ func (o *Orchestrator) startStage(ctx context.Context, job models.ProvisioningJo
 			return fmt.Errorf("power on/restart: %w (also: %v)", err2, err)
 		}
 	}
+	// After media swap / ForceRestart, give nested serial a moment to settle.
+	settle := 2 * time.Second
+	if idx > 0 {
+		settle = 8 * time.Second
+	}
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(settle):
+	}
 
 	phase := "WAITING_SOL"
 	if stage.Kind == models.JobStageKindPrep {
@@ -461,6 +476,11 @@ func (o *Orchestrator) startStage(ctx context.Context, job models.ProvisioningJo
 		_ = bmc.CleanupMediaAndBoot(ctx, sys.ID)
 		return fmt.Errorf("register watch: %w", err)
 	}
+	rs.stageStarted = time.Now().UTC()
+	rs.solReopens = 0
+	if rs.maxSOLReopens == 0 {
+		rs.maxSOLReopens = 4
+	}
 	o.log.Info("stage media attached",
 		"job_id", job.ID,
 		"device_id", job.DeviceID,
@@ -470,6 +490,59 @@ func (o *Orchestrator) startStage(ctx context.Context, job models.ProvisioningJo
 		"kind", stage.Kind,
 	)
 	return nil
+}
+
+// reopenSOL re-registers the SOL watch after an early stream drop (stage handoff).
+func (o *Orchestrator) reopenSOL(jobID string) {
+	o.mu.Lock()
+	rs := o.running[jobID]
+	o.mu.Unlock()
+	if rs == nil {
+		return
+	}
+	if rs.terminalQueued {
+		return
+	}
+	job, err := o.store.Get(context.Background(), jobID)
+	if err != nil || job.State != models.StateProvisioning {
+		return
+	}
+	// Unregister current session if any.
+	if rs.sessionID != "" && o.watches != nil {
+		_ = o.watches.Unregister(context.Background(), rs.sessionID)
+	}
+	time.Sleep(4 * time.Second)
+	if rs.terminalQueued {
+		return
+	}
+	rs.solReopens++
+	sessionID := fmt.Sprintf("sol-%s-r%d", jobID, rs.solReopens)
+	rs.sessionID = sessionID
+	_ = o.store.UpdateRuntime(context.Background(), jobID, rs.systemID, sessionID, rs.credential)
+	stall := rs.stallTimeout
+	if stall <= 0 {
+		stall = DefaultSOLStall
+	}
+	session := models.WatchSession{
+		ID:           sessionID,
+		JobID:        jobID,
+		DeviceID:     rs.deviceID,
+		Transport:    "libvirt",
+		Target:       rs.serialTarget,
+		StartedAt:    time.Now().UTC(),
+		StallTimeout: stall,
+	}
+	if err := o.watches.Register(context.Background(), session); err != nil {
+		o.log.Error("sol reopen failed", "job_id", jobID, "err", err.Error())
+		o.enqueueTerminal(jobID, ReasonTransport)
+		return
+	}
+	rs.stageStarted = time.Now().UTC()
+	o.log.Info("sol watch reopened after stream drop",
+		"job_id", jobID,
+		"session_id", sessionID,
+		"reopen", rs.solReopens,
+	)
 }
 
 // advanceAfterPrepDone completes the prep stage and starts os_install (M2).
@@ -516,7 +589,8 @@ func (o *Orchestrator) advanceAfterPrepDone(jobID string) {
 		return
 	}
 	_ = o.store.UpdateStages(ctx, jobID, models.JobStageKindOSInstall, job.InstallStrategy, stages)
-	_ = o.store.UpdateProgress(ctx, jobID, "STAGE_ADVANCE", nil, 0, "prep done; starting os_install")
+	// Clear soft error from prior progress; phase only for observability.
+	_ = o.store.UpdateProgress(ctx, jobID, "STAGE_ADVANCE", nil, 0, "")
 
 	cred, err := o.secrets.Get(ctx, rs.credential)
 	if err != nil {
@@ -1125,6 +1199,21 @@ func (p *progressAdapter) ReportTransportError(ctx context.Context, jobID string
 	// Ignore stream close after DONE/cancel/stall already committed (e.g. guest poweroff).
 	if !p.stillProvisioning(ctx, jobID) {
 		return nil
+	}
+	// After stage handoff / ForceRestart, nested serial often drops once; reopen SOL.
+	p.orch.mu.Lock()
+	rs := p.orch.running[jobID]
+	p.orch.mu.Unlock()
+	if rs != nil && !rs.terminalQueued && rs.solReopens < rs.maxSOLReopens {
+		// Allow reopens for a couple of minutes after stage start.
+		if rs.stageStarted.IsZero() || time.Since(rs.stageStarted) < 2*time.Minute {
+			p.orch.log.Warn("sol stream closed early; reopening",
+				"job_id", jobID,
+				"reopen", rs.solReopens+1,
+			)
+			go p.orch.reopenSOL(jobID)
+			return nil
+		}
 	}
 	msg := "transport error"
 	if err != nil {

--- a/internal/deploy/job/orchestrator.go
+++ b/internal/deploy/job/orchestrator.go
@@ -78,12 +78,21 @@ type runState struct {
 	sessionID  string
 	credential string
 	bmcURL     string
+	// serialTarget / stallTimeout / deviceID retained for stage advance (M2).
+	serialTarget string
+	stallTimeout time.Duration
+	deviceID     string
+	// req is the original start request (needed to re-enter startStage after prep).
+	// Credentials live in secrets backend; password fields must never be logged.
+	req models.StartJobRequest
 	// terminalQueued is set under Orchestrator.mu so only the first terminal
 	// reason (cancel, DONE, stall, transport, …) is accepted. Without this,
 	// Unregister-driven stream close races cancel and can win with "sol transport error".
 	terminalQueued bool
 	// terminalOnce ensures HandleTerminal runs once
 	terminalOnce sync.Once
+	// advanceOnce ensures PREP_DONE only advances once.
+	advanceOnce sync.Once
 }
 
 type terminalEvent struct {
@@ -276,12 +285,20 @@ func (o *Orchestrator) Start(ctx context.Context, req models.StartJobRequest) (m
 	o.syncNetBoxLifecycle(ctx, req.DeviceID, models.StateProvisioning)
 
 	jobCtx, cancel := context.WithCancel(context.Background())
+	stall := req.StallTimeout
+	if stall <= 0 {
+		stall = DefaultSOLStall
+	}
 	rs := &runState{
-		cancel:     cancel,
-		systemID:   req.SystemID,
-		credential: credRef,
-		bmcURL:     req.BMCEndpoint,
-		sessionID:  sessionID,
+		cancel:       cancel,
+		systemID:     req.SystemID,
+		credential:   credRef,
+		bmcURL:       req.BMCEndpoint,
+		sessionID:    sessionID,
+		serialTarget: req.SerialTarget,
+		stallTimeout: stall,
+		deviceID:     req.DeviceID,
+		req:          req,
 	}
 	o.mu.Lock()
 	o.running[jobID] = rs
@@ -304,8 +321,8 @@ func (o *Orchestrator) Start(ctx context.Context, req models.StartJobRequest) (m
 	return out, nil
 }
 
-// provision runs the multi-stage job loop. M1 always has one os_install stage
-// (image_write/simulate media attach). Later slices add prep media swap.
+// provision expands stages and starts only the first stage. Later stages start
+// when ApplyMarker sees PREP_DONE (M2 event-driven advance).
 func (o *Orchestrator) provision(ctx context.Context, job models.ProvisioningJob, req models.StartJobRequest, cred secrets.Credential, rs *runState) error {
 	stages := job.Stages
 	if len(stages) == 0 {
@@ -319,49 +336,39 @@ func (o *Orchestrator) provision(ctx context.Context, job models.ProvisioningJob
 	if strategy == "" && len(stages) > 0 {
 		strategy = stages[0].Strategy
 	}
-
-	for i := range stages {
-		st := stages[i]
-		stages = setStageState(stages, st.ID, models.JobStageStateRunning, "STARTING", "")
-		if err := o.store.UpdateStages(ctx, job.ID, st.ID, strategy, stages); err != nil {
-			return fmt.Errorf("persist stages: %w", err)
-		}
-		o.log.Info("stage start",
-			"job_id", job.ID,
-			"stage", st.ID,
-			"kind", st.Kind,
-			"strategy", st.Strategy,
-		)
-
-		var stageErr error
-		switch st.Kind {
-		case models.JobStageKindOSInstall:
-			stageErr = o.runOSInstallStage(ctx, job, req, cred, rs, st)
-		default:
-			stageErr = fmt.Errorf("job: stage kind %q not implemented", st.Kind)
-		}
-		if stageErr != nil {
-			stages = setStageState(stages, st.ID, models.JobStageStateFailed, "ERROR", stageErr.Error())
-			_ = o.store.UpdateStages(ctx, job.ID, st.ID, strategy, stages)
-			return stageErr
-		}
-		// M1: os_install returns after SOL watch is registered; terminal DONE is async.
-		// Mark stage running with WAITING_SOL; HandleTerminal finalizes the job.
-		stages = setStageState(stages, st.ID, models.JobStageStateRunning, "WAITING_SOL", "")
-		_ = o.store.UpdateStages(ctx, job.ID, st.ID, strategy, stages)
+	if err := o.store.UpdateStages(ctx, job.ID, stages[0].ID, strategy, stages); err != nil {
+		return fmt.Errorf("persist stages: %w", err)
 	}
-	return nil
+	job.Stages = stages
+	job.CurrentStage = stages[0].ID
+	job.InstallStrategy = strategy
+	return o.startStage(ctx, job, req, cred, rs, 0)
 }
 
-// runOSInstallStage attaches Virtual Media, boots once from CD, and registers SOL watch.
-// Terminal DONE is handled asynchronously via ApplyMarker → HandleTerminal (M1: job-terminal).
-func (o *Orchestrator) runOSInstallStage(ctx context.Context, job models.ProvisioningJob, req models.StartJobRequest, cred secrets.Credential, rs *runState, stage models.JobStage) error {
+// startStage attaches stage media, boots CD once, and registers SOL watch.
+func (o *Orchestrator) startStage(ctx context.Context, job models.ProvisioningJob, req models.StartJobRequest, cred secrets.Credential, rs *runState, idx int) error {
+	if idx < 0 || idx >= len(job.Stages) {
+		return fmt.Errorf("job: invalid stage index %d", idx)
+	}
+	stage := job.Stages[idx]
+	strategy := job.InstallStrategy
+	stages := setStageState(job.Stages, stage.ID, models.JobStageStateRunning, "STARTING", "")
+	if err := o.store.UpdateStages(ctx, job.ID, stage.ID, strategy, stages); err != nil {
+		return fmt.Errorf("persist stages: %w", err)
+	}
+	o.log.Info("stage start",
+		"job_id", job.ID,
+		"stage", stage.ID,
+		"kind", stage.Kind,
+		"strategy", stage.Strategy,
+	)
+
 	mediaURL := strings.TrimSpace(stage.MediaURL)
-	if mediaURL == "" {
+	if mediaURL == "" && stage.Kind == models.JobStageKindOSInstall {
 		mediaURL = strings.TrimSpace(req.ISOURL)
 	}
 	if mediaURL == "" {
-		return fmt.Errorf("os_install: media_url is empty")
+		return fmt.Errorf("%s: media_url is empty", stage.Kind)
 	}
 
 	bmc, err := o.newBMC(redfish.Config{
@@ -381,14 +388,12 @@ func (o *Orchestrator) runOSInstallStage(ctx context.Context, job models.Provisi
 	}
 	defer func() { _ = bmc.Close(context.Background()) }()
 
-	// Prefer explicit SystemID; else match Redfish Name to DeviceID (lab: shoal-node-1).
 	lookup := req.SystemID
 	if lookup == "" {
 		lookup = req.DeviceID
 	}
 	sys, err := bmc.GetSystem(ctx, lookup)
 	if err != nil {
-		// Last resort: if DeviceID lookup failed and SystemID was empty, try empty only when single system.
 		if req.SystemID == "" && req.DeviceID != "" {
 			sys, err = bmc.GetSystem(ctx, "")
 		}
@@ -397,10 +402,12 @@ func (o *Orchestrator) runOSInstallStage(ctx context.Context, job models.Provisi
 		}
 	}
 	rs.systemID = sys.ID
-	// Persist runtime coords so a different process can cancel/orphan-cleanup.
 	if err := o.store.UpdateRuntime(ctx, job.ID, sys.ID, rs.sessionID, rs.credential); err != nil {
 		return fmt.Errorf("persist runtime: %w", err)
 	}
+
+	// Best-effort eject previous media before insert (stage handoff).
+	_ = bmc.CleanupMediaAndBoot(ctx, sys.ID)
 
 	vms, err := bmc.ListVirtualMedia(ctx, sys.ID)
 	if err != nil {
@@ -416,23 +423,33 @@ func (o *Orchestrator) runOSInstallStage(ctx context.Context, job models.Provisi
 	if err := bmc.SetBootOverrideOnceCD(ctx, sys.ID); err != nil {
 		return fmt.Errorf("boot override: %w", err)
 	}
-	// Prefer ForceRestart so an already-on system reboots into the new media.
-	// Fall back to On for powered-off domains (sushy maps both onto libvirt).
 	if err := bmc.Power(ctx, sys.ID, "ForceRestart"); err != nil {
 		if err2 := bmc.Power(ctx, sys.ID, "On"); err2 != nil {
 			return fmt.Errorf("power on/restart: %w (also: %v)", err2, err)
 		}
 	}
 
-	_ = o.store.UpdateProgress(ctx, job.ID, "WAITING_SOL", nil, 0, "")
+	phase := "WAITING_SOL"
+	if stage.Kind == models.JobStageKindPrep {
+		phase = "PREP_BOOT"
+	}
+	_ = o.store.UpdateProgress(ctx, job.ID, phase, nil, 0, "")
+	stages = setStageState(stages, stage.ID, models.JobStageStateRunning, phase, "")
+	_ = o.store.UpdateStages(ctx, job.ID, stage.ID, strategy, stages)
 
-	stall := req.StallTimeout
+	stall := rs.stallTimeout
 	if stall <= 0 {
-		// Live ISO boot can take well over 90s before the first marker.
 		stall = DefaultSOLStall
 	}
+	// New session id per stage so Unregister of previous stage does not race.
+	sessionID := rs.sessionID
+	if idx > 0 {
+		sessionID = "sol-" + job.ID + "-s" + fmt.Sprintf("%d", idx)
+		rs.sessionID = sessionID
+		_ = o.store.UpdateRuntime(ctx, job.ID, sys.ID, sessionID, rs.credential)
+	}
 	session := models.WatchSession{
-		ID:           rs.sessionID,
+		ID:           sessionID,
 		JobID:        job.ID,
 		DeviceID:     req.DeviceID,
 		Transport:    "libvirt",
@@ -440,22 +457,82 @@ func (o *Orchestrator) runOSInstallStage(ctx context.Context, job models.Provisi
 		StartedAt:    time.Now().UTC(),
 		StallTimeout: stall,
 	}
-	_ = o.store.UpdateProgress(ctx, job.ID, "WAITING_SOL", nil, 0, "")
-
 	if err := o.watches.Register(ctx, session); err != nil {
 		_ = bmc.CleanupMediaAndBoot(ctx, sys.ID)
 		return fmt.Errorf("register watch: %w", err)
 	}
-	o.log.Info("job started",
+	o.log.Info("stage media attached",
 		"job_id", job.ID,
 		"device_id", job.DeviceID,
 		"bmc", req.BMCEndpoint,
 		"iso_url", mediaURL,
 		"stage", stage.ID,
-		"strategy", stage.Strategy,
-		// never log password
+		"kind", stage.Kind,
 	)
 	return nil
+}
+
+// advanceAfterPrepDone completes the prep stage and starts os_install (M2).
+func (o *Orchestrator) advanceAfterPrepDone(jobID string) {
+	o.mu.Lock()
+	rs := o.running[jobID]
+	o.mu.Unlock()
+	if rs == nil {
+		o.log.Warn("prep advance: no runState", "job_id", jobID)
+		return
+	}
+	var run bool
+	rs.advanceOnce.Do(func() { run = true })
+	if !run {
+		return
+	}
+
+	ctx := context.Background()
+	job, err := o.store.Get(ctx, jobID)
+	if err != nil {
+		o.log.Error("prep advance get job", "job_id", jobID, "err", err.Error())
+		return
+	}
+	if job.CurrentStage != models.JobStageKindPrep && job.CurrentStage != "" {
+		// Allow empty current during race; still require a prep stage present.
+		if stageIndex(job.Stages, models.JobStageKindPrep) < 0 {
+			return
+		}
+	}
+	if job.State != models.StateProvisioning {
+		return
+	}
+
+	// Unregister prep SOL session.
+	if rs.sessionID != "" && o.watches != nil {
+		_ = o.watches.Unregister(ctx, rs.sessionID)
+	}
+
+	// Mark prep done.
+	stages := setStageState(job.Stages, models.JobStageKindPrep, models.JobStageStateDone, "PREP_DONE", "")
+	osIdx := stageIndex(stages, models.JobStageKindOSInstall)
+	if osIdx < 0 {
+		o.enqueueTerminal(jobID, ReasonMarkerError)
+		return
+	}
+	_ = o.store.UpdateStages(ctx, jobID, models.JobStageKindOSInstall, job.InstallStrategy, stages)
+	_ = o.store.UpdateProgress(ctx, jobID, "STAGE_ADVANCE", nil, 0, "prep done; starting os_install")
+
+	cred, err := o.secrets.Get(ctx, rs.credential)
+	if err != nil {
+		o.log.Error("prep advance secrets", "job_id", jobID, "err", err.Error())
+		o.enqueueTerminal(jobID, ReasonBMC)
+		return
+	}
+	job.Stages = stages
+	job.CurrentStage = models.JobStageKindOSInstall
+	req := rs.req
+	if err := o.startStage(ctx, job, req, cred, rs, osIdx); err != nil {
+		o.log.Error("os_install start after prep failed", "job_id", jobID, "err", err.Error())
+		stages = setStageState(stages, models.JobStageKindOSInstall, models.JobStageStateFailed, "ERROR", err.Error())
+		_ = o.store.UpdateStages(ctx, jobID, models.JobStageKindOSInstall, job.InstallStrategy, stages)
+		o.enqueueTerminal(jobID, ReasonBMC)
+	}
 }
 
 func pickCDMedia(vms []redfish.VirtualMedia) string {
@@ -1002,7 +1079,33 @@ func (p *progressAdapter) ApplyMarker(ctx context.Context, jobID string, m model
 	if err := p.orch.store.UpdateProgress(ctx, jobID, phase, m.Percent, m.Seq, soft); err != nil {
 		return err
 	}
+	// Best-effort stage phase mirror.
+	if j, err := p.orch.store.Get(ctx, jobID); err == nil && j.CurrentStage != "" && len(j.Stages) > 0 {
+		stages := setStageState(j.Stages, j.CurrentStage, models.JobStageStateRunning, phase, soft)
+		_ = p.orch.store.UpdateStages(ctx, jobID, j.CurrentStage, j.InstallStrategy, stages)
+	}
+
+	// M2: PREP_DONE advances to os_install — not a job-terminal event.
+	if strings.EqualFold(m.Phase, "PREP_DONE") && (m.State == "OK" || m.State == "") {
+		job, err := p.orch.store.Get(ctx, jobID)
+		if err == nil && (job.CurrentStage == models.JobStageKindPrep || stageIndex(job.Stages, models.JobStageKindPrep) >= 0) {
+			// If DONE-shaped marker on prep only: advance when still on prep.
+			if job.CurrentStage == models.JobStageKindPrep || job.CurrentStage == "" {
+				go p.orch.advanceAfterPrepDone(jobID)
+				return nil
+			}
+		}
+	}
+
 	if sol.IsTerminal(m) {
+		// DONE during prep stage is a misbehaving image — fail the job.
+		if strings.EqualFold(m.Phase, "DONE") {
+			if j, err := p.orch.store.Get(ctx, jobID); err == nil && j.CurrentStage == models.JobStageKindPrep {
+				_ = p.orch.store.UpdateProgress(ctx, jobID, "ERROR", nil, m.Seq, "DONE during prep stage")
+				p.orch.enqueueTerminal(jobID, ReasonMarkerError)
+				return nil
+			}
+		}
 		reason := TerminalReason(sol.TerminalReasonFromMarker(m))
 		p.orch.enqueueTerminal(jobID, reason)
 	}

--- a/internal/deploy/job/stages.go
+++ b/internal/deploy/job/stages.go
@@ -2,38 +2,62 @@ package job
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/mattcburns/shoal/internal/common/models"
 	"github.com/mattcburns/shoal/internal/deploy/iso"
 )
 
-// expandStages derives the stage list for a StartJobRequest (multi-stage design M1).
-// M1 always returns a single os_install stage; multi-stage expansion lands in M2+.
+// expandStages derives the stage list for a StartJobRequest (multi-stage design).
+// M1: single os_install. M2: optional prep wipe + os_install.
 func expandStages(req models.StartJobRequest) ([]models.JobStage, error) {
-	if p := strings.TrimSpace(strings.ToLower(req.Prep)); p != "" && p != "skip" {
-		return nil, fmt.Errorf("job: prep %q not implemented (M1 allows only skip)", req.Prep)
-	}
 	strategy, err := resolveInstallStrategy(req)
 	if err != nil {
 		return nil, err
 	}
-	// M1: scripted_iso / operator_iso are accepted by validate but not expanded yet.
 	switch strategy {
 	case models.InstallStrategyScriptedISO, models.InstallStrategyOperatorISO:
-		return nil, fmt.Errorf("job: install_strategy %q not implemented in M1 (use image_write or simulate)", strategy)
+		return nil, fmt.Errorf("job: install_strategy %q not implemented (use image_write or simulate)", strategy)
 	}
 
-	media := strings.TrimSpace(req.ISOURL)
-	stage := models.JobStage{
+	installMedia := strings.TrimSpace(req.ISOURL)
+	osStage := models.JobStage{
 		ID:           models.JobStageKindOSInstall,
 		Kind:         models.JobStageKindOSInstall,
 		Strategy:     strategy,
-		MediaURL:     media,
+		MediaURL:     installMedia,
 		SeedDelivery: "none",
 		State:        models.JobStageStatePending,
 	}
-	return []models.JobStage{stage}, nil
+
+	prep := strings.TrimSpace(strings.ToLower(req.Prep))
+	switch prep {
+	case "", "skip":
+		return []models.JobStage{osStage}, nil
+	case "wipe_only":
+		prepURL := strings.TrimSpace(req.PrepISOURL)
+		if prepURL == "" {
+			prepURL = strings.TrimSpace(os.Getenv("SHOAL_PREP_ISO_URL"))
+		}
+		if prepURL == "" {
+			return nil, fmt.Errorf("job: prep wipe_only requires prep_iso_url or SHOAL_PREP_ISO_URL")
+		}
+		if installMedia == "" {
+			return nil, fmt.Errorf("job: prep wipe_only requires iso_url for os_install stage")
+		}
+		prepStage := models.JobStage{
+			ID:       models.JobStageKindPrep,
+			Kind:     models.JobStageKindPrep,
+			MediaURL: prepURL,
+			State:    models.JobStageStatePending,
+		}
+		return []models.JobStage{prepStage, osStage}, nil
+	case "full":
+		return nil, fmt.Errorf("job: prep full not implemented (use wipe_only)")
+	default:
+		return nil, fmt.Errorf("job: unknown prep %q", req.Prep)
+	}
 }
 
 func resolveInstallStrategy(req models.StartJobRequest) (string, error) {
@@ -47,7 +71,6 @@ func resolveInstallStrategy(req models.StartJobRequest) (string, error) {
 	case iso.InstallModeSimulate:
 		return models.InstallStrategySimulate, nil
 	case "":
-		// Default: treat as image_write-compatible media attach (7a cloud ISO, marker write, etc.).
 		return models.InstallStrategyImageWrite, nil
 	default:
 		return models.InstallStrategyImageWrite, nil
@@ -71,4 +94,14 @@ func setStageState(stages []models.JobStage, id, state, phase, errMsg string) []
 		}
 	}
 	return out
+}
+
+// stageIndex returns the index of stage id, or -1.
+func stageIndex(stages []models.JobStage, id string) int {
+	for i := range stages {
+		if stages[i].ID == id {
+			return i
+		}
+	}
+	return -1
 }

--- a/internal/deploy/job/stages_test.go
+++ b/internal/deploy/job/stages_test.go
@@ -47,13 +47,34 @@ func TestExpandStagesSimulate(t *testing.T) {
 	}
 }
 
-func TestExpandStagesRejectsPrepWipe(t *testing.T) {
+func TestExpandStagesWipeOnly(t *testing.T) {
+	stages, err := expandStages(models.StartJobRequest{
+		ISOURL:     "http://example/os.iso",
+		PrepISOURL: "http://example/prep.iso",
+		Prep:       "wipe_only",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(stages) != 2 {
+		t.Fatalf("len=%d", len(stages))
+	}
+	if stages[0].Kind != models.JobStageKindPrep || stages[0].MediaURL != "http://example/prep.iso" {
+		t.Fatalf("prep %+v", stages[0])
+	}
+	if stages[1].Kind != models.JobStageKindOSInstall || stages[1].MediaURL != "http://example/os.iso" {
+		t.Fatalf("os %+v", stages[1])
+	}
+}
+
+func TestExpandStagesWipeOnlyNeedsPrepURL(t *testing.T) {
+	t.Setenv("SHOAL_PREP_ISO_URL", "")
 	_, err := expandStages(models.StartJobRequest{
-		ISOURL: "http://example/m.iso",
+		ISOURL: "http://example/os.iso",
 		Prep:   "wipe_only",
 	})
-	if err == nil || !strings.Contains(err.Error(), "not implemented") {
-		t.Fatalf("want not implemented, got %v", err)
+	if err == nil || !strings.Contains(err.Error(), "prep_iso") {
+		t.Fatalf("got %v", err)
 	}
 }
 

--- a/internal/observe/sol/parse.go
+++ b/internal/observe/sol/parse.go
@@ -92,6 +92,20 @@ func IsTerminal(m models.SOLMarker) bool {
 	return false
 }
 
+// IsStageComplete reports whether the marker ends the current stage's SOL session
+// without ending the job (e.g. multi-stage PREP_DONE). Watch must stop cleanly
+// so Unregister/stream close does not surface as a transport error.
+func IsStageComplete(m models.SOLMarker) bool {
+	if IsTerminal(m) {
+		return true
+	}
+	if strings.EqualFold(m.Phase, "PREP_DONE") && (m.State == "OK" || m.State == "" || m.State == "HEARTBEAT") {
+		// PREP_DONE is emitted with state OK from the prep image.
+		return m.State == "OK" || m.State == ""
+	}
+	return false
+}
+
 // TerminalReasonFromMarker maps a terminal marker to a reason string used by Deploy.
 func TerminalReasonFromMarker(m models.SOLMarker) string {
 	if strings.EqualFold(m.Phase, "DONE") && m.State == "OK" {

--- a/internal/observe/sol/parse_test.go
+++ b/internal/observe/sol/parse_test.go
@@ -82,4 +82,18 @@ func TestIsTerminal(t *testing.T) {
 	}
 }
 
+func TestIsStageComplete(t *testing.T) {
+	m, ok := sol.ParseLine("SHOAL|1|1|2026-06-19T04:11:02Z|PREP_DONE|100|OK|ready")
+	if !ok || sol.IsTerminal(m) {
+		t.Fatal("PREP_DONE must not be job-terminal")
+	}
+	if !sol.IsStageComplete(m) {
+		t.Fatal("PREP_DONE must be stage-complete")
+	}
+	m, ok = sol.ParseLine("SHOAL|1|2|2026-06-19T04:11:02Z|DONE|100|OK|x")
+	if !ok || !sol.IsStageComplete(m) {
+		t.Fatal("DONE should be stage-complete")
+	}
+}
+
 func intPtr(v int) *int { return &v }

--- a/internal/observe/sol/watch.go
+++ b/internal/observe/sol/watch.go
@@ -202,10 +202,10 @@ func (w *WatchService) run(ctx context.Context, aw *activeWatch, lines <-chan st
 			if err := progress.ApplyMarker(context.Background(), aw.session.JobID, m); err != nil {
 				w.log.Error("apply marker failed", "job_id", aw.session.JobID, "err", err.Error())
 			}
-			// Terminal markers: orchestrator is notified via jobport; stop the
-			// watch loop so guest poweroff does not race as a transport error and
-			// so Unregister is not stuck draining a dead serial stream.
-			if IsTerminal(m) {
+			// Stage-complete or job-terminal markers: stop the watch loop so
+			// guest poweroff / Unregister does not race as a transport error.
+			// PREP_DONE is stage-complete only (job continues on next media).
+			if IsStageComplete(m) {
 				return
 			}
 		}


### PR DESCRIPTION
## Summary

Implements multi-stage design **M2** (next after M1):

1. **Prep live ISO** (`SHOAL_INSTALL_MODE=prep`) — wipe install disk, emit `PREP_BOOT` / `PREP_WIPE` / `PREP_DONE`
2. **`expandStages`** — `prep=wipe_only` → `[prep, os_install]` (requires `prep_iso_url` + `approve_destruct`)
3. **Event-driven orchestrator** — start first stage only; on `PREP_DONE` unregister SOL, eject media, start `os_install` with install ISO
4. **`DONE` during prep** fails the job; only install-stage `DONE` → `provisioned`
5. Docs: multi-stage table + lab-runbook recipe

**Not in this PR:** RAID, config-drive/second_media (M3), operator_iso (M5), full profiles (M6).

## Test plan

- [x] `go test ./internal/deploy/job/ ./internal/common/validate/ ./internal/deploy/iso/`
- [x] Unit: expandStages wipe_only / skip; validate approve_destruct
- [ ] Lab: build `shoal-prep.iso` + cloud-write ISO; `deploy run -prep wipe_only -approve-destruct …` → `provisioned` (lab host was unreachable during this PR)