### PR TITLE
feat(deploy): multi-stage M6 profile-driven job defaults

### DIFF
--- a/docs/lab-runbook.md
+++ b/docs/lab-runbook.md
@@ -552,6 +552,39 @@ seed device — Shoal does not remaster the installer in M4.
 
 Ubuntu `scripted_iso` + NoCloud seed uses the same attach path (`build-nocloud-seed-iso.sh`).
 
+### Multi-stage M6: profile-driven deploy (happy path)
+
+Profiles under `SHOAL_PROFILE_DIR` can supply `install_strategy`, `os_family`, `prep`,
+`seed_*`, and media (`iso_base` / `media_url`) so each run only needs device + BMC +
+serial (and `-approve-destruct` when the profile wipes).
+
+Example profiles: `testdata/profiles/*.json`.
+
+```bash
+export SHOAL_PROFILE_DIR=/var/lib/shoal/profiles   # lab Ansible default
+export SHOAL_ISO_BASE_URL=http://192.168.124.1:8080
+
+# Save once
+go run ./cmd/shoal profile save -file testdata/profiles/lab-ubuntu-image-write.json
+
+# Profile-only start (no -iso-url / -install-strategy)
+go run ./cmd/shoal deploy run \
+  -device-id shoal-node-1 \
+  -profile-ref lab-ubuntu-image-write \
+  -bmc-url http://192.168.122.100:8001 \
+  -bmc-user admin -bmc-pass password \
+  -serial-target shoal-node-1 \
+  -serial-ssh-host 192.168.122.100 \
+  -serial-ssh-user lab \
+  -serial-ssh-key "$HOME/.ssh/shoal_lab_vm" \
+  -wait
+```
+
+**Merge rule:** non-empty request flags override the profile. Wipe profiles need
+`-approve-destruct` (or prior `profile approve`).
+
+`GET /v1/jobs/{id}` (and `deploy status`) already return `current_stage` and `stages`.
+
 ### Phase 6b: graphics failure-screen OCR
 
 SOL remains the primary progress channel. Graphics OCR is **diagnostic only**.

--- a/docs/multi-stage-provisioning-design.md
+++ b/docs/multi-stage-provisioning-design.md
@@ -818,7 +818,7 @@ Version media URLs when content changes (sushy cache lesson from 7a).
 | **M3** | Offline seed preference #1 then #2: **second_media**, else **config_drive**, for Ubuntu NoCloud | **Implemented** (seed ISO builder + dual-media attach + `auto` resolve; `config_drive` rejected with `image_write`; config_drive write deferred) |
 | **M4** | Flatcar offline Ignition (same preference order) | **Implemented** (`scripted_iso` + Ignition seed ISO + second_media; coarse progress; config_drive deferred) |
 | **M5** | **`operator_iso`** path shared by ESXi + Windows shape (attach + boot + cleanup + coarse progress) | **Implemented** (coarse stage deadline → provisioned; SOL stall disabled; seed forbidden; esxi\|windows) |
-| **M6** | Profiles + `seed_delivery: auto` + Operator API §6 fields on `POST/GET /v1/jobs` | Happy path without ad-hoc flags; §6.9 ACs |
+| **M6** | Profiles + `seed_delivery: auto` + Operator API §6 fields on `POST/GET /v1/jobs` | **Implemented** (profile defaults merge into Start; profile-only Ubuntu path; GET stages already present) |
 | **Later** | Separate designs: ESXi/Windows ISO compose; optional Windows dual-media unattend; single_iso remaster polish | Out of this doc’s v1 slices |
 
 ---

--- a/internal/api/jobs.go
+++ b/internal/api/jobs.go
@@ -5,9 +5,9 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"strings"
 
 	"github.com/mattcburns/shoal/internal/common/models"
-	"github.com/mattcburns/shoal/internal/common/validate"
 	"github.com/mattcburns/shoal/internal/deploy/jobstore"
 )
 
@@ -56,8 +56,10 @@ func (s *Server) handleStartJob(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid json"})
 		return
 	}
-	if err := validate.StartJobRequest(req); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]any{"error": err.Error()})
+	// Full StartJobRequest validation runs inside Orchestrator.Start after M6
+	// profile defaults are applied (so profile-only jobs can omit iso_url/strategy).
+	if strings.TrimSpace(req.DeviceID) == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "validate: device_id is required"})
 		return
 	}
 	j, err := s.start.Start(r.Context(), req)
