### PR TITLE
feat(lab): empty CD on nested nodes for sushy Virtual Media

### DIFF
--- a/docs/lab-runbook.md
+++ b/docs/lab-runbook.md
@@ -38,6 +38,32 @@ ansible-playbook -i infra/ansible/inventory/lab-vm.yml \
   infra/ansible/playbooks/build_marker_iso.yml
 ```
 
+### Nested Virtual Media (sushy + CD tray)
+
+Nested BMC guests (`shoal-node-*`) must have an **empty CD-ROM** device in libvirt.
+sushy-tools **cannot hotplug** a CD; `InsertMedia` fills the tray. Without it, Deploy
+fails with `Target libvirt device Cd does not exist`.
+
+- Template: `infra/ansible/roles/libvirt_lab/templates/vm-node.xml.j2` (empty `sda` CD).
+- Optional dual CD for `second_media` smoke: set `shoal_lab_node_dual_cd: true` and re-run
+  lab node define (domains **restart** once when the template changes).
+- sushy compose mounts libvirt socket + `/var/lib/libvirt/images` for media files.
+- App-side: multi-node media is scoped per system (do not merge all managers’ Cd slots).
+
+**Repair an existing lab** (after pulling this change), on the lab host that owns nested
+libvirt (L1 inside the lab VM for VM-hosted mode):
+
+```bash
+# From L0 against lab-vm inventory — refreshes node XML + restarts domains if needed
+ansible-playbook -i infra/ansible/inventory/lab-vm.yml infra/ansible/playbooks/up.yml \
+  --tags nodes,sushy
+# or full up.yml
+
+# Verify
+ssh lab@192.168.122.100 'sudo virsh dumpxml shoal-node-1 | grep -A6 "device=.cdrom."'
+ansible-playbook -i infra/ansible/inventory/lab-vm.yml infra/ansible/playbooks/smoke.yml
+```
+
 ### Phase 2 app smoke (from L0 against VM lab)
 ```bash
 export SHOAL_BMC_USERNAME=...   # vault

--- a/docs/lab-setup-checklist.md
+++ b/docs/lab-setup-checklist.md
@@ -16,6 +16,8 @@ L0 is the **Linux hypervisor** that runs the lab VM. **macOS is not a valid L0**
 - [ ] `/dev/kvm` exists on host
 - [ ] CPU virtualization flags present (`vmx` or `svm`)
 - [ ] **Nested virtualization** enabled on L0 (required for L2 sushy nodes)
