### PR TITLE
feat(deploy): multi-stage M5 operator_iso coarse progress

### DIFF
--- a/docs/lab-runbook.md
+++ b/docs/lab-runbook.md
@@ -484,6 +484,31 @@ go run ./cmd/shoal deploy run \
 | `auto` | Prefer second_media when ≥2 CDs + `seed_iso_url`; else error if image_write (no config_drive) |
 | `config_drive` | **Forbidden** with `image_write` (full-disk dd wipes partition); write path not implemented yet |
 
+### Multi-stage M5: operator_iso (ESXi / Windows)
+
+Operator supplies a **ready** install ISO (kickstart / Autounattend already on media).
+Shoal attaches, boots CD once, waits, then cleans up. **No seed fields** (config is on the ISO).
+
+**Coarse progress:** ESXi/Windows do not emit `SHOAL|…` markers. The job becomes
+`provisioned` when **`stage_timeout` elapses** (default **60m**, or
+`SHOAL_OPERATOR_ISO_TIMEOUT`). This is **not** guest install verification — confirm
+the host out of band. Optional SOL is best-effort (stall disabled); serial may be omitted.
+
+```bash
+go run ./cmd/shoal deploy run \
+  -device-id host-7 \
+  -bmc-url https://bmc/redfish/v1 \
+  -bmc-user admin -bmc-pass '…' \
+  -install-strategy operator_iso \
+  -os-family esxi \
+  -iso-url http://192.168.124.1:8080/esxi-custom.iso \
+  -stage-timeout 90m \
+  -wait
+```
+
+Nested sushy can smoke-test attach + short `-stage-timeout` only; it does **not** prove
+ESXi/Windows install. Prefer real BMC hardware for true AC.
+
 ### Phase 6b: graphics failure-screen OCR
 
 SOL remains the primary progress channel. Graphics OCR is **diagnostic only**.

--- a/docs/multi-stage-provisioning-design.md
+++ b/docs/multi-stage-provisioning-design.md
@@ -804,7 +804,7 @@ Version media URLs when content changes (sushy cache lesson from 7a).
 | **M2** | Prep v1: wipe + `PREP_*` + handoff to image-write Ubuntu | **Implemented** (event-driven `PREP_DONE` → os_install) |
 | **M3** | Offline seed preference #1 then #2: **second_media**, else **config_drive**, for Ubuntu NoCloud | **Implemented** (seed ISO builder + dual-media attach + `auto` resolve; `config_drive` rejected with `image_write`; config_drive write deferred) |
 | **M4** | Flatcar offline Ignition (same preference order) | Documented AC |
-| **M5** | **`operator_iso`** path shared by ESXi + Windows shape (attach + boot + cleanup + coarse progress) | Hardware preferred |
+| **M5** | **`operator_iso`** path shared by ESXi + Windows shape (attach + boot + cleanup + coarse progress) | **Implemented** (coarse stage deadline → provisioned; SOL stall disabled; seed forbidden; esxi\|windows) |
 | **M6** | Profiles + `seed_delivery: auto` + Operator API §6 fields on `POST/GET /v1/jobs` | Happy path without ad-hoc flags; §6.9 ACs |
 | **Later** | Separate designs: ESXi/Windows ISO compose; optional Windows dual-media unattend; single_iso remaster polish | Out of this doc’s v1 slices |
 