@@ -66,6 +68,12 @@ func (s *Server) handleStartJob(w http.ResponseWriter, r *http.Request) {
 		// May still have a job row after partial start.
 		if j.ID != "" {
 			writeJSON(w, http.StatusConflict, map[string]any{"error": err.Error(), "job": j})
+			return
+		}
+		// Validation / approval errors are client faults.
+		msg := err.Error()
+		if strings.Contains(msg, "validate:") || strings.Contains(msg, "requires approval") || strings.Contains(msg, "load profile") {
+			writeJSON(w, http.StatusBadRequest, map[string]any{"error": msg})
 			return
 		}
 		writeJSON(w, http.StatusInternalServerError, map[string]any{"error": err.Error()})

--- a/internal/api/jobs_test.go
+++ b/internal/api/jobs_test.go
@@ -20,7 +20,12 @@ func TestGetJob(t *testing.T) {
 	now := time.Now().UTC()
 	_ = store.Insert(context.Background(), models.ProvisioningJob{
 		ID: "j1", DeviceID: "d1", State: models.StateProvisioning,
-		UpdatedAt: &now,
+		UpdatedAt: &now, CurrentStage: models.JobStageKindOSInstall,
+		InstallStrategy: models.InstallStrategyImageWrite,
+		Stages: []models.JobStage{{
+			ID: models.JobStageKindOSInstall, Kind: models.JobStageKindOSInstall,
+			Strategy: models.InstallStrategyImageWrite, State: models.JobStageStateRunning,
+		}},
 	})
 	s := api.New(config.Config{}, nil).WithJobStore(store)
 	rr := httptest.NewRecorder()
@@ -35,6 +40,13 @@ func TestGetJob(t *testing.T) {
 	}
 	if j.ID != "j1" {
 		t.Fatalf("id %s", j.ID)
+	}
+	// M6 AC: GET exposes current_stage + stages
+	if j.CurrentStage != models.JobStageKindOSInstall {
+		t.Fatalf("current_stage=%s", j.CurrentStage)
+	}
+	if len(j.Stages) != 1 {
+		t.Fatalf("stages=%d", len(j.Stages))
 	}
 }
 

--- a/internal/common/models/models.go
+++ b/internal/common/models/models.go
@@ -193,14 +193,31 @@ type ProfileRequirements struct {
 }
 
 // ProvisioningProfile is a schema-validated AI or operator profile.
+// Multi-stage M6 fields fill StartJobRequest defaults when the request omits them
+// (request wins when non-empty).
 type ProvisioningProfile struct {
 	Ref              string   `json:"ref"`
-	ISOBase          string   `json:"iso_base"`
+	ISOBase          string   `json:"iso_base,omitempty"` // basename or URL; required unless MediaURL set
 	EmbeddedPayload  string   `json:"embedded_payload,omitempty"`
 	PostInstallSteps []string `json:"post_install_steps,omitempty"`
 	// DestructSteps require AllowDestruct + explicit operator approval before Deploy runs them.
 	DestructSteps []string `json:"destruct_steps,omitempty"`
 	NeedsApproval bool     `json:"needs_approval"`
+
+	// Multi-stage defaults (M6).
+	OSFamily        string `json:"os_family,omitempty"`        // ubuntu | flatcar | esxi | windows
+	InstallStrategy string `json:"install_strategy,omitempty"` // simulate | image_write | scripted_iso | operator_iso
+	SeedDelivery    string `json:"seed_delivery,omitempty"`    // none | auto | second_media | config_drive
+	SeedISOBase     string `json:"seed_iso_base,omitempty"`    // resolve via SHOAL_ISO_BASE_URL
+	SeedISOURL      string `json:"seed_iso_url,omitempty"`     // full BMC-reachable seed URL
+	Prep            string `json:"prep,omitempty"`             // skip | wipe_only
+	WipeLevel       string `json:"wipe_level,omitempty"`       // discard | zero
+	PrepISOBase     string `json:"prep_iso_base,omitempty"`
+	PrepISOURL      string `json:"prep_iso_url,omitempty"`
+	MediaURL        string `json:"media_url,omitempty"`    // full install ISO URL (preferred over iso_base resolve)
+	ISOHostname     string `json:"iso_hostname,omitempty"` // optional hostname for builds
+	// StageTimeout is a Go duration string for coarse paths (e.g. "60m").
+	StageTimeout string `json:"stage_timeout,omitempty"`
 }
 
 // DeviceStatus is the Observe aggregate view.

--- a/internal/common/redfish/client.go
+++ b/internal/common/redfish/client.go
@@ -287,6 +287,9 @@ func (c *client) ClearBootOverride(ctx context.Context, systemID string) error {
 }
 
 // ListVirtualMedia lists virtual media for a system, falling back to managers.
+// When systemID is set, only that system's media is returned (or its matching
+// manager). Merging every manager's slots would attach media to the wrong node
+// in multi-BMC labs (sushy-tools exposes one Cd per system/manager).
 func (c *client) ListVirtualMedia(_ context.Context, systemID string) ([]VirtualMedia, error) {
 	api, err := c.apiClient()
 	if err != nil {
@@ -303,19 +306,27 @@ func (c *client) ListVirtualMedia(_ context.Context, systemID string) ([]Virtual
 				out = append(out, mapVM(vm))
 			}
 		}
+		// If the system exposes media, do not merge other systems' managers.
+		if len(out) > 0 {
+			return out, nil
+		}
 	}
 
-	// Also check managers (sushy-tools often exposes VM here).
+	// Fallback: managers. When systemID is known, only the manager with the
+	// same id/uuid (sushy-tools 1:1 mapping) is used.
 	managers, err := api.Service.Managers()
 	if err == nil {
 		for _, m := range managers {
+			if systemID != "" && m.ID != systemID && m.UUID != systemID {
+				// Still allow empty systemID (list all) for diagnostics.
+				continue
+			}
 			vms, vmErr := m.VirtualMedia()
 			if vmErr != nil {
 				continue
 			}
 			for _, vm := range vms {
 				mapped := mapVM(vm)
-				// de-dupe by URI
 				dup := false
 				for _, existing := range out {
 					if existing.URI == mapped.URI {
@@ -325,6 +336,22 @@ func (c *client) ListVirtualMedia(_ context.Context, systemID string) ([]Virtual
 				}
 				if !dup {
 					out = append(out, mapped)
+				}
+			}
+		}
+	}
+
+	// Last resort: if systemID was empty or no manager matched, scan all managers.
+	if len(out) == 0 && systemID == "" {
+		managers, err = api.Service.Managers()
+		if err == nil {
+			for _, m := range managers {
+				vms, vmErr := m.VirtualMedia()
+				if vmErr != nil {
+					continue
+				}
+				for _, vm := range vms {
+					out = append(out, mapVM(vm))
 				}
 			}
 		}

--- a/internal/common/validate/validate.go
+++ b/internal/common/validate/validate.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/mattcburns/shoal/internal/common/models"
 	"github.com/mattcburns/shoal/internal/common/redact"
@@ -78,8 +79,8 @@ func ProvisioningProfile(p models.ProvisioningProfile) error {
 	if strings.TrimSpace(p.Ref) == "" {
 		return fmt.Errorf("validate: profile ref is required")
 	}
-	if strings.TrimSpace(p.ISOBase) == "" {
-		return fmt.Errorf("validate: profile iso_base is required")
+	if strings.TrimSpace(p.ISOBase) == "" && strings.TrimSpace(p.MediaURL) == "" {
+		return fmt.Errorf("validate: profile iso_base or media_url is required")
 	}
 	for _, step := range append(append([]string{}, p.PostInstallSteps...), p.DestructSteps...) {
 		if looksSecretStep(step) {
@@ -89,7 +90,66 @@ func ProvisioningProfile(p models.ProvisioningProfile) error {
 	if len(p.DestructSteps) > 0 && !p.NeedsApproval {
 		return fmt.Errorf("validate: destruct_steps require needs_approval=true")
 	}
+	prep := strings.TrimSpace(strings.ToLower(p.Prep))
+	if prep == "wipe_only" && !p.NeedsApproval && len(p.DestructSteps) == 0 {
+		// Wipe is destructive; require needs_approval when prep wipe is in the profile.
+		return fmt.Errorf("validate: profile prep wipe_only requires needs_approval=true")
+	}
+	if s := strings.TrimSpace(p.InstallStrategy); s != "" {
+		switch s {
+		case models.InstallStrategySimulate, models.InstallStrategyImageWrite,
+			models.InstallStrategyScriptedISO, models.InstallStrategyOperatorISO:
+		default:
+			return fmt.Errorf("validate: profile unknown install_strategy %q", s)
+		}
+	}
+	if fam := strings.TrimSpace(strings.ToLower(p.OSFamily)); fam != "" {
+		switch fam {
+		case models.OSFamilyUbuntu, models.OSFamilyFlatcar, models.OSFamilyESXi, models.OSFamilyWindows:
+		default:
+			return fmt.Errorf("validate: profile unknown os_family %q", p.OSFamily)
+		}
+	}
+	if seed := strings.TrimSpace(strings.ToLower(p.SeedDelivery)); seed != "" {
+		switch seed {
+		case models.SeedDeliveryNone, models.SeedDeliveryAuto,
+			models.SeedDeliverySecondMedia, models.SeedDeliveryConfigDrive:
+		case models.SeedDeliverySingleISO:
+			return fmt.Errorf("validate: profile seed_delivery single_iso not implemented")
+		default:
+			return fmt.Errorf("validate: profile unknown seed_delivery %q", p.SeedDelivery)
+		}
+	}
+	if w := strings.TrimSpace(strings.ToLower(p.WipeLevel)); w != "" && w != "discard" && w != "zero" {
+		return fmt.Errorf("validate: profile wipe_level must be discard or zero")
+	}
+	// Guest HTTP answer-file patterns are forbidden (offline seed constraint).
+	for _, field := range []string{p.ISOBase, p.MediaURL, p.SeedISOBase, p.SeedISOURL, p.PrepISOBase, p.PrepISOURL, p.EmbeddedPayload} {
+		if hasGuestHTTPSeedPattern(field) {
+			return fmt.Errorf("validate: profile must not contain guest HTTP seed URLs (ks=http, nocloud-net, ignition.config.url=http)")
+		}
+	}
+	if to := strings.TrimSpace(p.StageTimeout); to != "" {
+		if _, err := time.ParseDuration(to); err != nil {
+			return fmt.Errorf("validate: profile stage_timeout: %w", err)
+		}
+	}
 	return nil
+}
+
+func hasGuestHTTPSeedPattern(s string) bool {
+	lower := strings.ToLower(s)
+	needles := []string{
+		"ks=http://", "ks=https://",
+		"ignition.config.url=http://", "ignition.config.url=https://",
+		"nocloud-net", "ds=nocloud-net",
+	}
+	for _, n := range needles {
+		if strings.Contains(lower, n) {
+			return true
+		}
+	}
+	return false
 }
 
 func looksSecretStep(s string) bool {

--- a/internal/common/validate/validate_test.go
+++ b/internal/common/validate/validate_test.go
@@ -35,6 +35,47 @@ func TestNormalizationResultConfidence(t *testing.T) {
 	}
 }
 
+func TestProvisioningProfileM6(t *testing.T) {
+	good := models.ProvisioningProfile{
+		Ref: "lab-1", ISOBase: "shoal-marker", InstallStrategy: models.InstallStrategyImageWrite,
+		OSFamily: models.OSFamilyUbuntu, SeedDelivery: models.SeedDeliveryNone,
+	}
+	if err := validate.ProvisioningProfile(good); err != nil {
+		t.Fatal(err)
+	}
+	// media_url without iso_base
+	mediaOnly := models.ProvisioningProfile{
+		Ref: "esxi", MediaURL: "http://lab:8080/esxi.iso",
+		InstallStrategy: models.InstallStrategyOperatorISO, OSFamily: models.OSFamilyESXi,
+	}
+	if err := validate.ProvisioningProfile(mediaOnly); err != nil {
+		t.Fatal(err)
+	}
+	// wipe requires needs_approval
+	wipe := good
+	wipe.Prep = "wipe_only"
+	if err := validate.ProvisioningProfile(wipe); err == nil {
+		t.Fatal("expected wipe without needs_approval to fail")
+	}
+	wipe.NeedsApproval = true
+	if err := validate.ProvisioningProfile(wipe); err != nil {
+		t.Fatal(err)
+	}
+	// guest HTTP seed pattern
+	bad := good
+	bad.SeedISOURL = "http://x?ignition.config.url=http://evil"
+	// pattern is in string
+	bad.EmbeddedPayload = "ignition.config.url=http://evil/"
+	if err := validate.ProvisioningProfile(bad); err == nil {
+		t.Fatal("expected guest HTTP pattern reject")
+	}
+	// neither media
+	empty := models.ProvisioningProfile{Ref: "x"}
+	if err := validate.ProvisioningProfile(empty); err == nil {
+		t.Fatal("expected iso_base or media_url required")
+	}
+}
+
 func TestNormalizedEventRequiresDeviceID(t *testing.T) {
 	if err := validate.NormalizedEvent(models.NormalizedEvent{Message: "x"}); err == nil {
 		t.Fatal("expected error")

--- a/internal/deploy/job/iso_resolve_test.go
+++ b/internal/deploy/job/iso_resolve_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"log/slog"
+	"strings"
 	"testing"
 
 	"github.com/mattcburns/shoal/internal/common/models"
@@ -50,6 +51,113 @@ func TestStartResolvesISOURLFromProfile(t *testing.T) {
 	}
 	if j.ISOURL != "http://192.168.124.1:8080/shoal-marker.iso" {
 		t.Fatalf("iso_url %q", j.ISOURL)
+	}
+}
+
+func TestStartProfileOnlyImageWrite(t *testing.T) {
+	// M6: strategy/family from profile; no iso_url or install_strategy on request.
+	ctx := context.Background()
+	ps := profile.NewMemory()
+	_, err := ps.Save(ctx, models.ProvisioningProfile{
+		Ref:             "lab-ubuntu-image-write",
+		ISOBase:         "shoal-ubuntu-m1-test",
+		InstallStrategy: models.InstallStrategyImageWrite,
+		OSFamily:        models.OSFamilyUbuntu,
+		SeedDelivery:    models.SeedDeliveryNone,
+		Prep:            "skip",
+		NeedsApproval:   false,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	pr, pw := io.Pipe()
+	watch := sol.NewWatchService(log, nil)
+	watch.NewTransport = func(session models.WatchSession) sol.Transport {
+		return sol.NewReaderTransport(pr)
+	}
+	store := jobstore.NewMemory()
+	orch := job.NewOrchestrator(job.Options{
+		Log: log, Store: store, Secrets: secrets.NewMemory(),
+		Profiles: ps, ISOBaseURL: "http://192.168.124.1:8080",
+		NewBMC:  func(cfg redfish.Config) (redfish.BMC, error) { return redfish.NewFake(), nil },
+		Watches: watch, AuthMode: "basic", TLSMode: "off",
+	})
+	defer orch.Stop()
+	watch.SetProgress(orch.ProgressPort())
+
+	j, err := orch.Start(ctx, models.StartJobRequest{
+		DeviceID:     "lab-node-1",
+		ProfileRef:   "lab-ubuntu-image-write",
+		BMCEndpoint:  "http://bmc",
+		BMCUsername:  "a",
+		BMCPassword:  "b",
+		SerialTarget: "lab-node-1",
+		// no ISOURL, InstallStrategy, OsFamily, Prep
+	})
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	if j.InstallStrategy != models.InstallStrategyImageWrite {
+		t.Fatalf("strategy=%s", j.InstallStrategy)
+	}
+	if j.ISOURL != "http://192.168.124.1:8080/shoal-ubuntu-m1-test.iso" {
+		t.Fatalf("iso=%s", j.ISOURL)
+	}
+	if len(j.Stages) != 1 || j.Stages[0].Kind != models.JobStageKindOSInstall {
+		t.Fatalf("stages=%+v", j.Stages)
+	}
+	// finish so test does not leak
+	_, _ = io.WriteString(pw, "SHOAL|1|1|2026-06-19T04:10:00Z|DONE|100|OK|done\n")
+	_ = pw.Close()
+}
+
+func TestStartProfileOperatorISO(t *testing.T) {
+	ctx := context.Background()
+	ps := profile.NewMemory()
+	_, err := ps.Save(ctx, models.ProvisioningProfile{
+		Ref:             "esxi-fleet",
+		MediaURL:        "http://lab:8080/esxi-custom.iso",
+		InstallStrategy: models.InstallStrategyOperatorISO,
+		OSFamily:        models.OSFamilyESXi,
+		SeedDelivery:    models.SeedDeliveryNone,
+		StageTimeout:    "100ms",
+		NeedsApproval:   false,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	watch := sol.NewWatchService(log, nil)
+	watch.NewTransport = func(session models.WatchSession) sol.Transport {
+		return sol.NewReaderTransport(io.NopCloser(strings.NewReader("")))
+	}
+	store := jobstore.NewMemory()
+	orch := job.NewOrchestrator(job.Options{
+		Log: log, Store: store, Secrets: secrets.NewMemory(),
+		Profiles: ps, ISOBaseURL: "http://lab:8080",
+		NewBMC:  func(cfg redfish.Config) (redfish.BMC, error) { return redfish.NewFake(), nil },
+		Watches: watch, AuthMode: "basic", TLSMode: "off",
+	})
+	defer orch.Stop()
+	watch.SetProgress(orch.ProgressPort())
+
+	j, err := orch.Start(ctx, models.StartJobRequest{
+		DeviceID:    "esxi-1",
+		ProfileRef:  "esxi-fleet",
+		BMCEndpoint: "http://bmc",
+		BMCUsername: "a",
+		BMCPassword: "b",
+		// no serial, no iso_url — coarse operator_iso from profile
+	})
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	if j.InstallStrategy != models.InstallStrategyOperatorISO {
+		t.Fatalf("strategy=%s", j.InstallStrategy)
+	}
+	if j.ISOURL != "http://lab:8080/esxi-custom.iso" {
+		t.Fatalf("iso=%s", j.ISOURL)
 	}
 }
 

--- a/internal/deploy/job/orchestrator.go
+++ b/internal/deploy/job/orchestrator.go
@@ -219,13 +219,10 @@ func (o *Orchestrator) Get(ctx context.Context, jobID string) (models.Provisioni
 // When NetBox is configured, best-effort lifecycle_state=provisioning is written
 // (failure is logged and does not block BMC actions).
 // Profiles with NeedsApproval/DestructSteps require store approval or ApproveDestruct.
-// When ISOURL is empty and a non-spike profile is loaded, iso_base is resolved via
-// SHOAL_ISO_BASE_URL (Phase 5c). Optional BuildISO / SHOAL_ISO_DYNAMIC builds and
-// publishes a live image first (Phase 6a).
+// M6: non-spike profiles fill empty strategy/prep/seed/family/media fields before validate.
+// When ISOURL is empty, media_url / iso_base resolve via SHOAL_ISO_BASE_URL (Phase 5c).
+// Optional BuildISO / SHOAL_ISO_DYNAMIC builds and publishes a live image first (Phase 6a).
 func (o *Orchestrator) Start(ctx context.Context, req models.StartJobRequest) (models.ProvisioningJob, error) {
-	if err := validate.StartJobRequest(req); err != nil {
-		return models.ProvisioningJob{}, err
-	}
 	if o.watches == nil {
 		return models.ProvisioningJob{}, fmt.Errorf("job: watch registrar not configured")
 	}
@@ -234,12 +231,35 @@ func (o *Orchestrator) Start(ctx context.Context, req models.StartJobRequest) (m
 	if profileRef == "" {
 		profileRef = "spike"
 	}
+	req.ProfileRef = profileRef
+
+	// M6: apply profile defaults before validation so profile-only starts work.
+	var prof models.ProvisioningProfile
+	if profileRef != "" && profileRef != "spike" {
+		if o.profiles == nil {
+			return models.ProvisioningJob{}, fmt.Errorf("job: profile %q requires SHOAL_PROFILE_DIR (profile store not configured)", profileRef)
+		}
+		rec, err := o.profiles.Get(ctx, profileRef)
+		if err != nil {
+			return models.ProvisioningJob{}, fmt.Errorf("job: load profile %q: %w", profileRef, err)
+		}
+		prof = rec.Profile
+		applyProfileDefaults(&req, prof)
+		if err := resolveProfileURLs(&req, prof, o.isoBaseURL); err != nil {
+			return models.ProvisioningJob{}, err
+		}
+	}
+
+	if err := validate.StartJobRequest(req); err != nil {
+		return models.ProvisioningJob{}, err
+	}
 	if err := o.checkProfileApproval(ctx, profileRef, req.ApproveDestruct); err != nil {
 		return models.ProvisioningJob{}, err
 	}
 	if err := o.maybeBuildISO(ctx, &req, profileRef); err != nil {
 		return models.ProvisioningJob{}, err
 	}
+	// Legacy resolve if still empty (iso_base only path when media_url not used).
 	if err := o.resolveISOURL(ctx, &req, profileRef); err != nil {
 		return models.ProvisioningJob{}, err
 	}

--- a/internal/deploy/job/profile_apply.go
+++ b/internal/deploy/job/profile_apply.go
@@ -1,0 +1,92 @@
+package job
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/mattcburns/shoal/internal/common/models"
+	"github.com/mattcburns/shoal/internal/deploy/iso"
+)
+
+// applyProfileDefaults fills empty StartJobRequest fields from a provisioning profile.
+// Non-empty request fields always win (operator one-off overrides).
+func applyProfileDefaults(req *models.StartJobRequest, p models.ProvisioningProfile) {
+	if req == nil {
+		return
+	}
+	if strings.TrimSpace(req.InstallStrategy) == "" && strings.TrimSpace(p.InstallStrategy) != "" {
+		req.InstallStrategy = strings.TrimSpace(p.InstallStrategy)
+	}
+	if strings.TrimSpace(req.OsFamily) == "" && strings.TrimSpace(p.OSFamily) != "" {
+		req.OsFamily = strings.TrimSpace(p.OSFamily)
+	}
+	if strings.TrimSpace(req.SeedDelivery) == "" && strings.TrimSpace(p.SeedDelivery) != "" {
+		req.SeedDelivery = strings.TrimSpace(p.SeedDelivery)
+	}
+	if strings.TrimSpace(req.SeedISOURL) == "" && strings.TrimSpace(p.SeedISOURL) != "" {
+		req.SeedISOURL = strings.TrimSpace(p.SeedISOURL)
+	}
+	if strings.TrimSpace(req.Prep) == "" && strings.TrimSpace(p.Prep) != "" {
+		req.Prep = strings.TrimSpace(p.Prep)
+	}
+	if strings.TrimSpace(req.WipeLevel) == "" && strings.TrimSpace(p.WipeLevel) != "" {
+		req.WipeLevel = strings.TrimSpace(p.WipeLevel)
+	}
+	if strings.TrimSpace(req.PrepISOURL) == "" && strings.TrimSpace(p.PrepISOURL) != "" {
+		req.PrepISOURL = strings.TrimSpace(p.PrepISOURL)
+	}
+	if strings.TrimSpace(req.ISOHostname) == "" && strings.TrimSpace(p.ISOHostname) != "" {
+		req.ISOHostname = strings.TrimSpace(p.ISOHostname)
+	}
+	// media_url → iso_url when request omitted install media
+	if strings.TrimSpace(req.ISOURL) == "" && strings.TrimSpace(p.MediaURL) != "" {
+		req.ISOURL = strings.TrimSpace(p.MediaURL)
+	}
+	if req.StageTimeout <= 0 && strings.TrimSpace(p.StageTimeout) != "" {
+		if d, err := time.ParseDuration(strings.TrimSpace(p.StageTimeout)); err == nil && d > 0 {
+			req.StageTimeout = d
+		}
+	}
+}
+
+// resolveProfileURLs fills iso_url / seed_iso_url / prep_iso_url from profile bases
+// when still empty after applyProfileDefaults.
+func resolveProfileURLs(req *models.StartJobRequest, p models.ProvisioningProfile, isoBaseURL string) error {
+	if req == nil {
+		return nil
+	}
+	if strings.TrimSpace(req.ISOURL) == "" {
+		base := strings.TrimSpace(p.ISOBase)
+		if base != "" {
+			u, err := iso.ResolveFromProfile(base, isoBaseURL)
+			if err != nil {
+				return fmt.Errorf("job: resolve iso from profile: %w", err)
+			}
+			req.ISOURL = u
+		}
+	}
+	if strings.TrimSpace(req.SeedISOURL) == "" {
+		if u := strings.TrimSpace(p.SeedISOURL); u != "" {
+			req.SeedISOURL = u
+		} else if base := strings.TrimSpace(p.SeedISOBase); base != "" {
+			u, err := iso.ResolveFromProfile(base, isoBaseURL)
+			if err != nil {
+				return fmt.Errorf("job: resolve seed iso from profile: %w", err)
+			}
+			req.SeedISOURL = u
+		}
+	}
+	if strings.TrimSpace(req.PrepISOURL) == "" {
+		if u := strings.TrimSpace(p.PrepISOURL); u != "" {
+			req.PrepISOURL = u
+		} else if base := strings.TrimSpace(p.PrepISOBase); base != "" {
+			u, err := iso.ResolveFromProfile(base, isoBaseURL)
+			if err != nil {
+				return fmt.Errorf("job: resolve prep iso from profile: %w", err)
+			}
+			req.PrepISOURL = u
+		}
+	}
+	return nil
+}

--- a/internal/deploy/job/profile_apply_test.go
+++ b/internal/deploy/job/profile_apply_test.go
@@ -1,0 +1,68 @@
+package job
+
+import (
+	"testing"
+	"time"
+
+	"github.com/mattcburns/shoal/internal/common/models"
+)
+
+func TestApplyProfileDefaults(t *testing.T) {
+	p := models.ProvisioningProfile{
+		Ref:             "p1",
+		ISOBase:         "shoal-marker",
+		InstallStrategy: models.InstallStrategyImageWrite,
+		OSFamily:        models.OSFamilyUbuntu,
+		SeedDelivery:    models.SeedDeliveryNone,
+		Prep:            "skip",
+		MediaURL:        "http://lab:8080/from-profile.iso",
+		StageTimeout:    "45m",
+	}
+	req := models.StartJobRequest{DeviceID: "d1"}
+	applyProfileDefaults(&req, p)
+	if req.InstallStrategy != models.InstallStrategyImageWrite {
+		t.Fatalf("strategy=%s", req.InstallStrategy)
+	}
+	if req.OsFamily != models.OSFamilyUbuntu {
+		t.Fatalf("family=%s", req.OsFamily)
+	}
+	if req.ISOURL != "http://lab:8080/from-profile.iso" {
+		t.Fatalf("iso=%s", req.ISOURL)
+	}
+	if req.StageTimeout != 45*time.Minute {
+		t.Fatalf("timeout=%s", req.StageTimeout)
+	}
+	// request wins
+	req2 := models.StartJobRequest{
+		InstallStrategy: models.InstallStrategySimulate,
+		ISOURL:          "http://lab:8080/override.iso",
+	}
+	applyProfileDefaults(&req2, p)
+	if req2.InstallStrategy != models.InstallStrategySimulate {
+		t.Fatal("request should win strategy")
+	}
+	if req2.ISOURL != "http://lab:8080/override.iso" {
+		t.Fatal("request should win iso")
+	}
+}
+
+func TestResolveProfileURLs(t *testing.T) {
+	p := models.ProvisioningProfile{
+		ISOBase:     "shoal-marker",
+		SeedISOBase: "cidata",
+		PrepISOBase: "shoal-prep",
+	}
+	req := models.StartJobRequest{}
+	if err := resolveProfileURLs(&req, p, "http://192.168.124.1:8080"); err != nil {
+		t.Fatal(err)
+	}
+	if req.ISOURL != "http://192.168.124.1:8080/shoal-marker.iso" {
+		t.Fatalf("iso=%s", req.ISOURL)
+	}
+	if req.SeedISOURL != "http://192.168.124.1:8080/cidata.iso" {
+		t.Fatalf("seed=%s", req.SeedISOURL)
+	}
+	if req.PrepISOURL != "http://192.168.124.1:8080/shoal-prep.iso" {
+		t.Fatalf("prep=%s", req.PrepISOURL)
+	}
+}

--- a/testdata/profiles/lab-operator-esxi.json
+++ b/testdata/profiles/lab-operator-esxi.json
@@ -1,0 +1,10 @@
+{
+  "ref": "lab-operator-esxi",
+  "media_url": "http://192.168.124.1:8080/esxi-custom.iso",
+  "os_family": "esxi",
+  "install_strategy": "operator_iso",
+  "seed_delivery": "none",
+  "prep": "skip",
+  "stage_timeout": "60m",
+  "needs_approval": false
+}

--- a/testdata/profiles/lab-ubuntu-image-write.json
+++ b/testdata/profiles/lab-ubuntu-image-write.json
@@ -1,0 +1,9 @@
+{
+  "ref": "lab-ubuntu-image-write",
+  "iso_base": "shoal-ubuntu-m1-test",
+  "os_family": "ubuntu",
+  "install_strategy": "image_write",
+  "seed_delivery": "none",
+  "prep": "skip",
+  "needs_approval": false
+}

--- a/testdata/profiles/lab-ubuntu-wipe-image-write.json
+++ b/testdata/profiles/lab-ubuntu-wipe-image-write.json
@@ -1,0 +1,12 @@
+{
+  "ref": "lab-ubuntu-wipe-image-write",
+  "iso_base": "shoal-ubuntu-m1-test",
+  "prep_iso_base": "shoal-prep",
+  "os_family": "ubuntu",
+  "install_strategy": "image_write",
+  "seed_delivery": "none",
+  "prep": "wipe_only",
+  "wipe_level": "discard",
+  "needs_approval": true,
+  "destruct_steps": ["secure_wipe"]
+}


### PR DESCRIPTION
## Summary

Implements multi-stage design slice **M6**: profile-driven happy path for `POST /v1/jobs` / `deploy run`.

- **`ProvisioningProfile`** gains `os_family`, `install_strategy`, `seed_delivery`, `seed_iso_*`, `prep*`, `media_url`, `stage_timeout`, …
- **`applyProfileDefaults`**: request non-empty fields win; profile fills the rest
- **URL resolve**: `iso_base` / `seed_iso_base` / `prep_iso_base` via `SHOAL_ISO_BASE_URL`; `media_url` preferred for install media
- **Validate after apply** in Orchestrator (API only requires `device_id` up front)
- Profile wipe requires `needs_approval`; guest HTTP seed patterns rejected on profile fields
- Examples: `testdata/profiles/lab-ubuntu-image-write.json`, wipe variant, operator ESXi
- GET `/v1/jobs/{id}` stages regression test

```bash
shoal profile save -file testdata/profiles/lab-ubuntu-image-write.json
shoal deploy run -profile-ref lab-ubuntu-image-write -device-id … -bmc-url … -serial-target … -wait
# no -iso-url / -install-strategy required
```

## Test plan

- [x] `go test ./...` / `go vet` / `staticcheck`
- [x] Profile-only image_write + operator_iso unit tests
- [x] apply/resolve unit tests; profile validate matrix
- [ ] Optional lab: save profile + deploy against nested Ubuntu image-write ISO name

## Design

Completes multi-stage v1 slices M0–M6 in `docs/multi-stage-provisioning-design.md` §11.