+- [ ] After `up.yml`: nested `shoal-node-*` domains include **empty CD-ROM** for
+      sushy Virtual Media (`virsh dumpxml shoal-node-1 | grep cdrom`; smoke.yml checks this)
 
 Quick checks:
 ```bash

--- a/infra/ansible/playbooks/smoke.yml
+++ b/infra/ansible/playbooks/smoke.yml
@@ -159,6 +159,39 @@
         loop_var: res
         label: "{{ res.node.name }}"
 
+    # Nested domains need an empty CD tray for sushy Virtual Media (no CD hotplug).
+    - name: Check nested node empty CD tray for Virtual Media
+      ansible.builtin.shell: |
+        set -e
+        xml="$(virsh dumpxml {{ node.name }})"
+        echo "$xml" | grep -q "device='cdrom'"
+      args:
+        executable: /bin/bash
+      loop: "{{ shoal_bmc_nodes }}"
+      loop_control:
+        loop_var: node
+        label: "{{ node.name }}"
+      delegate_to: "{{ shoal_serial_delegate }}"
+      become: true
+      environment:
+        LIBVIRT_DEFAULT_URI: qemu:///system
+      register: smoke_cdrom
+      changed_when: false
+      failed_when: false
+
+    - name: Assert every nested node has a CD-ROM device
+      ansible.builtin.assert:
+        that:
+          - res.rc == 0
+        fail_msg: >-
+          No empty CD tray on {{ res.node.name }}. Re-run lab_up / libvirt_lab so
+          vm-node.xml.j2 includes device=cdrom (required for sushy InsertMedia).
+        success_msg: "CD tray present for Virtual Media on {{ res.node.name }}"
+      loop: "{{ smoke_cdrom.results }}"
+      loop_control:
+        loop_var: res
+        label: "{{ res.node.name }}"
+
     - name: Assert HTTP dependency checks
       ansible.builtin.assert:
         that:

--- a/infra/ansible/roles/libvirt_lab/defaults/main.yml
+++ b/infra/ansible/roles/libvirt_lab/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+# Nested BMC guests (L2 under the lab VM / direct host).
+# Empty CD tray is required: sushy-tools cannot hotplug a CD device; InsertMedia
+# fills an existing tray. Without this, boot override fails with
+# "Target libvirt device Cd does not exist".
+shoal_lab_node_dual_cd: false

--- a/infra/ansible/roles/libvirt_lab/tasks/create_node.yml
+++ b/infra/ansible/roles/libvirt_lab/tasks/create_node.yml
@@ -6,6 +6,7 @@
   register: node_info
   failed_when: false
   changed_when: false
+
 - name: Check if node disk exists
   stat:
     path: /var/lib/libvirt/images/{{ node.name }}.qcow2
@@ -31,6 +32,28 @@
   register: node_define
   changed_when: node_info.rc != 0 or node_xml.changed
 
+- name: Check current node state before CD/XML refresh restart
+  command: virsh domstate {{ node.name }}
+  register: node_state_pre
+  changed_when: false
+  failed_when: false
+  when: node_xml.changed and node_info.rc == 0
+
+- name: Restart node so new empty CD tray is live
+  # QEMU cannot hotplug cdrom; redefine alone is not enough while the domain is running.
+  # One-time downtime when the domain template changes (e.g. empty CD for Virtual Media).
+  shell: |
+    set -e
+    virsh destroy {{ node.name }} || true
+    virsh start {{ node.name }}
+  when:
+    - node_xml.changed
+    - node_info.rc == 0
+    - node_state_pre is defined
+    - "'running' in (node_state_pre.stdout | default(''))"
+  register: node_cd_restart
+  changed_when: true
+
 - name: Ensure node autostarts
   command: virsh autostart {{ node.name }}
   register: node_autostart
@@ -42,6 +65,7 @@
   when: node_info.rc != 0
   register: node_start
   changed_when: "'started' in node_start.stdout"
+
 - name: Check current node state
   command: virsh domstate {{ node.name }}
   register: node_state

--- a/infra/ansible/roles/libvirt_lab/templates/vm-node.xml.j2
+++ b/infra/ansible/roles/libvirt_lab/templates/vm-node.xml.j2
@@ -27,6 +27,21 @@
       <source file='/var/lib/libvirt/images/{{ node.name }}.qcow2'/>
       <target dev='vda' bus='virtio'/>
     </disk>
+    {# Empty CD tray for Redfish Virtual Media (sushy InsertMedia / change-media). #}
+    <disk type='file' device='cdrom'>
+      <driver name='qemu' type='raw'/>
+      <target dev='sda' bus='sata'/>
+      <readonly/>
+    </disk>
+{% if shoal_lab_node_dual_cd | default(false) | bool %}
+    {# Optional second tray for seed_delivery=second_media lab smoke. #}
+    <disk type='file' device='cdrom'>
+      <driver name='qemu' type='raw'/>
+      <target dev='sdb' bus='sata'/>
+      <readonly/>
+    </disk>
+{% endif %}
+    <controller type='sata' index='0'/>
     <interface type='network'>
       <mac address='{{ node.mac }}'/>
       <source network='shoal-lab-net'/>

--- a/infra/ansible/roles/sushy_tools/tasks/main.yml
+++ b/infra/ansible/roles/sushy_tools/tasks/main.yml
@@ -29,12 +29,23 @@
     src: docker-compose.sushy.yml.j2
     dest: "{{ shoal_sushy_dir }}/docker-compose.sushy.yml"
     mode: '0644'
+  register: sushy_compose_file
   tags: [compose]
+
+- name: Recreate sushy-tools when compose volumes/config change
+  shell: |
+    cd {{ shoal_sushy_dir }}
+    docker compose -f docker-compose.sushy.yml up -d --force-recreate
+  when: sushy_compose_file.changed
+  register: sushy_recreate
+  changed_when: true
+  tags: [start, compose]
 
 - name: Start sushy-tools container
   shell: |
     cd {{ shoal_sushy_dir }}
     docker compose -f docker-compose.sushy.yml up -d
+  when: not sushy_compose_file.changed
   register: sushy_start
   changed_when: >
     'Creating' in ((sushy_start.stdout | default('')) ~ (sushy_start.stderr | default('')))

--- a/infra/ansible/roles/sushy_tools/templates/docker-compose.sushy.yml.j2
+++ b/infra/ansible/roles/sushy_tools/templates/docker-compose.sushy.yml.j2
@@ -5,10 +5,13 @@ services:
     # sushy-emulator reads its settings from a Python config file mounted at
     # /root/sushy/conf.py; the SUSHY_TOOLS_* environment variables are not used
     # by this image.
+    # libvirt: need the socket for domain ops; images dir for Virtual Media ISO files
+    # written into the default storage pool (nested nodes must already have empty CD trays).
     volumes:
       - {{ shoal_sushy_dir }}/conf.py:/root/sushy/conf.py:ro
       - {{ shoal_sushy_dir }}/auth.htpasswd:/root/sushy/auth.htpasswd:ro
-      - /var/run/libvirt:/var/run/libvirt:ro
+      - /var/run/libvirt:/var/run/libvirt
+      - /var/lib/libvirt/images:/var/lib/libvirt/images
     ports:
       - "{{ shoal_sushy_port }}:{{ shoal_sushy_port }}"
     restart: unless-stopped


### PR DESCRIPTION
## Summary

Lab hardening after multi-stage M0–M6: nested sushy guests are **Virtual Media ready** out of `up.yml`.

- **`vm-node.xml.j2`**: empty SATA CD tray (required — no CD hotplug); optional second CD with `shoal_lab_node_dual_cd: true`
- **`create_node.yml`**: on template change, redefine + **restart** running domains so the tray is live
- **sushy compose**: mount `/var/lib/libvirt/images` and libvirt socket (rw); force-recreate when compose changes
- **smoke.yml**: assert every `shoal-node-*` has `device=cdrom`
- **Docs**: lab-runbook + setup checklist repair path

Without an empty tray, Deploy failed with `Target libvirt device Cd does not exist` after lab rebuild.

## Test plan

- [x] Template/task review + jinja sanity
- [ ] `ansible-playbook … up.yml --tags nodes,sushy` on a live lab (restart nodes once)
- [ ] `smoke.yml` passes CD tray asserts
- [ ] Profile-only marker simulate → `provisioned` (same as post-M6 lab AC)