### PR TITLE
feat(deploy): multi-stage M3 offline NoCloud seed (second_media)

### DIFF
--- a/docs/lab-runbook.md
+++ b/docs/lab-runbook.md
@@ -445,6 +445,45 @@ go run ./cmd/shoal deploy run \
 `PREP_DONE` does **not** complete the job; only the final install `DONE` yields
 `provisioned`. Status JSON shows `current_stage` moving from `prep` → `os_install`.
 
+### Multi-stage M3: offline NoCloud seed (second_media)
+
+Guest must **not** fetch user-data over the network. M3 delivers a tiny CIDATA ISO
+on a **second Virtual Media** slot when the BMC has ≥2 CD devices.
+
+**Build seed ISO (any host with xorriso/genisoimage):**
+
+```bash
+SHOAL_SEED_HOSTNAME=lab-node-1 \
+  ./infra/scripts/build-nocloud-seed-iso.sh /srv/iso/shoal-cidata.iso
+# BMC-reachable URL (nested lab):
+#   http://192.168.124.1:8080/shoal-cidata.iso
+```
+
+**Deploy with dual media** (requires dual-CD BMC or `redfish.NewFakeDualCD` in unit tests).
+Nested sushy-tools typically has **one** CD — second_media will fail with an actionable
+error; for image_write offline seed, bake cloud-init into the payload with
+`prepare-ubuntu-cloud-payload.sh` instead (`seed_delivery=none`).
+
+```bash
+go run ./cmd/shoal deploy run \
+  -device-id shoal-node-1 \
+  -bmc-url http://192.168.122.100:8001 \
+  -bmc-user admin -bmc-pass password \
+  -serial-target shoal-node-1 \
+  -iso-url http://192.168.124.1:8080/ubuntu-live.iso \
+  -seed-delivery second_media \
+  -seed-iso-url http://192.168.124.1:8080/shoal-cidata.iso \
+  -os-family ubuntu \
+  -wait
+```
+
+| Mode | Notes |
+|------|--------|
+| `none` (default) | No runtime seed (7a prepare-time seed is fine) |
+| `second_media` | Install ISO on CD1 + seed ISO on CD2; needs ≥2 CD slots |
+| `auto` | Prefer second_media when ≥2 CDs + `seed_iso_url`; else error if image_write (no config_drive) |
+| `config_drive` | **Forbidden** with `image_write` (full-disk dd wipes partition); write path not implemented yet |
+
 ### Phase 6b: graphics failure-screen OCR
 
 SOL remains the primary progress channel. Graphics OCR is **diagnostic only**.

--- a/docs/multi-stage-provisioning-design.md
+++ b/docs/multi-stage-provisioning-design.md
@@ -494,7 +494,7 @@ shoal deploy run \
   -os-family ubuntu \
   -seed-delivery second_media \
   -iso-url http://mgmt:8080/ubuntu-live.iso \