--- a/internal/cli/deploy.go
+++ b/internal/cli/deploy.go
@@ -70,13 +70,14 @@ func cmdDeployRun(args []string) int {
 	ubuntuISO := fs.String("ubuntu-iso", os.Getenv("SHOAL_UBUNTU_ISO"), "Ubuntu live-server ISO (legacy remaster)")
 	cloudImg := fs.String("ubuntu-cloud-img", os.Getenv("SHOAL_UBUNTU_CLOUD_IMG"), "Ubuntu cloud image for autoinstall build (preferred)")
 	isoHostname := fs.String("iso-hostname", "", "autoinstall hostname when building")
-	installStrategy := fs.String("install-strategy", "", "simulate|image_write (M1); reserved: scripted_iso|operator_iso")
+	installStrategy := fs.String("install-strategy", "", "simulate|image_write|operator_iso (M5 ESXi/Windows); reserved: scripted_iso")
 	prep := fs.String("prep", "", "skip (default) | wipe_only (M2 multi-stage prep)")
 	prepISO := fs.String("prep-iso-url", os.Getenv("SHOAL_PREP_ISO_URL"), "BMC-reachable prep live ISO (wipe_only)")
 	wipeLevel := fs.String("wipe-level", "", "discard|zero (baked into prep ISO at build; optional)")
 	seedDelivery := fs.String("seed-delivery", "", "none|auto|second_media|config_drive (M3 offline NoCloud; no guest HTTP)")
 	seedISO := fs.String("seed-iso-url", os.Getenv("SHOAL_SEED_ISO_URL"), "BMC-reachable NoCloud cidata ISO (second_media)")
-	osFamily := fs.String("os-family", "", "ubuntu (M3 seed paths); flatcar later")
+	osFamily := fs.String("os-family", "", "ubuntu | esxi | windows (operator_iso requires esxi|windows)")
+	stageTimeout := fs.Duration("stage-timeout", 0, "operator_iso coarse wait (default 60m or SHOAL_OPERATOR_ISO_TIMEOUT)")
 	sshHost := fs.String("serial-ssh-host", cfg.SerialSSHHost, "SSH host for nested libvirt serial (VM mode)")
 	sshUser := fs.String("serial-ssh-user", cfg.SerialSSHUser, "SSH user for serial delegate")
 	sshKey := fs.String("serial-ssh-key", cfg.SerialSSHKey, "SSH private key for serial delegate")
@@ -132,6 +133,7 @@ func cmdDeployRun(args []string) int {
 		SeedDelivery:     *seedDelivery,
 		SeedISOURL:       *seedISO,
 		OsFamily:         *osFamily,
+		StageTimeout:     *stageTimeout,
 	}
 	// Cloud image is passed via env for the builder (StartJobRequest has no field yet for 7a.1).
 	if strings.TrimSpace(*cloudImg) != "" {

--- a/internal/common/models/models.go
+++ b/internal/common/models/models.go
@@ -69,8 +69,24 @@ const (
 const (
 	InstallStrategySimulate    = "simulate"
 	InstallStrategyImageWrite  = "image_write"
-	InstallStrategyScriptedISO = "scripted_iso" // reserved; not expanded in M1
-	InstallStrategyOperatorISO = "operator_iso" // reserved; not expanded in M1
+	InstallStrategyScriptedISO = "scripted_iso" // reserved; M4+
+	InstallStrategyOperatorISO = "operator_iso" // M5: ESXi/Windows operator media
+)
+
+// OS families for install / seed paths.
+const (
+	OSFamilyUbuntu  = "ubuntu"
+	OSFamilyFlatcar = "flatcar"
+	OSFamilyESXi    = "esxi"
+	OSFamilyWindows = "windows"
+)
+
+// Progress policies (how a stage reaches terminal success).
+const (
+	// ProgressPolicyMarkers requires SHOAL|… SOL markers (default for image_write/simulate/prep).
+	ProgressPolicyMarkers = "markers"
+	// ProgressPolicyCoarse completes on stage deadline without SOL markers (operator_iso).
+	ProgressPolicyCoarse = "coarse"
 )
 
 // Seed delivery modes (multi-stage M3 offline NoCloud). Never guest HTTP.
@@ -207,7 +223,10 @@ type WatchSession struct {
 	Transport    string        `json:"transport"` // "libvirt" | "redfish_sol" | "ipmi_sol"
 	Target       string        `json:"target"`    // console path or BMC URI
 	StartedAt    time.Time     `json:"started_at"`
-	StallTimeout time.Duration `json:"stall_timeout"` // e.g. 90s
+	StallTimeout time.Duration `json:"stall_timeout"` // e.g. 90s; 0 = watch default
+	// StallDisabled skips the silence stall timer (M5 operator_iso coarse progress).
+	// Zero StallTimeout still means default when StallDisabled is false.
+	StallDisabled bool `json:"stall_disabled,omitempty"`
 }
 
 // DeviceIdentity is NetBox-facing identity fields.
@@ -222,17 +241,22 @@ type DeviceIdentity struct {
 
 // StartJobRequest carries Phase 2 binding fields; NetBox-only resolution is post-Phase 3 optional.
 type StartJobRequest struct {
-	DeviceID      string `json:"device_id"`
-	ProfileRef    string `json:"profile_ref,omitempty"`
-	ISOURL        string `json:"iso_url"`
-	BMCEndpoint   string `json:"bmc_endpoint"`           // Redfish base URL
-	BMCUsername   string `json:"bmc_username,omitempty"` // stored to secrets; not logged
-	BMCPassword   string `json:"bmc_password,omitempty"` // stored to secrets; never returned
-	SerialTarget  string `json:"serial_target"`          // libvirt domain or SOL target
+	DeviceID    string `json:"device_id"`
+	ProfileRef  string `json:"profile_ref,omitempty"`
+	ISOURL      string `json:"iso_url"`
+	BMCEndpoint string `json:"bmc_endpoint"`           // Redfish base URL
+	BMCUsername string `json:"bmc_username,omitempty"` // stored to secrets; not logged
+	BMCPassword string `json:"bmc_password,omitempty"` // stored to secrets; never returned
+	// SerialTarget is libvirt domain or SOL target. Optional for operator_iso (M5 coarse).
+	SerialTarget  string `json:"serial_target"`
 	SystemID      string `json:"system_id,omitempty"`
 	CredentialRef string `json:"credential_ref,omitempty"` // alt: pre-seeded secret (skip user/pass)
 	// StallTimeout is the SOL silence window before ReportStall (0 = Orchestrator default).
+	// Ignored for operator_iso (stall disabled under coarse progress).
 	StallTimeout time.Duration `json:"stall_timeout,omitempty"`
+	// StageTimeout is max wait for operator_iso coarse stage (0 = default 60m).
+	// Deadline → provisioned (optimistic; not guest verification).
+	StageTimeout time.Duration `json:"stage_timeout,omitempty"`
 	// ApproveDestruct acknowledges NeedsApproval / DestructSteps on the profile (Phase 5b).
 	// Does not bypass a missing profile store entry; only supplies operator consent.
 	ApproveDestruct bool `json:"approve_destruct,omitempty"`
@@ -249,7 +273,7 @@ type StartJobRequest struct {
 	ISOUbuntuBase string `json:"iso_ubuntu_base,omitempty"`
 	// ISOHostname is the autoinstall identity hostname (Phase 7a).
 	ISOHostname string `json:"iso_hostname,omitempty"`
-	// InstallStrategy is optional: simulate | image_write (M1). Other values reserved.
+	// InstallStrategy is optional: simulate | image_write | operator_iso (M5). scripted_iso reserved.
 	InstallStrategy string `json:"install_strategy,omitempty"`
 	// Prep is optional: skip (default) | wipe_only (M2 multi-stage prep).
 	Prep string `json:"prep,omitempty"`
@@ -259,10 +283,11 @@ type StartJobRequest struct {
 	WipeLevel string `json:"wipe_level,omitempty"`
 	// SeedDelivery is none (default) | auto | second_media | config_drive (M3).
 	// config_drive is forbidden with install_strategy=image_write (full-disk dd).
+	// operator_iso requires none (config baked into operator media).
 	SeedDelivery string `json:"seed_delivery,omitempty"`
 	// SeedISOURL is BMC-reachable NoCloud/CIDATA ISO for second_media.
 	SeedISOURL string `json:"seed_iso_url,omitempty"`
-	// OsFamily is ubuntu for M3 seed paths (flatcar later).
+	// OsFamily is ubuntu | esxi | windows (flatcar later). Required for operator_iso.
 	OsFamily string `json:"os_family,omitempty"`
 }
 

--- a/internal/common/validate/validate.go
+++ b/internal/common/validate/validate.go
@@ -153,7 +153,9 @@ func StartJobRequest(r models.StartJobRequest) error {
 			return fmt.Errorf("validate: iso_url is required (or non-spike profile_ref / build_iso)")
 		}
 	}
-	if strings.TrimSpace(r.SerialTarget) == "" {
+	strategy := strings.TrimSpace(r.InstallStrategy)
+	operatorISO := strategy == models.InstallStrategyOperatorISO
+	if strings.TrimSpace(r.SerialTarget) == "" && !operatorISO {
 		return fmt.Errorf("validate: serial_target is required")
 	}
 	hasUserPass := r.BMCUsername != "" || r.BMCPassword != ""
@@ -161,13 +163,42 @@ func StartJobRequest(r models.StartJobRequest) error {
 	if !hasUserPass && !hasRef {
 		return fmt.Errorf("validate: bmc credentials or credential_ref is required")
 	}
-	if s := strings.TrimSpace(r.InstallStrategy); s != "" {
-		switch s {
+	if strategy != "" {
+		switch strategy {
 		case models.InstallStrategySimulate, models.InstallStrategyImageWrite,
 			models.InstallStrategyScriptedISO, models.InstallStrategyOperatorISO:
-			// ok (scripted/operator reserved; expand may reject later)
+			// scripted_iso may still be rejected at expand
 		default:
-			return fmt.Errorf("validate: unknown install_strategy %q", s)
+			return fmt.Errorf("validate: unknown install_strategy %q", strategy)
+		}
+	}
+	if operatorISO {
+		if strings.TrimSpace(r.ISOURL) == "" && !r.BuildISO {
+			ref := strings.TrimSpace(r.ProfileRef)
+			if ref == "" || ref == "spike" {
+				return fmt.Errorf("validate: operator_iso requires iso_url (operator-supplied media)")
+			}
+		}
+		fam := strings.TrimSpace(strings.ToLower(r.OsFamily))
+		switch fam {
+		case models.OSFamilyESXi, models.OSFamilyWindows:
+			// ok
+		case "":
+			return fmt.Errorf("validate: operator_iso requires os_family esxi or windows")
+		case models.OSFamilyUbuntu, models.OSFamilyFlatcar:
+			return fmt.Errorf("validate: os_family %q is not valid with operator_iso (use image_write or scripted_iso)", r.OsFamily)
+		default:
+			return fmt.Errorf("validate: unknown os_family %q for operator_iso (want esxi or windows)", r.OsFamily)
+		}
+		seed := strings.TrimSpace(strings.ToLower(r.SeedDelivery))
+		if seed != "" && seed != models.SeedDeliveryNone {
+			return fmt.Errorf("validate: operator_iso does not use seed_delivery (config must be on the operator ISO; use none)")
+		}
+		if strings.TrimSpace(r.SeedISOURL) != "" {
+			return fmt.Errorf("validate: operator_iso does not use seed_iso_url")
+		}
+		if r.StageTimeout < 0 {
+			return fmt.Errorf("validate: stage_timeout must be non-negative")
 		}
 	}
 	prep := strings.TrimSpace(strings.ToLower(r.Prep))
@@ -205,8 +236,17 @@ func StartJobRequest(r models.StartJobRequest) error {
 	default:
 		return fmt.Errorf("validate: unknown seed_delivery %q", r.SeedDelivery)
 	}
-	if fam := strings.TrimSpace(strings.ToLower(r.OsFamily)); fam != "" && fam != "ubuntu" {
-		return fmt.Errorf("validate: os_family %q not supported yet (M3: ubuntu only)", r.OsFamily)
+	if fam := strings.TrimSpace(strings.ToLower(r.OsFamily)); fam != "" {
+		switch fam {
+		case models.OSFamilyUbuntu, models.OSFamilyESXi, models.OSFamilyWindows:
+			// ok (flatcar reserved for M4)
+		case models.OSFamilyFlatcar:
+			return fmt.Errorf("validate: os_family flatcar not implemented yet (M4)")
+		default:
+			if !operatorISO {
+				return fmt.Errorf("validate: unknown os_family %q", r.OsFamily)
+			}
+		}
 	}
 	if seedURL := strings.TrimSpace(r.SeedISOURL); seedURL != "" {
 		if !strings.HasPrefix(seedURL, "http://") && !strings.HasPrefix(seedURL, "https://") {

--- a/internal/common/validate/validate_test.go
+++ b/internal/common/validate/validate_test.go
@@ -130,4 +130,28 @@ func TestStartJobRequest(t *testing.T) {
 	if err := validate.StartJobRequest(seed); err == nil {
 		t.Fatal("expected unknown seed_delivery to fail")
 	}
+	// M5 operator_iso
+	op := good
+	op.InstallStrategy = models.InstallStrategyOperatorISO
+	op.OsFamily = models.OSFamilyESXi
+	op.SerialTarget = "" // allowed for operator_iso
+	if err := validate.StartJobRequest(op); err != nil {
+		t.Fatal(err)
+	}
+	op.OsFamily = models.OSFamilyUbuntu
+	if err := validate.StartJobRequest(op); err == nil {
+		t.Fatal("expected ubuntu+operator_iso to fail")
+	}
+	op.OsFamily = models.OSFamilyESXi
+	op.SeedDelivery = models.SeedDeliverySecondMedia
+	op.SeedISOURL = "http://lab:8080/seed.iso"
+	if err := validate.StartJobRequest(op); err == nil {
+		t.Fatal("expected operator_iso with seed to fail")
+	}
+	// non-operator still needs serial
+	noSerial := good
+	noSerial.SerialTarget = ""
+	if err := validate.StartJobRequest(noSerial); err == nil {
+		t.Fatal("expected serial_target required without operator_iso")
+	}
 }

--- a/internal/deploy/job/orchestrator.go
+++ b/internal/deploy/job/orchestrator.go
@@ -46,6 +46,8 @@ const (
 	UnregisterTimeout     = 10 * time.Second
 	TerminalWorkerTimeout = 2 * time.Minute
 	DefaultSOLStall       = 3 * time.Minute
+	// DefaultOperatorStageTimeout is the coarse wait for operator_iso when StageTimeout is 0.
+	DefaultOperatorStageTimeout = 60 * time.Minute
 )
 
 // Orchestrator owns lifecycle transitions, BMC actions, and cleanup.
@@ -100,6 +102,10 @@ type runState struct {
 	stageStarted  time.Time
 	solReopens    int
 	maxSOLReopens int
+	// progressCoarse: M5 operator_iso — no SOL stall; stage deadline → provisioned.
+	progressCoarse bool
+	// stopDeadline cancels the coarse stage timer (also called from HandleTerminal).
+	stopDeadline func()
 }
 
 type terminalEvent struct {
@@ -491,18 +497,29 @@ func (o *Orchestrator) startStage(ctx context.Context, job models.ProvisioningJo
 	case <-time.After(settle):
 	}
 
+	// Progress policy: operator_iso uses coarse deadline (no SOL stall).
+	stageStrategy := stage.Strategy
+	if stageStrategy == "" {
+		stageStrategy = strategy
+	}
+	coarse := stage.Kind == models.JobStageKindOSInstall && stageStrategy == models.InstallStrategyOperatorISO
+	rs.progressCoarse = coarse
+	if rs.stopDeadline != nil {
+		rs.stopDeadline()
+		rs.stopDeadline = nil
+	}
+
 	phase := "WAITING_SOL"
 	if stage.Kind == models.JobStageKindPrep {
 		phase = "PREP_BOOT"
+	}
+	if coarse {
+		phase = "WAITING_INSTALL"
 	}
 	_ = o.store.UpdateProgress(ctx, job.ID, phase, nil, 0, "")
 	stages = setStageState(stages, stage.ID, models.JobStageStateRunning, phase, "")
 	_ = o.store.UpdateStages(ctx, job.ID, stage.ID, strategy, stages)
 
-	stall := rs.stallTimeout
-	if stall <= 0 {
-		stall = DefaultSOLStall
-	}
 	// New session id per stage so Unregister of previous stage does not race.
 	sessionID := rs.sessionID
 	if idx > 0 {
@@ -510,24 +527,52 @@ func (o *Orchestrator) startStage(ctx context.Context, job models.ProvisioningJo
 		rs.sessionID = sessionID
 		_ = o.store.UpdateRuntime(ctx, job.ID, sys.ID, sessionID, rs.credential)
 	}
-	session := models.WatchSession{
-		ID:           sessionID,
-		JobID:        job.ID,
-		DeviceID:     req.DeviceID,
-		Transport:    "libvirt",
-		Target:       req.SerialTarget,
-		StartedAt:    time.Now().UTC(),
-		StallTimeout: stall,
-	}
-	if err := o.watches.Register(ctx, session); err != nil {
+
+	serialTarget := strings.TrimSpace(req.SerialTarget)
+	if serialTarget != "" {
+		stall := rs.stallTimeout
+		if stall <= 0 {
+			stall = DefaultSOLStall
+		}
+		session := models.WatchSession{
+			ID:            sessionID,
+			JobID:         job.ID,
+			DeviceID:      req.DeviceID,
+			Transport:     "libvirt",
+			Target:        serialTarget,
+			StartedAt:     time.Now().UTC(),
+			StallTimeout:  stall,
+			StallDisabled: coarse,
+		}
+		if err := o.watches.Register(ctx, session); err != nil {
+			_ = bmc.CleanupMediaAndBoot(ctx, sys.ID)
+			return fmt.Errorf("register watch: %w", err)
+		}
+	} else if !coarse {
 		_ = bmc.CleanupMediaAndBoot(ctx, sys.ID)
-		return fmt.Errorf("register watch: %w", err)
+		return fmt.Errorf("serial_target is required for marker-based stages")
 	}
 	rs.stageStarted = time.Now().UTC()
 	rs.solReopens = 0
 	if rs.maxSOLReopens == 0 {
 		rs.maxSOLReopens = 4
 	}
+
+	if coarse {
+		deadline := req.StageTimeout
+		if deadline <= 0 {
+			if env := strings.TrimSpace(os.Getenv("SHOAL_OPERATOR_ISO_TIMEOUT")); env != "" {
+				if d, err := time.ParseDuration(env); err == nil && d > 0 {
+					deadline = d
+				}
+			}
+		}
+		if deadline <= 0 {
+			deadline = DefaultOperatorStageTimeout
+		}
+		o.armCoarseDeadline(job.ID, rs, deadline)
+	}
+
 	o.log.Info("stage media attached",
 		"job_id", job.ID,
 		"device_id", job.DeviceID,
@@ -535,9 +580,48 @@ func (o *Orchestrator) startStage(ctx context.Context, job models.ProvisioningJo
 		"iso_url", mediaURL,
 		"stage", stage.ID,
 		"kind", stage.Kind,
+		"coarse", coarse,
 	)
 	return nil
 }
+
+// armCoarseDeadline schedules optimistic provisioned when operator_iso stage timeout elapses.
+func (o *Orchestrator) armCoarseDeadline(jobID string, rs *runState, deadline time.Duration) {
+	timer := time.NewTimer(deadline)
+	done := make(chan struct{})
+	rs.stopDeadline = func() {
+		if !timer.Stop() {
+			select {
+			case <-timer.C:
+			default:
+			}
+		}
+		select {
+		case <-done:
+		default:
+			close(done)
+		}
+	}
+	o.log.Info("operator_iso coarse deadline armed",
+		"job_id", jobID,
+		"deadline", deadline.String(),
+	)
+	go func() {
+		select {
+		case <-done:
+			return
+		case <-timer.C:
+		case <-o.stopCh:
+			return
+		}
+		// Mark phase then terminal success (not install verification).
+		_ = o.store.UpdateProgress(context.Background(), jobID, "COARSE_DONE", intPtr(100), 0,
+			"operator_iso: stage deadline elapsed (no SOL verify)")
+		o.enqueueTerminal(jobID, ReasonDoneOK)
+	}()
+}
+
+func intPtr(n int) *int { return &n }
 
 // reopenSOL re-registers the SOL watch after an early stream drop (stage handoff).
 func (o *Orchestrator) reopenSOL(jobID string) {
@@ -743,8 +827,14 @@ func (o *Orchestrator) HandleTerminal(ctx context.Context, jobID string, reason 
 func (o *Orchestrator) handleTerminalOnce(ctx context.Context, jobID string, reason TerminalReason, rs *runState) error {
 	o.log.Info("HandleTerminal", "job_id", jobID, "reason", string(reason))
 
-	if rs != nil && rs.cancel != nil {
-		rs.cancel()
+	if rs != nil {
+		if rs.stopDeadline != nil {
+			rs.stopDeadline()
+			rs.stopDeadline = nil
+		}
+		if rs.cancel != nil {
+			rs.cancel()
+		}
 	}
 
 	// Unregister watch first so SOL stops feeding markers.
@@ -1287,6 +1377,13 @@ func (p *progressAdapter) ReportTransportError(ctx context.Context, jobID string
 	p.orch.mu.Lock()
 	rs := p.orch.running[jobID]
 	p.orch.mu.Unlock()
+	// M5 operator_iso: SOL is best-effort; stream close must not fail the job.
+	if rs != nil && rs.progressCoarse {
+		p.orch.log.Info("sol stream closed during coarse progress; ignoring",
+			"job_id", jobID,
+		)
+		return nil
+	}
 	if rs != nil && !rs.terminalQueued && rs.solReopens < rs.maxSOLReopens {
 		// Allow reopens for a couple of minutes after stage start.
 		if rs.stageStarted.IsZero() || time.Since(rs.stageStarted) < 2*time.Minute {

--- a/internal/deploy/job/orchestrator_test.go
+++ b/internal/deploy/job/orchestrator_test.go
@@ -379,6 +379,92 @@ func TestOrchestratorOrphanReconcile(t *testing.T) {
 	}
 }
 
+func TestOrchestratorOperatorISOCoarseDeadline(t *testing.T) {
+	ctx := context.Background()
+	store := jobstore.NewMemory()
+	fakeBMC := redfish.NewFake()
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	watch := sol.NewWatchService(log, nil)
+	// No SOL markers; coarse path must not stall-fail.
+	watch.NewTransport = func(session models.WatchSession) sol.Transport {
+		return sol.NewReaderTransport(io.NopCloser(strings.NewReader("")))
+	}
+	orch := job.NewOrchestrator(job.Options{
+		Log: log, Store: store, Secrets: secrets.NewMemory(),
+		NewBMC:  func(cfg redfish.Config) (redfish.BMC, error) { return fakeBMC, nil },
+		Watches: watch, AuthMode: "basic", TLSMode: "off",
+	})
+	defer orch.Stop()
+	watch.SetProgress(orch.ProgressPort())
+
+	j, err := orch.Start(ctx, models.StartJobRequest{
+		DeviceID:        "esxi-1",
+		BMCEndpoint:     "http://bmc.test",
+		BMCUsername:     "admin",
+		BMCPassword:     "secret",
+		ISOURL:          "http://iso/esxi-custom.iso",
+		InstallStrategy: models.InstallStrategyOperatorISO,
+		OsFamily:        models.OSFamilyESXi,
+		StageTimeout:    80 * time.Millisecond,
+		// no serial_target — pure coarse wait
+	})
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	if !fakeBMC.MediaInserted() {
+		t.Fatal("expected media inserted")
+	}
+	if j.InstallStrategy != models.InstallStrategyOperatorISO {
+		t.Fatalf("strategy=%s", j.InstallStrategy)
+	}
+
+	deadline := time.Now().Add(3 * time.Second)
+	var final models.ProvisioningJob
+	for time.Now().Before(deadline) {
+		final, _ = store.Get(ctx, j.ID)
+		if final.State == models.StateProvisioned {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if final.State != models.StateProvisioned {
+		t.Fatalf("want provisioned, got %s err=%s phase=%s", final.State, final.Error, final.Phase)
+	}
+	if fakeBMC.MediaInserted() || !fakeBMC.BootCleared() {
+		t.Fatal("cleanup incomplete after coarse DONE")
+	}
+}
+
+func TestOrchestratorOperatorISORejectsSeed(t *testing.T) {
+	ctx := context.Background()
+	store := jobstore.NewMemory()
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	watch := sol.NewWatchService(log, nil)
+	orch := job.NewOrchestrator(job.Options{
+		Log: log, Store: store, Secrets: secrets.NewMemory(),
+		NewBMC:  func(cfg redfish.Config) (redfish.BMC, error) { return redfish.NewFake(), nil },
+		Watches: watch, AuthMode: "basic", TLSMode: "off",
+	})
+	defer orch.Stop()
+	watch.SetProgress(orch.ProgressPort())
+
+	_, err := orch.Start(ctx, models.StartJobRequest{
+		DeviceID:        "esxi-1",
+		BMCEndpoint:     "http://bmc.test",
+		BMCUsername:     "admin",
+		BMCPassword:     "secret",
+		ISOURL:          "http://iso/esxi.iso",
+		InstallStrategy: models.InstallStrategyOperatorISO,
+		OsFamily:        models.OSFamilyESXi,
+		SeedDelivery:    models.SeedDeliverySecondMedia,
+		SeedISOURL:      "http://iso/seed.iso",
+		StageTimeout:    time.Second,
+	})
+	if err == nil {
+		t.Fatal("expected seed with operator_iso to fail validate")
+	}
+}
+
 func TestOrchestratorSecondMediaDualInsert(t *testing.T) {
 	ctx := context.Background()
 	store := jobstore.NewMemory()

--- a/internal/deploy/job/stages.go
+++ b/internal/deploy/job/stages.go
@@ -12,14 +12,14 @@ import (
 // expandStages derives the stage list for a StartJobRequest (multi-stage design).
 // M1: single os_install. M2: optional prep wipe + os_install.
 // M3: offline seed fields on os_install (second_media / config_drive / auto).
+// M5: operator_iso (ESXi/Windows) with coarse progress — no seed.
 func expandStages(req models.StartJobRequest) ([]models.JobStage, error) {
 	strategy, err := resolveInstallStrategy(req)
 	if err != nil {
 		return nil, err
 	}
-	switch strategy {
-	case models.InstallStrategyScriptedISO, models.InstallStrategyOperatorISO:
-		return nil, fmt.Errorf("job: install_strategy %q not implemented (use image_write or simulate)", strategy)
+	if strategy == models.InstallStrategyScriptedISO {
+		return nil, fmt.Errorf("job: install_strategy scripted_iso not implemented yet (use image_write, operator_iso, or simulate)")
 	}
 
 	seedDelivery, seedURL, err := normalizeSeedRequest(req, strategy)
@@ -71,6 +71,10 @@ func expandStages(req models.StartJobRequest) ([]models.JobStage, error) {
 // normalizeSeedRequest applies defaults for seed fields before stage expansion.
 // Final mode for "auto" is chosen at startStage once Virtual Media is listed.
 func normalizeSeedRequest(req models.StartJobRequest, strategy string) (delivery, seedURL string, err error) {
+	if strategy == models.InstallStrategyOperatorISO {
+		// Operator media already contains unattended config.
+		return models.SeedDeliveryNone, "", nil
+	}
 	delivery = strings.TrimSpace(strings.ToLower(req.SeedDelivery))
 	seedURL = strings.TrimSpace(req.SeedISOURL)
 	if seedURL == "" {

--- a/internal/deploy/job/stages_test.go
+++ b/internal/deploy/job/stages_test.go
@@ -88,6 +88,48 @@ func TestExpandStagesRejectsScriptedISO(t *testing.T) {
 	}
 }
 
+func TestExpandStagesOperatorISO(t *testing.T) {
+	stages, err := expandStages(models.StartJobRequest{
+		ISOURL:          "http://example/esxi.iso",
+		InstallStrategy: models.InstallStrategyOperatorISO,
+		OsFamily:        models.OSFamilyESXi,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(stages) != 1 {
+		t.Fatalf("len=%d", len(stages))
+	}
+	if stages[0].Strategy != models.InstallStrategyOperatorISO {
+		t.Fatalf("strategy=%s", stages[0].Strategy)
+	}
+	if stages[0].Family != models.OSFamilyESXi {
+		t.Fatalf("family=%s", stages[0].Family)
+	}
+	if stages[0].SeedDelivery != models.SeedDeliveryNone {
+		t.Fatalf("seed=%s", stages[0].SeedDelivery)
+	}
+}
+
+func TestExpandStagesOperatorISOWithPrep(t *testing.T) {
+	stages, err := expandStages(models.StartJobRequest{
+		ISOURL:          "http://example/esxi.iso",
+		PrepISOURL:      "http://example/prep.iso",
+		Prep:            "wipe_only",
+		InstallStrategy: models.InstallStrategyOperatorISO,
+		OsFamily:        models.OSFamilyWindows,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(stages) != 2 {
+		t.Fatalf("len=%d", len(stages))
+	}
+	if stages[1].Strategy != models.InstallStrategyOperatorISO {
+		t.Fatalf("os strategy=%s", stages[1].Strategy)
+	}
+}
+
 func TestExpandStagesSeedSecondMedia(t *testing.T) {
 	stages, err := expandStages(models.StartJobRequest{
 		ISOURL:          "http://example/os.iso",

--- a/internal/observe/sol/watch.go
+++ b/internal/observe/sol/watch.go
@@ -70,7 +70,7 @@ func (w *WatchService) Register(ctx context.Context, session models.WatchSession
 	if session.Target == "" {
 		return fmt.Errorf("sol: watch session missing target")
 	}
-	if session.StallTimeout <= 0 {
+	if !session.StallDisabled && session.StallTimeout <= 0 {
 		session.StallTimeout = DefaultStallTimeout
 	}
 
@@ -165,11 +165,20 @@ func (w *WatchService) Unregister(_ context.Context, sessionID string) error {
 
 func (w *WatchService) run(ctx context.Context, aw *activeWatch, lines <-chan string, progress jobport.JobProgress) {
 	defer close(aw.done)
+	stallDisabled := aw.session.StallDisabled
 	stall := aw.session.StallTimeout
-	timer := time.NewTimer(stall)
-	defer timer.Stop()
+	var timer *time.Timer
+	var timerC <-chan time.Time
+	if !stallDisabled {
+		timer = time.NewTimer(stall)
+		timerC = timer.C
+		defer timer.Stop()
+	}
 
 	resetStall := func() {
+		if stallDisabled || timer == nil {
+			return
+		}
 		if !timer.Stop() {
 			select {
 			case <-timer.C:
@@ -183,7 +192,7 @@ func (w *WatchService) run(ctx context.Context, aw *activeWatch, lines <-chan st
 		select {
 		case <-ctx.Done():
 			return
-		case <-timer.C:
+		case <-timerC:
 			w.log.Warn("sol stall detected", "job_id", aw.session.JobID, "timeout", stall.String())
 			_ = progress.ReportStall(context.Background(), aw.session.JobID, fmt.Sprintf("no SOL marker for %s", stall))
 			return

--- a/internal/observe/sol/watch_test.go
+++ b/internal/observe/sol/watch_test.go
@@ -67,6 +67,33 @@ func TestWatchServiceMarkers(t *testing.T) {
 	_ = pw.Close()
 }
 
+func TestWatchServiceStallDisabled(t *testing.T) {
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	prog := &recordingProgress{}
+	w := sol.NewWatchService(log, prog)
+	pr, pw := io.Pipe()
+	w.NewTransport = func(models.WatchSession) sol.Transport {
+		return sol.NewReaderTransport(pr)
+	}
+	err := w.Register(context.Background(), models.WatchSession{
+		ID: "s1", JobID: "j1", DeviceID: "d1", Target: "x",
+		StallTimeout:  30 * time.Millisecond,
+		StallDisabled: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(80 * time.Millisecond)
+	prog.mu.Lock()
+	stalls := prog.stalls
+	prog.mu.Unlock()
+	if stalls != 0 {
+		t.Fatalf("stalls=%d want 0 when StallDisabled", stalls)
+	}
+	_ = w.Unregister(context.Background(), "s1")
+	_ = pw.Close()
+}
+
 func TestWatchServiceStopsOnTerminalMarker(t *testing.T) {
 	log := slog.New(slog.NewTextHandler(io.Discard, nil))
 	prog := &recordingProgress{}


### PR DESCRIPTION
## Summary

Implements multi-stage design slice **M5**: **`operator_iso`** for ESXi/Windows.

- Operator supplies a ready install ISO (kickstart/Autounattend already on media)
- Shoal attaches CD, one-time boot, waits, cleans up Virtual Media + boot override
- **Coarse progress:** no `SHOAL|…` markers required; **stage deadline** (default 60m / `-stage-timeout` / `SHOAL_OPERATOR_ISO_TIMEOUT`) → `provisioned`
- SOL stall **disabled** for this path; transport close ignored; serial optional
- **No seed** (`seed_delivery` must be none); `os_family` required (`esxi` | `windows`)
- `scripted_iso` still rejected (M4)
- prep wipe + operator_iso still expands `[prep, os_install]`

**Not install verification** — deadline success is optimistic; confirm host out of band.

## Test plan

- [x] `go test ./...` / `go vet` / `staticcheck` on touched packages
- [x] Unit: coarse short deadline → provisioned + cleanup; seed rejected; expand stages
- [x] SOL `StallDisabled` does not ReportStall
- [ ] Nested lab: optional smoke with any ISO + short `-stage-timeout` (does not prove ESXi/Windows)
- [ ] Real BMC preferred for hardware AC

## Design

Advances `docs/multi-stage-provisioning-design.md` §11 M5.