-  -seed-url http://mgmt:8080/cidata-host7.iso \
+  -seed-iso-url http://mgmt:8080/cidata-host7.iso \
   -wait
 ```
 
@@ -522,7 +522,7 @@ shoal deploy run \
 | `credential_ref` | Opaque BMC (and seed-render) secret handle |
 | `serial_target` | Libvirt domain or SOL target for Observe |
 | `iso_url` / `media_url` | Installer or marker ISO (**BMC-reachable**; mgmt HTTP OK) |
-| `seed_url` | Second Virtual Media seed ISO URL (when `seed_delivery=second_media`) |
+| `seed_iso_url` | Second Virtual Media seed ISO URL (when `seed_delivery=second_media`) |
 | `install_strategy` | `operator_iso` \| `scripted_iso` \| `image_write` \| `simulate` |
 | `seed_delivery` | `auto` \| `second_media` \| `config_drive` \| `single_iso` \| `none` |
 | `os_family` | `ubuntu` \| `flatcar` \| `esxi` \| `windows` |
@@ -802,7 +802,7 @@ Version media URLs when content changes (sushy cache lesson from 7a).
 | **M0** | This design merged | Docs only |
 | **M1** | Stage runner skeleton; single-stage compat with 7a image-write | **Implemented** (single `os_install` stage; job fields + API) |
 | **M2** | Prep v1: wipe + `PREP_*` + handoff to image-write Ubuntu | **Implemented** (event-driven `PREP_DONE` → os_install) |
-| **M3** | Offline seed preference #1 then #2: **second_media**, else **config_drive**, for Ubuntu NoCloud | Lab or hardware AC; no HTTP seed |
+| **M3** | Offline seed preference #1 then #2: **second_media**, else **config_drive**, for Ubuntu NoCloud | **Implemented** (seed ISO builder + dual-media attach + `auto` resolve; `config_drive` rejected with `image_write`; config_drive write deferred) |
 | **M4** | Flatcar offline Ignition (same preference order) | Documented AC |
 | **M5** | **`operator_iso`** path shared by ESXi + Windows shape (attach + boot + cleanup + coarse progress) | Hardware preferred |
 | **M6** | Profiles + `seed_delivery: auto` + Operator API §6 fields on `POST/GET /v1/jobs` | Happy path without ad-hoc flags; §6.9 ACs |

--- a/infra/scripts/build-nocloud-seed-iso.sh
+++ b/infra/scripts/build-nocloud-seed-iso.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# build-nocloud-seed-iso.sh — tiny CIDATA/NoCloud seed ISO for offline cloud-init.
+#
+# Offline only: guest must not fetch user-data over the network. This ISO is
+# attached as secondary Virtual Media (seed_delivery=second_media) or used as
+# input for other offline seed paths.
+#
+# Usage:
+#   SHOAL_SEED_HOSTNAME=node1 ./infra/scripts/build-nocloud-seed-iso.sh [/out/seed.iso]
+#   SHOAL_SEED_USER_DATA=/path/to/user-data SHOAL_SEED_META_DATA=/path/to/meta-data \
+#     ./infra/scripts/build-nocloud-seed-iso.sh /srv/iso/cidata.iso
+set -euo pipefail
+
+OUT="${1:-${SHOAL_SEED_ISO_OUT:-./shoal-nocloud-seed.iso}}"
+HOSTNAME="${SHOAL_SEED_HOSTNAME:-${SHOAL_AUTOINSTALL_HOSTNAME:-shoal-node}}"
+INSTANCE_ID="${SHOAL_SEED_INSTANCE_ID:-shoal-${HOSTNAME}}"
+USERNAME="${SHOAL_SEED_USERNAME:-${SHOAL_AUTOINSTALL_USERNAME:-ubuntu}}"
+# Lab-only optional password for cloud-config (empty = lock_passwd / no chpasswd).
+PASSWORD="${SHOAL_SEED_PASSWORD:-${SHOAL_AUTOINSTALL_PASSWORD:-}}"
+
+if ! command -v xorriso >/dev/null 2>&1 && ! command -v genisoimage >/dev/null 2>&1 && ! command -v mkisofs >/dev/null 2>&1; then
+  echo "error: need xorriso, genisoimage, or mkisofs" >&2
+  exit 1
+fi
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/shoal-nocloud-seed.XXXXXX")"
+cleanup() { rm -rf "$WORK"; }
+trap cleanup EXIT
+
+SEED="$WORK/cidata"
+mkdir -p "$SEED"
+
+if [[ -n "${SHOAL_SEED_META_DATA:-}" && -r "${SHOAL_SEED_META_DATA}" ]]; then
+  cp "${SHOAL_SEED_META_DATA}" "$SEED/meta-data"
+else
+  cat >"$SEED/meta-data" <<EOF
+instance-id: ${INSTANCE_ID}
+local-hostname: ${HOSTNAME}
+EOF
+fi
+
+if [[ -n "${SHOAL_SEED_USER_DATA:-}" && -r "${SHOAL_SEED_USER_DATA}" ]]; then
+  cp "${SHOAL_SEED_USER_DATA}" "$SEED/user-data"
+else
+  if [[ -n "$PASSWORD" ]]; then
+    cat >"$SEED/user-data" <<EOF
+#cloud-config
+hostname: ${HOSTNAME}
+manage_etc_hosts: true
+users:
+  - name: ${USERNAME}
+    lock_passwd: false
+    shell: /bin/bash
+    sudo: ALL=(ALL) NOPASSWD:ALL
+ssh_pwauth: true
+chpasswd:
+  expire: false
+  list: |
+    ${USERNAME}:${PASSWORD}
+EOF
+  else
+    cat >"$SEED/user-data" <<EOF
+#cloud-config
+hostname: ${HOSTNAME}
+manage_etc_hosts: true
+users:
+  - name: ${USERNAME}
+    lock_passwd: true
+    shell: /bin/bash
+    sudo: ALL=(ALL) NOPASSWD:ALL
+ssh_pwauth: false
+EOF
+  fi
+fi
+
+# Empty network-config keeps some cloud-init versions happy offline.
+if [[ ! -f "$SEED/network-config" ]]; then
+  printf 'version: 2\n' >"$SEED/network-config"
+fi
+
+mkdir -p "$(dirname "$OUT")"
+if command -v xorriso >/dev/null 2>&1; then
+  xorriso -as mkisofs -quiet -V cidata -o "$OUT" -R -J "$SEED"
+elif command -v genisoimage >/dev/null 2>&1; then
+  genisoimage -quiet -V cidata -o "$OUT" -R -J "$SEED"
+else
+  mkisofs -quiet -V cidata -o "$OUT" -R -J "$SEED"
+fi
+chmod 644 "$OUT" 2>/dev/null || true
+SIZE="$(wc -c <"$OUT" | tr -d ' ')"
+echo "built $OUT ($SIZE bytes) NoCloud label=cidata hostname=${HOSTNAME}"
+echo "use as seed_iso_url / SHOAL_SEED_ISO_URL for seed_delivery=second_media"

--- a/internal/cli/deploy.go
+++ b/internal/cli/deploy.go
@@ -74,6 +74,9 @@ func cmdDeployRun(args []string) int {
 	prep := fs.String("prep", "", "skip (default) | wipe_only (M2 multi-stage prep)")
 	prepISO := fs.String("prep-iso-url", os.Getenv("SHOAL_PREP_ISO_URL"), "BMC-reachable prep live ISO (wipe_only)")
 	wipeLevel := fs.String("wipe-level", "", "discard|zero (baked into prep ISO at build; optional)")
+	seedDelivery := fs.String("seed-delivery", "", "none|auto|second_media|config_drive (M3 offline NoCloud; no guest HTTP)")
+	seedISO := fs.String("seed-iso-url", os.Getenv("SHOAL_SEED_ISO_URL"), "BMC-reachable NoCloud cidata ISO (second_media)")
+	osFamily := fs.String("os-family", "", "ubuntu (M3 seed paths); flatcar later")
 	sshHost := fs.String("serial-ssh-host", cfg.SerialSSHHost, "SSH host for nested libvirt serial (VM mode)")
 	sshUser := fs.String("serial-ssh-user", cfg.SerialSSHUser, "SSH user for serial delegate")
 	sshKey := fs.String("serial-ssh-key", cfg.SerialSSHKey, "SSH private key for serial delegate")
@@ -126,6 +129,9 @@ func cmdDeployRun(args []string) int {
 		Prep:             *prep,
 		PrepISOURL:       *prepISO,
 		WipeLevel:        *wipeLevel,
+		SeedDelivery:     *seedDelivery,
+		SeedISOURL:       *seedISO,
+		OsFamily:         *osFamily,
 	}
 	// Cloud image is passed via env for the builder (StartJobRequest has no field yet for 7a.1).
 	if strings.TrimSpace(*cloudImg) != "" {

--- a/internal/common/models/models.go
+++ b/internal/common/models/models.go
@@ -73,6 +73,16 @@ const (
 	InstallStrategyOperatorISO = "operator_iso" // reserved; not expanded in M1
 )
 
+// Seed delivery modes (multi-stage M3 offline NoCloud). Never guest HTTP.
+const (
+	SeedDeliveryNone        = "none"
+	SeedDeliveryAuto        = "auto"
+	SeedDeliverySecondMedia = "second_media"
+	SeedDeliveryConfigDrive = "config_drive"
+	// SeedDeliverySingleISO reserved (preference #3 remaster).
+	SeedDeliverySingleISO = "single_iso"
+)
+
 // Job stage kinds.
 const (
 	JobStageKindPrep      = "prep"
@@ -247,6 +257,13 @@ type StartJobRequest struct {
 	PrepISOURL string `json:"prep_iso_url,omitempty"`
 	// WipeLevel is discard (prefer blkdiscard) or zero (dd first 64MiB). Prep only.
 	WipeLevel string `json:"wipe_level,omitempty"`
+	// SeedDelivery is none (default) | auto | second_media | config_drive (M3).
+	// config_drive is forbidden with install_strategy=image_write (full-disk dd).
+	SeedDelivery string `json:"seed_delivery,omitempty"`
+	// SeedISOURL is BMC-reachable NoCloud/CIDATA ISO for second_media.
+	SeedISOURL string `json:"seed_iso_url,omitempty"`
+	// OsFamily is ubuntu for M3 seed paths (flatcar later).
+	OsFamily string `json:"os_family,omitempty"`
 }
 
 // CancelJobRequest cancels an in-flight provisioning job.

--- a/internal/common/redfish/fake.go
+++ b/internal/common/redfish/fake.go
@@ -51,6 +51,26 @@ func NewFake() *Fake {
 	}
 }
 
+// NewFakeDualCD returns a Fake with two CD-capable Virtual Media slots (M3 second_media tests).
+func NewFakeDualCD() *Fake {
+	f := NewFake()
+	f.Media["/redfish/v1/Managers/1/VirtualMedia/Cd2"] = VirtualMedia{
+		URI: "/redfish/v1/Managers/1/VirtualMedia/Cd2", Name: "Cd2", ID: "Cd2", SupportsCD: true,
+	}
+	return f
+}
+
+// InsertedImages returns a copy of media URI → image URL (test helper).
+func (f *Fake) InsertedImages() map[string]string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make(map[string]string, len(f.InsertedImage))
+	for k, v := range f.InsertedImage {
+		out[k] = v
+	}
+	return out
+}
+
 func (f *Fake) Open(_ context.Context) error  { return f.OpenErr }
 func (f *Fake) Close(_ context.Context) error { return nil }
 

--- a/internal/common/validate/validate.go
+++ b/internal/common/validate/validate.go
@@ -193,7 +193,53 @@ func StartJobRequest(r models.StartJobRequest) error {
 	if w := strings.TrimSpace(strings.ToLower(r.WipeLevel)); w != "" && w != "discard" && w != "zero" {
 		return fmt.Errorf("validate: wipe_level must be discard or zero")
 	}
+
+	// Multi-stage M3: offline seed delivery (no guest HTTP).
+	seed := strings.TrimSpace(strings.ToLower(r.SeedDelivery))
+	switch seed {
+	case "", models.SeedDeliveryNone, models.SeedDeliveryAuto,
+		models.SeedDeliverySecondMedia, models.SeedDeliveryConfigDrive:
+		// ok
+	case models.SeedDeliverySingleISO:
+		return fmt.Errorf("validate: seed_delivery single_iso not implemented (use second_media or prepare-time seed)")
+	default:
+		return fmt.Errorf("validate: unknown seed_delivery %q", r.SeedDelivery)
+	}
+	if fam := strings.TrimSpace(strings.ToLower(r.OsFamily)); fam != "" && fam != "ubuntu" {
+		return fmt.Errorf("validate: os_family %q not supported yet (M3: ubuntu only)", r.OsFamily)
+	}
+	if seedURL := strings.TrimSpace(r.SeedISOURL); seedURL != "" {
+		if !strings.HasPrefix(seedURL, "http://") && !strings.HasPrefix(seedURL, "https://") {
+			return fmt.Errorf("validate: seed_iso_url must be an http(s) URL reachable by the BMC")
+		}
+	}
+	// Full-disk image_write overwrites any config-drive partition; forbid the combination.
+	if seed == models.SeedDeliveryConfigDrive && installStrategyIsImageWrite(r) {
+		return fmt.Errorf("validate: seed_delivery config_drive is incompatible with install_strategy image_write (full-disk dd destroys the partition); use prepare-ubuntu-cloud-payload for offline seed, or second_media with a dual-CD BMC")
+	}
+	if seed == models.SeedDeliverySecondMedia && strings.TrimSpace(r.SeedISOURL) == "" {
+		if strings.TrimSpace(os.Getenv("SHOAL_SEED_ISO_URL")) == "" {
+			return fmt.Errorf("validate: seed_delivery second_media requires seed_iso_url or SHOAL_SEED_ISO_URL")
+		}
+	}
 	return nil
+}
+
+// installStrategyIsImageWrite mirrors deploy/job strategy defaults for validation.
+func installStrategyIsImageWrite(r models.StartJobRequest) bool {
+	if s := strings.TrimSpace(r.InstallStrategy); s != "" {
+		return s == models.InstallStrategyImageWrite
+	}
+	mode := strings.TrimSpace(strings.ToLower(r.ISOInstallMode))
+	switch mode {
+	case "write", "autoinstall", "":
+		// empty mode defaults to image_write in expandStages
+		return true
+	case "simulate":
+		return false
+	default:
+		return true
+	}
 }
 
 // CancelJobRequest requires job_id.

--- a/internal/common/validate/validate_test.go
+++ b/internal/common/validate/validate_test.go
@@ -101,4 +101,33 @@ func TestStartJobRequest(t *testing.T) {
 	if err := validate.StartJobRequest(prep); err != nil {
 		t.Fatal(err)
 	}
+	// M3: config_drive forbidden with image_write
+	seed := good
+	seed.SeedDelivery = models.SeedDeliveryConfigDrive
+	seed.InstallStrategy = models.InstallStrategyImageWrite
+	if err := validate.StartJobRequest(seed); err == nil {
+		t.Fatal("expected config_drive+image_write to fail")
+	}
+	// second_media needs seed URL
+	seed = good
+	seed.SeedDelivery = models.SeedDeliverySecondMedia
+	t.Setenv("SHOAL_SEED_ISO_URL", "")
+	if err := validate.StartJobRequest(seed); err == nil {
+		t.Fatal("expected second_media without seed URL to fail")
+	}
+	seed.SeedISOURL = "http://lab:8080/cidata.iso"
+	if err := validate.StartJobRequest(seed); err != nil {
+		t.Fatal(err)
+	}
+	// none / empty seed is fine
+	seed.SeedDelivery = ""
+	seed.SeedISOURL = ""
+	if err := validate.StartJobRequest(seed); err != nil {
+		t.Fatal(err)
+	}
+	// bad seed delivery
+	seed.SeedDelivery = "http_guest"
+	if err := validate.StartJobRequest(seed); err == nil {
+		t.Fatal("expected unknown seed_delivery to fail")
+	}
 }

--- a/internal/deploy/job/orchestrator.go
+++ b/internal/deploy/job/orchestrator.go
@@ -8,6 +8,8 @@ import (
 	"encoding/hex"
 	"fmt"
 	"log/slog"
+	"os"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -259,10 +261,7 @@ func (o *Orchestrator) Start(ctx context.Context, req models.StartJobRequest) (m
 	if err != nil {
 		return models.ProvisioningJob{}, err
 	}
-	strategy := ""
-	if len(stages) > 0 {
-		strategy = stages[0].Strategy
-	}
+	strategy := installStrategyFromStages(stages)
 
 	profile := profileRef
 	now := time.Now().UTC()
@@ -338,8 +337,8 @@ func (o *Orchestrator) provision(ctx context.Context, job models.ProvisioningJob
 		}
 	}
 	strategy := job.InstallStrategy
-	if strategy == "" && len(stages) > 0 {
-		strategy = stages[0].Strategy
+	if strategy == "" {
+		strategy = installStrategyFromStages(stages)
 	}
 	if err := o.store.UpdateStages(ctx, job.ID, stages[0].ID, strategy, stages); err != nil {
 		return fmt.Errorf("persist stages: %w", err)
@@ -418,12 +417,60 @@ func (o *Orchestrator) startStage(ctx context.Context, job models.ProvisioningJo
 	if err != nil {
 		return fmt.Errorf("list virtual media: %w", err)
 	}
-	mediaURI := pickCDMedia(vms)
-	if mediaURI == "" {
+	primaryURI, secondaryURI := pickCDMediaPair(vms)
+	if primaryURI == "" {
 		return fmt.Errorf("no CD-capable virtual media slot")
 	}
-	if err := bmc.InsertVirtualMedia(ctx, mediaURI, mediaURL); err != nil {
+
+	// M3: resolve offline seed and optionally attach second_media seed ISO.
+	seedDelivery := models.SeedDeliveryNone
+	seedURL := ""
+	if stage.Kind == models.JobStageKindOSInstall {
+		seedURL = strings.TrimSpace(stage.SeedMediaURL)
+		if seedURL == "" {
+			seedURL = strings.TrimSpace(req.SeedISOURL)
+		}
+		if seedURL == "" {
+			seedURL = strings.TrimSpace(os.Getenv("SHOAL_SEED_ISO_URL"))
+		}
+		requested := stage.SeedDelivery
+		if requested == "" {
+			requested = req.SeedDelivery
+		}
+		stageStrategy := stage.Strategy
+		if stageStrategy == "" {
+			stageStrategy = strategy
+		}
+		var resErr error
+		seedDelivery, resErr = resolveSeedDelivery(requested, seedURL, stageStrategy, countCDMedia(vms))
+		if resErr != nil {
+			return resErr
+		}
+		if seedDelivery == models.SeedDeliverySecondMedia {
+			if secondaryURI == "" {
+				return fmt.Errorf("job: second_media resolved but no secondary CD slot")
+			}
+			if seedURL == "" {
+				return fmt.Errorf("job: second_media requires seed ISO URL")
+			}
+		}
+		// Persist resolved delivery on the stage for job status.
+		stages = setStageSeed(stages, stage.ID, seedDelivery, seedURL)
+		_ = o.store.UpdateStages(ctx, job.ID, stage.ID, strategy, stages)
+	}
+
+	if err := bmc.InsertVirtualMedia(ctx, primaryURI, mediaURL); err != nil {
 		return fmt.Errorf("insert media: %w", err)
+	}
+	if seedDelivery == models.SeedDeliverySecondMedia {
+		if err := bmc.InsertVirtualMedia(ctx, secondaryURI, seedURL); err != nil {
+			return fmt.Errorf("insert seed media: %w", err)
+		}
+		o.log.Info("second_media seed attached",
+			"job_id", job.ID,
+			"install_media", primaryURI,
+			"seed_media", secondaryURI,
+		)
 	}
 	if err := bmc.SetBootOverrideOnceCD(ctx, sys.ID); err != nil {
 		return fmt.Errorf("boot override: %w", err)
@@ -609,16 +656,52 @@ func (o *Orchestrator) advanceAfterPrepDone(jobID string) {
 	}
 }
 
-func pickCDMedia(vms []redfish.VirtualMedia) string {
+// pickCDMediaPair returns primary (boot) and secondary CD-capable media URIs.
+// URIs are sorted so selection is stable across Fake map iteration order.
+func pickCDMediaPair(vms []redfish.VirtualMedia) (primary, secondary string) {
+	var cds []string
 	for _, vm := range vms {
 		if vm.SupportsCD {
-			return vm.URI
+			cds = append(cds, vm.URI)
 		}
 	}
-	if len(vms) > 0 {
-		return vms[0].URI
+	sort.Strings(cds)
+	if len(cds) == 0 {
+		if len(vms) > 0 {
+			return vms[0].URI, ""
+		}
+		return "", ""
 	}
-	return ""
+	if len(cds) == 1 {
+		return cds[0], ""
+	}
+	return cds[0], cds[1]
+}
+
+func countCDMedia(vms []redfish.VirtualMedia) int {
+	n := 0
+	for _, vm := range vms {
+		if vm.SupportsCD {
+			n++
+		}
+	}
+	return n
+}
+
+// setStageSeed updates seed fields on the stage with id.
+func setStageSeed(stages []models.JobStage, id, delivery, seedURL string) []models.JobStage {
+	out := make([]models.JobStage, len(stages))
+	copy(out, stages)
+	for i := range out {
+		if out[i].ID == id {
+			out[i].SeedDelivery = delivery
+			if seedURL != "" {
+				out[i].SeedMediaURL = seedURL
+			}
+			break
+		}
+	}
+	return out
 }
 
 // Cancel requests terminal handling for a job.

--- a/internal/deploy/job/orchestrator_test.go
+++ b/internal/deploy/job/orchestrator_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"log/slog"
+	"strings"
 	"testing"
 	"time"
 
@@ -375,6 +376,124 @@ func TestOrchestratorOrphanReconcile(t *testing.T) {
 	}
 	if got.State != models.StateFailed {
 		t.Fatalf("orphan state %s", got.State)
+	}
+}
+
+func TestOrchestratorSecondMediaDualInsert(t *testing.T) {
+	ctx := context.Background()
+	store := jobstore.NewMemory()
+	sec := secrets.NewMemory()
+	fakeBMC := redfish.NewFakeDualCD()
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	pr, pw := io.Pipe()
+	watch := sol.NewWatchService(log, nil)
+	watch.NewTransport = func(session models.WatchSession) sol.Transport {
+		return sol.NewReaderTransport(pr)
+	}
+	orch := job.NewOrchestrator(job.Options{
+		Log: log, Store: store, Secrets: sec,
+		NewBMC:  func(cfg redfish.Config) (redfish.BMC, error) { return fakeBMC, nil },
+		Watches: watch, AuthMode: "basic", TLSMode: "off",
+	})
+	defer orch.Stop()
+	watch.SetProgress(orch.ProgressPort())
+
+	installURL := "http://iso/install.iso"
+	seedURL := "http://iso/cidata.iso"
+	j, err := orch.Start(ctx, models.StartJobRequest{
+		DeviceID:        "lab-node-1",
+		BMCEndpoint:     "http://bmc.test",
+		BMCUsername:     "admin",
+		BMCPassword:     "secret",
+		SerialTarget:    "lab-node-1",
+		ISOURL:          installURL,
+		SeedDelivery:    models.SeedDeliverySecondMedia,
+		SeedISOURL:      seedURL,
+		InstallStrategy: models.InstallStrategySimulate,
+	})
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	imgs := fakeBMC.InsertedImages()
+	if len(imgs) != 2 {
+		t.Fatalf("want 2 media inserts, got %v", imgs)
+	}
+	var foundInstall, foundSeed bool
+	for _, u := range imgs {
+		if u == installURL {
+			foundInstall = true
+		}
+		if u == seedURL {
+			foundSeed = true
+		}
+	}
+	if !foundInstall || !foundSeed {
+		t.Fatalf("expected install+seed URLs, got %v", imgs)
+	}
+	// Stage should record resolved second_media
+	loaded, err := store.Get(ctx, j.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(loaded.Stages) != 1 {
+		t.Fatalf("stages=%d", len(loaded.Stages))
+	}
+	if loaded.Stages[0].SeedDelivery != models.SeedDeliverySecondMedia {
+		t.Fatalf("seed_delivery=%s", loaded.Stages[0].SeedDelivery)
+	}
+	if loaded.Stages[0].SeedMediaURL != seedURL {
+		t.Fatalf("seed_media_url=%s", loaded.Stages[0].SeedMediaURL)
+	}
+
+	writeMarker(t, pw, "SHOAL|1|1|2026-06-19T04:10:00Z|DONE|100|OK|done")
+	_ = pw.Close()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		final, _ := store.Get(ctx, j.ID)
+		if final.State == models.StateProvisioned {
+			if fakeBMC.MediaInserted() {
+				t.Fatal("cleanup should eject both media")
+			}
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatal("job did not reach provisioned")
+}
+
+func TestOrchestratorSecondMediaFailsWithOneCD(t *testing.T) {
+	ctx := context.Background()
+	store := jobstore.NewMemory()
+	fakeBMC := redfish.NewFake() // single CD
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	watch := sol.NewWatchService(log, nil)
+	watch.NewTransport = func(session models.WatchSession) sol.Transport {
+		return sol.NewReaderTransport(io.NopCloser(strings.NewReader("")))
+	}
+	orch := job.NewOrchestrator(job.Options{
+		Log: log, Store: store, Secrets: secrets.NewMemory(),
+		NewBMC:  func(cfg redfish.Config) (redfish.BMC, error) { return fakeBMC, nil },
+		Watches: watch, AuthMode: "basic", TLSMode: "off",
+	})
+	defer orch.Stop()
+	watch.SetProgress(orch.ProgressPort())
+
+	_, err := orch.Start(ctx, models.StartJobRequest{
+		DeviceID:        "lab-node-1",
+		BMCEndpoint:     "http://bmc.test",
+		BMCUsername:     "admin",
+		BMCPassword:     "secret",
+		SerialTarget:    "lab-node-1",
+		ISOURL:          "http://iso/install.iso",
+		SeedDelivery:    models.SeedDeliverySecondMedia,
+		SeedISOURL:      "http://iso/cidata.iso",
+		InstallStrategy: models.InstallStrategySimulate,
+	})
+	if err == nil {
+		t.Fatal("expected second_media with 1 CD to fail")
+	}
+	if !strings.Contains(err.Error(), "second_media") && !strings.Contains(err.Error(), "Virtual Media") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/internal/deploy/job/stages.go
+++ b/internal/deploy/job/stages.go
@@ -11,6 +11,7 @@ import (
 
 // expandStages derives the stage list for a StartJobRequest (multi-stage design).
 // M1: single os_install. M2: optional prep wipe + os_install.
+// M3: offline seed fields on os_install (second_media / config_drive / auto).
 func expandStages(req models.StartJobRequest) ([]models.JobStage, error) {
 	strategy, err := resolveInstallStrategy(req)
 	if err != nil {
@@ -21,13 +22,20 @@ func expandStages(req models.StartJobRequest) ([]models.JobStage, error) {
 		return nil, fmt.Errorf("job: install_strategy %q not implemented (use image_write or simulate)", strategy)
 	}
 
+	seedDelivery, seedURL, err := normalizeSeedRequest(req, strategy)
+	if err != nil {
+		return nil, err
+	}
+
 	installMedia := strings.TrimSpace(req.ISOURL)
 	osStage := models.JobStage{
 		ID:           models.JobStageKindOSInstall,
 		Kind:         models.JobStageKindOSInstall,
 		Strategy:     strategy,
+		Family:       strings.TrimSpace(strings.ToLower(req.OsFamily)),
 		MediaURL:     installMedia,
-		SeedDelivery: "none",
+		SeedMediaURL: seedURL,
+		SeedDelivery: seedDelivery,
 		State:        models.JobStageStatePending,
 	}
 
@@ -58,6 +66,95 @@ func expandStages(req models.StartJobRequest) ([]models.JobStage, error) {
 	default:
 		return nil, fmt.Errorf("job: unknown prep %q", req.Prep)
 	}
+}
+
+// normalizeSeedRequest applies defaults for seed fields before stage expansion.
+// Final mode for "auto" is chosen at startStage once Virtual Media is listed.
+func normalizeSeedRequest(req models.StartJobRequest, strategy string) (delivery, seedURL string, err error) {
+	delivery = strings.TrimSpace(strings.ToLower(req.SeedDelivery))
+	seedURL = strings.TrimSpace(req.SeedISOURL)
+	if seedURL == "" {
+		seedURL = strings.TrimSpace(os.Getenv("SHOAL_SEED_ISO_URL"))
+	}
+	if delivery == "" {
+		if seedURL != "" {
+			delivery = models.SeedDeliveryAuto
+		} else {
+			delivery = models.SeedDeliveryNone
+		}
+	}
+	switch delivery {
+	case models.SeedDeliveryNone:
+		seedURL = ""
+		return delivery, seedURL, nil
+	case models.SeedDeliveryAuto, models.SeedDeliverySecondMedia, models.SeedDeliveryConfigDrive:
+		// ok
+	case models.SeedDeliverySingleISO:
+		return "", "", fmt.Errorf("job: seed_delivery single_iso not implemented")
+	default:
+		return "", "", fmt.Errorf("job: unknown seed_delivery %q", req.SeedDelivery)
+	}
+	if delivery == models.SeedDeliveryConfigDrive && strategy == models.InstallStrategyImageWrite {
+		return "", "", fmt.Errorf("job: seed_delivery config_drive is incompatible with image_write (full-disk dd destroys config-drive); use prepare-ubuntu-cloud-payload or second_media")
+	}
+	if delivery == models.SeedDeliverySecondMedia && seedURL == "" {
+		return "", "", fmt.Errorf("job: seed_delivery second_media requires seed_iso_url or SHOAL_SEED_ISO_URL")
+	}
+	if delivery == models.SeedDeliveryAuto && seedURL == "" {
+		// auto without seed URL is a no-op (nothing to deliver).
+		return models.SeedDeliveryNone, "", nil
+	}
+	return delivery, seedURL, nil
+}
+
+// resolveSeedDelivery picks the concrete offline seed mode given CD-capable media count.
+// nCD is the number of CD-capable Virtual Media slots on the BMC.
+func resolveSeedDelivery(requested, seedURL, strategy string, nCD int) (string, error) {
+	req := strings.TrimSpace(strings.ToLower(requested))
+	if req == "" || req == models.SeedDeliveryNone {
+		return models.SeedDeliveryNone, nil
+	}
+	if strings.TrimSpace(seedURL) == "" && req != models.SeedDeliveryConfigDrive {
+		return models.SeedDeliveryNone, nil
+	}
+	switch req {
+	case models.SeedDeliverySecondMedia:
+		if nCD < 2 {
+			return "", fmt.Errorf("job: seed_delivery second_media needs ≥2 CD-capable Virtual Media slots (found %d); use prepare-time seed for image_write or dual-CD hardware", nCD)
+		}
+		return models.SeedDeliverySecondMedia, nil
+	case models.SeedDeliveryConfigDrive:
+		if strategy == models.InstallStrategyImageWrite {
+			return "", fmt.Errorf("job: seed_delivery config_drive is incompatible with image_write")
+		}
+		// Prep-stage FAT writer for scripted_iso is not shipped yet.
+		return "", fmt.Errorf("job: seed_delivery config_drive not implemented yet (M3 ships second_media; for image_write use prepare-ubuntu-cloud-payload)")
+	case models.SeedDeliveryAuto:
+		if nCD >= 2 && strings.TrimSpace(seedURL) != "" {
+			return models.SeedDeliverySecondMedia, nil
+		}
+		if strategy == models.InstallStrategyImageWrite {
+			return "", fmt.Errorf("job: seed_delivery auto: only one Virtual Media slot and image_write cannot use config_drive; bake seed with prepare-ubuntu-cloud-payload or attach seed_iso_url on a dual-CD BMC")
+		}
+		return "", fmt.Errorf("job: seed_delivery auto: config_drive fallback not implemented yet (need ≥2 CD slots for second_media, found %d)", nCD)
+	default:
+		return "", fmt.Errorf("job: unknown seed_delivery %q", requested)
+	}
+}
+
+// installStrategyFromStages returns the os_install strategy (not prep's empty strategy).
+func installStrategyFromStages(stages []models.JobStage) string {
+	for _, s := range stages {
+		if s.Kind == models.JobStageKindOSInstall && s.Strategy != "" {
+			return s.Strategy
+		}
+	}
+	for _, s := range stages {
+		if s.Strategy != "" {
+			return s.Strategy
+		}
+	}
+	return ""
 }
 
 func resolveInstallStrategy(req models.StartJobRequest) (string, error) {

--- a/internal/deploy/job/stages_test.go
+++ b/internal/deploy/job/stages_test.go
@@ -88,6 +88,72 @@ func TestExpandStagesRejectsScriptedISO(t *testing.T) {
 	}
 }
 
+func TestExpandStagesSeedSecondMedia(t *testing.T) {
+	stages, err := expandStages(models.StartJobRequest{
+		ISOURL:          "http://example/os.iso",
+		InstallStrategy: models.InstallStrategyImageWrite,
+		SeedDelivery:    models.SeedDeliverySecondMedia,
+		SeedISOURL:      "http://example/cidata.iso",
+		OsFamily:        "ubuntu",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	st := stages[0]
+	if st.SeedDelivery != models.SeedDeliverySecondMedia {
+		t.Fatalf("delivery=%s", st.SeedDelivery)
+	}
+	if st.SeedMediaURL != "http://example/cidata.iso" {
+		t.Fatalf("seed=%s", st.SeedMediaURL)
+	}
+	if st.Family != "ubuntu" {
+		t.Fatalf("family=%s", st.Family)
+	}
+}
+
+func TestExpandStagesRejectsConfigDriveImageWrite(t *testing.T) {
+	_, err := expandStages(models.StartJobRequest{
+		ISOURL:          "http://example/os.iso",
+		InstallStrategy: models.InstallStrategyImageWrite,
+		SeedDelivery:    models.SeedDeliveryConfigDrive,
+	})
+	if err == nil || !strings.Contains(err.Error(), "config_drive") {
+		t.Fatalf("got %v", err)
+	}
+}
+
+func TestResolveSeedDelivery(t *testing.T) {
+	// dual CD → second_media for auto
+	got, err := resolveSeedDelivery(models.SeedDeliveryAuto, "http://s/seed.iso", models.InstallStrategyImageWrite, 2)
+	if err != nil || got != models.SeedDeliverySecondMedia {
+		t.Fatalf("auto dual: got %q err=%v", got, err)
+	}
+	// single CD + image_write → error (no config_drive)
+	_, err = resolveSeedDelivery(models.SeedDeliveryAuto, "http://s/seed.iso", models.InstallStrategyImageWrite, 1)
+	if err == nil {
+		t.Fatal("expected auto+1cd+image_write error")
+	}
+	// explicit second_media needs 2 slots
+	_, err = resolveSeedDelivery(models.SeedDeliverySecondMedia, "http://s/seed.iso", models.InstallStrategyImageWrite, 1)
+	if err == nil {
+		t.Fatal("expected second_media with 1 slot to fail")
+	}
+	got, err = resolveSeedDelivery(models.SeedDeliverySecondMedia, "http://s/seed.iso", models.InstallStrategyImageWrite, 2)
+	if err != nil || got != models.SeedDeliverySecondMedia {
+		t.Fatalf("second_media dual: %q %v", got, err)
+	}
+	// none
+	got, err = resolveSeedDelivery(models.SeedDeliveryNone, "", models.InstallStrategyImageWrite, 1)
+	if err != nil || got != models.SeedDeliveryNone {
+		t.Fatalf("none: %q %v", got, err)
+	}
+	// config_drive + image_write
+	_, err = resolveSeedDelivery(models.SeedDeliveryConfigDrive, "", models.InstallStrategyImageWrite, 1)
+	if err == nil {
+		t.Fatal("expected config_drive+image_write error")
+	}
+}
+
 func TestSetStageState(t *testing.T) {
 	stages := []models.JobStage{
 		{ID: "os_install", State: models.JobStageStatePending},


### PR DESCRIPTION
## Summary

Implements multi-stage design slice **M3**: offline Ubuntu NoCloud seed delivery without guest HTTP.

- **`infra/scripts/build-nocloud-seed-iso.sh`** — tiny `cidata` ISO (`user-data` / `meta-data` / `network-config`)
- **`seed_delivery` / `seed_iso_url` / `os_family`** on `StartJobRequest` + CLI flags
- **`second_media`**: attach install ISO + seed ISO when BMC has ≥2 CD-capable Virtual Media slots
- **`auto`**: prefer `second_media` when dual-CD + seed URL; actionable error on single-CD + `image_write`
- **Hard rule:** `config_drive` + `image_write` is **rejected** (full-disk dd would destroy any prep config-drive partition)
- `config_drive` partition writer deferred (not claimed complete); M3 ships dual-media path + policy
- Unit tests with `redfish.NewFakeDualCD`; design + lab-runbook notes (sushy often 1 CD)

## Test plan

- [x] `gofmt` / `go vet` / `staticcheck` on touched packages
- [x] `go test ./internal/deploy/job ./internal/common/validate ./...`
- [x] Seed ISO builder smoke (xorriso → ~380KB cidata ISO)
- [ ] Optional lab: dual-CD BMC/hardware only — nested sushy typically cannot prove second_media E2E

## Design

Advances `docs/multi-stage-provisioning-design.md` §11 M3.