### PR TITLE
feat(deploy): config_drive offline seed via prep

### DIFF
--- a/docs/lab-runbook.md
+++ b/docs/lab-runbook.md
@@ -515,8 +515,16 @@ go run ./cmd/shoal deploy run \
 When the BMC has only one Virtual Media slot, use **prep + config_drive** instead of
 `second_media`:
 
+**Host packages:** `mtools` + `dosfstools` (for `build-nocloud-seed-img.sh`). The
+`marker_iso` Ansible role installs both on the lab VM; on a developer host:
+`sudo apt install mtools dosfstools`.
+
+`SHOAL_SEED_IMG` is placed on the **ISO filesystem** as `/seed.img` (not the initrd)
+so multi‑MiB FAT images stay bootable; prep mounts the install media and `dd`s the
+seed to the end of the wipe target after `PREP_WIPE`.
+
 ```bash
-# 1) FAT NoCloud seed image
+# 1) FAT NoCloud seed image (needs mcopy / mkfs.vfat)
 ./infra/scripts/build-nocloud-seed-img.sh /tmp/cidata.img
 
 # 2) Prep ISO that wipes then dd's seed.img to end of disk
@@ -526,16 +534,24 @@ sudo env SHOAL_INSTALL_MODE=prep SHOAL_INSTALL_TARGET=/dev/vda \
   ./infra/scripts/build-marker-iso.sh /srv/iso/shoal-prep-seed.iso
 
 # 3) Job: wipe+seed prep, then scripted installer (single media attach for OS)
+# Nested VM lab: pass -serial-ssh-host/-key so SOL uses remote virsh ttyconsole.
 go run ./cmd/shoal deploy run \
   -install-strategy scripted_iso -os-family ubuntu \
   -seed-delivery auto \
   -prep wipe_only -approve-destruct \
   -prep-iso-url http://192.168.124.1:8080/shoal-prep-seed.iso \
   -iso-url http://192.168.124.1:8080/ubuntu-live.iso \
-  ...bmc/serial...
+  -serial-target shoal-node-1 \
+  -serial-ssh-host 192.168.122.100 \
+  -serial-ssh-user lab \
+  -serial-ssh-key "$HOME/.ssh/shoal_lab_vm" \
+  ...bmc...
 ```
 
 `auto` with one CD selects **config_drive**; with two CDs and `seed_iso_url` selects **second_media**.
+
+**Lab AC (nested sushy, 1 CD):** prep emits `PREP_SEED` / `PREP_DONE`; `os_install`
+attaches a single media URL with `seed_delivery=config_drive` (no dual Virtual Media).
 
 ### Multi-stage M5: operator_iso (ESXi / Windows)
 

--- a/docs/lab-runbook.md
+++ b/docs/lab-runbook.md
@@ -508,7 +508,34 @@ go run ./cmd/shoal deploy run \
 | `none` (default) | No runtime seed (7a prepare-time seed is fine) |
 | `second_media` | Install ISO on CD1 + seed ISO on CD2; needs ≥2 CD slots |
 | `auto` | Prefer second_media when ≥2 CDs + `seed_iso_url`; else error if image_write (no config_drive) |
-| `config_drive` | **Forbidden** with `image_write` (full-disk dd wipes partition); write path not implemented yet |
+| `config_drive` | Prep writes FAT `cidata` image to **end of disk** after wipe (single CD). **Forbidden** with `image_write`. Build prep with `SHOAL_SEED_IMG=…` |
+
+### Config-drive offline seed (single CD)
+
+When the BMC has only one Virtual Media slot, use **prep + config_drive** instead of
+`second_media`:
+
+```bash
+# 1) FAT NoCloud seed image
+./infra/scripts/build-nocloud-seed-img.sh /tmp/cidata.img
+
+# 2) Prep ISO that wipes then dd's seed.img to end of disk
+sudo env SHOAL_INSTALL_MODE=prep SHOAL_INSTALL_TARGET=/dev/vda \
+  SHOAL_SEED_IMG=/tmp/cidata.img \
+  SHOAL_ISO_NAME=shoal-prep-seed.iso \
+  ./infra/scripts/build-marker-iso.sh /srv/iso/shoal-prep-seed.iso
+
+# 3) Job: wipe+seed prep, then scripted installer (single media attach for OS)
+go run ./cmd/shoal deploy run \
+  -install-strategy scripted_iso -os-family ubuntu \
+  -seed-delivery auto \
+  -prep wipe_only -approve-destruct \
+  -prep-iso-url http://192.168.124.1:8080/shoal-prep-seed.iso \
+  -iso-url http://192.168.124.1:8080/ubuntu-live.iso \
+  ...bmc/serial...
+```
+
+`auto` with one CD selects **config_drive**; with two CDs and `seed_iso_url` selects **second_media**.
 
 ### Multi-stage M5: operator_iso (ESXi / Windows)
 

--- a/docs/multi-stage-provisioning-design.md
+++ b/docs/multi-stage-provisioning-design.md
@@ -815,7 +815,7 @@ Version media URLs when content changes (sushy cache lesson from 7a).
 | **M0** | This design merged | Docs only |
 | **M1** | Stage runner skeleton; single-stage compat with 7a image-write | **Implemented** (single `os_install` stage; job fields + API) |
 | **M2** | Prep v1: wipe + `PREP_*` + handoff to image-write Ubuntu | **Implemented** (event-driven `PREP_DONE` → os_install) |
-| **M3** | Offline seed preference #1 then #2: **second_media**, else **config_drive**, for Ubuntu NoCloud | **Implemented** (seed ISO builder + dual-media attach + `auto` resolve; `config_drive` rejected with `image_write`; config_drive write deferred) |
+| **M3** | Offline seed preference #1 then #2: **second_media**, else **config_drive**, for Ubuntu NoCloud | **Implemented** (second_media + dual attach; **config_drive** via prep FAT `cidata` after wipe; banned with `image_write`) |
 | **M4** | Flatcar offline Ignition (same preference order) | **Implemented** (`scripted_iso` + Ignition seed ISO + second_media; coarse progress; config_drive deferred) |
 | **M5** | **`operator_iso`** path shared by ESXi + Windows shape (attach + boot + cleanup + coarse progress) | **Implemented** (coarse stage deadline → provisioned; SOL stall disabled; seed forbidden; esxi\|windows) |
 | **M6** | Profiles + `seed_delivery: auto` + Operator API §6 fields on `POST/GET /v1/jobs` | **Implemented** (profile defaults merge into Start; profile-only Ubuntu path; GET stages already present) |

--- a/infra/ansible/roles/host_prereqs/tasks/main.yml
+++ b/infra/ansible/roles/host_prereqs/tasks/main.yml
@@ -30,6 +30,9 @@
       - git
       - curl
       - wget
+      # config_drive NoCloud seed.img (build-nocloud-seed-img.sh: mcopy + mkfs.vfat)
+      - mtools
+      - dosfstools
     state: present
   when: ansible_os_family == "Debian"
   tags: [packages]

--- a/infra/ansible/roles/lab_vm/templates/user-data.j2
+++ b/infra/ansible/roles/lab_vm/templates/user-data.j2
@@ -27,6 +27,9 @@ packages:
   - git
   - curl
   - wget
+  # config_drive offline seed (build-nocloud-seed-img.sh on L1)
+  - mtools
+  - dosfstools
 runcmd:
   - systemctl enable --now libvirtd
   - systemctl enable --now docker

--- a/infra/ansible/roles/marker_iso/files/build-marker-iso.sh
+++ b/infra/ansible/roles/marker_iso/files/build-marker-iso.sh
@@ -2,6 +2,16 @@
 # build-marker-iso.sh — build a minimal bootable live ISO that emits SHOAL| markers
 # on the serial console (ttyS0 / console), then powers off.
 #
+# Modes (Phase 6a):
+#   SHOAL_INSTALL_MODE=simulate (default) — Phase 2 demo markers; optional /payload size note
+#   SHOAL_INSTALL_MODE=write — when /payload is present, write it to a target with real progress
+#
+# Target selection for write mode (first match wins):
+#   1) kernel cmdline shoal.target=PATH
+#   2) SHOAL_INSTALL_TARGET at build time (baked into init)
+#   3) first of /dev/vda /dev/sda if block devices
+#   4) /tmp/shoal-install.out (lab harness fallback when no disk)
+#
 # Primary: run on the lab VM (L1) so the ISO lands in /srv/iso for nginx :8080.
 # Alternate: run on a workstation and scp the artifact into the lab ISO dir.
 #
@@ -10,21 +20,35 @@
 # Usage:
 #   ./infra/scripts/build-marker-iso.sh [/output/path/shoal-marker.iso]
 #   SHOAL_ISO_OUT=/srv/iso/shoal-marker.iso ./infra/scripts/build-marker-iso.sh
+#   SHOAL_INSTALL_MODE=write SHOAL_PAYLOAD_FILE=./rootfs.img ./infra/scripts/build-marker-iso.sh
 
 set -euo pipefail
 
 OUT="${1:-${SHOAL_ISO_OUT:-./shoal-marker.iso}}"
+# Optional basename override (Phase 5c Go builder sets SHOAL_ISO_NAME).
+if [[ -n "${SHOAL_ISO_NAME:-}" ]]; then
+  OUT_DIR="$(dirname "$OUT")"
+  OUT="${OUT_DIR%/}/${SHOAL_ISO_NAME}"
+fi
 WORK="$(mktemp -d "${TMPDIR:-/tmp}/shoal-marker-iso.XXXXXX")"
 cleanup() { rm -rf "$WORK"; }
 trap cleanup EXIT
 
 KERNEL="${SHOAL_KERNEL:-}"
 if [[ -z "$KERNEL" ]]; then
+  # Prefer the running kernel image so packed modules (uname -r) match.
+  # /boot/vmlinuz often points at a newer uname-mismatched install and yields
+  # "invalid module format" when insmod'ing isofs/ahci from /lib/modules/$(uname -r).
+  run_kver="$(uname -r 2>/dev/null || true)"
+  if [[ -n "$run_kver" && -r "/boot/vmlinuz-${run_kver}" ]]; then
+    KERNEL="/boot/vmlinuz-${run_kver}"
+  fi
+fi
+if [[ -z "$KERNEL" ]]; then
   for k in /boot/vmlinuz /boot/vmlinuz-linux /boot/vmlinuz-generic; do
     if [[ -r "$k" ]]; then KERNEL="$k"; break; fi
   done
   if [[ -z "$KERNEL" ]]; then
-    # Prefer versioned kernels
     KERNEL="$(ls -1 /boot/vmlinuz-* 2>/dev/null | tail -1 || true)"
   fi
 fi
@@ -32,6 +56,8 @@ if [[ -z "$KERNEL" || ! -r "$KERNEL" ]]; then
   echo "error: no readable kernel; set SHOAL_KERNEL=/boot/vmlinuz-..." >&2
   exit 1
 fi
+# Resolve symlinks for logging / version checks.
+KERNEL="$(readlink -f "$KERNEL" 2>/dev/null || echo "$KERNEL")"
 
 BUSYBOX="$(command -v busybox || true)"
 if [[ -z "$BUSYBOX" ]]; then
@@ -67,20 +93,169 @@ if ! command -v xorriso >/dev/null 2>&1; then
   exit 1
 fi
 
+INSTALL_MODE="${SHOAL_INSTALL_MODE:-simulate}"
+case "$INSTALL_MODE" in
+  simulate|write|autoinstall|prep) ;;
+  *)
+    echo "error: SHOAL_INSTALL_MODE must be simulate|write|autoinstall|prep (got $INSTALL_MODE)" >&2
+    exit 1
+    ;;
+esac
+# autoinstall is write-to-disk of an OS image payload (Phase 7a cloud image path).
+if [[ "$INSTALL_MODE" == "autoinstall" ]]; then
+  INSTALL_MODE="write"
+  # Prefer reboot into installed OS after write.
+  SHOAL_INSTALL_REBOOT="${SHOAL_INSTALL_REBOOT:-1}"
+  # Prefer first block device for real install.
+  if [[ -z "${SHOAL_INSTALL_TARGET:-}" ]]; then
+    SHOAL_INSTALL_TARGET="/dev/vda"
+  fi
+fi
+# prep: wipe install disk and emit PREP_* markers (multi-stage M2); no OS payload.
+if [[ "$INSTALL_MODE" == "prep" ]]; then
+  if [[ -z "${SHOAL_INSTALL_TARGET:-}" ]]; then
+    SHOAL_INSTALL_TARGET="/dev/vda"
+  fi
+  # Power off after wipe so orchestrator can attach OS media cleanly.
+  SHOAL_INSTALL_REBOOT="${SHOAL_INSTALL_REBOOT:-0}"
+fi
+# Baked default target for write/prep mode (overridable via kernel cmdline shoal.target=).
+INSTALL_TARGET_DEFAULT="${SHOAL_INSTALL_TARGET:-}"
+INSTALL_REBOOT="${SHOAL_INSTALL_REBOOT:-0}"
+# Wipe style for prep: discard (try blkdiscard) or zero (dd first N MiB of disk).
+PREP_WIPE_LEVEL="${SHOAL_PREP_WIPE_LEVEL:-discard}"
+
 echo "kernel:  $KERNEL"
 echo "busybox: $BUSYBOX"
+echo "mode:    $INSTALL_MODE"
 echo "output:  $OUT"
 
 # --- initramfs rootfs ---
 ROOT="$WORK/rootfs"
-mkdir -p "$ROOT"/{bin,dev,proc,sys,tmp}
+mkdir -p "$ROOT"/{bin,dev,proc,sys,tmp,mnt}
 
 cp "$BUSYBOX" "$ROOT/bin/busybox"
 chmod 755 "$ROOT/bin/busybox"
 # Install common applets used by /init
-for app in sh mount umount mkdir sleep cat echo poweroff reboot mkdir ln; do
+for app in sh mount umount mkdir sleep cat echo poweroff reboot mkdir ln dd wc rm sync gunzip zcat gzip \
+  insmod modprobe lsmod mdev; do
   ln -sf busybox "$ROOT/bin/$app"
 done
+
+# Kernel modules needed when payload lives on the ISO (SATA CD + isofs + virtio disk).
+# Host kernel modules: nested lab boots the L1 /boot/vmlinuz; without these, /init
+# cannot mount the install CD or see /dev/vda.
+pack_modules() {
+  local kver
+  kver="$(uname -r)"
+  local modroot="/lib/modules/${kver}"
+  if [[ ! -d "$modroot" ]]; then
+    echo "warn: no $modroot — skipping module pack (CD mount may fail)" >&2
+    return 0
+  fi
+  mkdir -p "$ROOT/lib/modules/${kver}"
+  # Resolve dependencies for modules we need (ignore builtins / missing).
+  local needed=()
+  local m dep line
+  for m in ahci libahci isofs virtio_blk virtio_pci virtio_ring virtio; do
+    if [[ -n "$(modinfo -n "$m" 2>/dev/null || true)" ]]; then
+      needed+=("$m")
+    fi
+  done
+  # Collect unique module files via modprobe --show-depends
+  local files=()
+  for m in "${needed[@]}"; do
+    while IFS= read -r line; do
+      case "$line" in
+        insmod\ *)
+          dep="${line#insmod }"
+          dep="${dep%% *}"
+          if [[ -f "$dep" ]]; then
+            files+=("$dep")
+          fi
+          ;;
+      esac
+    done < <(modprobe --show-depends "$m" 2>/dev/null || true)
+  done
+  # Dedup and copy preserving relative path under /lib/modules/$kver
+  local f rel dest
+  declare -A seen=()
+  for f in "${files[@]}"; do
+    [[ -n "${seen[$f]:-}" ]] && continue
+    seen[$f]=1
+    rel="${f#/lib/modules/${kver}/}"
+    if [[ "$rel" == "$f" ]]; then
+      # unexpected path — copy by basename
+      dest="$ROOT/lib/modules/${kver}/$(basename "$f")"
+    else
+      dest="$ROOT/lib/modules/${kver}/${rel}"
+    fi
+    mkdir -p "$(dirname "$dest")"
+    cp -a "$f" "$dest"
+    echo "module: $rel"
+  done
+  if command -v depmod >/dev/null 2>&1; then
+    depmod -b "$ROOT" "$kver" 2>/dev/null || true
+  fi
+  # Marker for init
+  printf '%s\n' "$kver" > "$ROOT/kver"
+  echo "packed modules for kernel $kver (${#seen[@]} files)"
+}
+pack_modules
+
+# Optional payload (Phase 5c text / Phase 6a binary image / Phase 7a OS raw|gz).
+# Prefer SHOAL_PAYLOAD_FILE (path); else SHOAL_EMBEDDED_PAYLOAD (inline text).
+#
+# Large payloads MUST NOT go into the initrd: a ~680MB cloud image initrd OOMs /
+# hangs nested 2GiB VMs (kernel must decompress the whole initramfs into RAM).
+# Threshold: embed in initrd only if <= SHOAL_PAYLOAD_INITRD_MAX (default 4MiB);
+# otherwise place on the ISO root and have /init mount the CDROM to stream it.
+PAYLOAD_INITRD_MAX="${SHOAL_PAYLOAD_INITRD_MAX:-4194304}"
+ISO_PAYLOAD_SRC=""   # host path to copy onto ISO (empty = none / already in initrd)
+ISO_PAYLOAD_NAME=""  # name on ISO: payload or payload.gz
+PAYLOAD_IS_GZIP=0
+
+if [[ -n "${SHOAL_PAYLOAD_FILE:-}" && -r "${SHOAL_PAYLOAD_FILE}" ]]; then
+  psz="$(wc -c <"${SHOAL_PAYLOAD_FILE}" | tr -d ' ')"
+  if [[ "${SHOAL_PAYLOAD_FILE}" == *.gz ]] || gzip -t "${SHOAL_PAYLOAD_FILE}" 2>/dev/null; then
+    PAYLOAD_IS_GZIP=1
+  fi
+  if [[ "$psz" -le "$PAYLOAD_INITRD_MAX" ]]; then
+    cp "${SHOAL_PAYLOAD_FILE}" "$ROOT/payload"
+    chmod 644 "$ROOT/payload"
+    if [[ "$PAYLOAD_IS_GZIP" -eq 1 ]]; then
+      printf '1\n' > "$ROOT/payload_gzip"
+    fi
+    echo "payload: embedded in initrd ($psz bytes gzip=${PAYLOAD_IS_GZIP})"
+  else
+    ISO_PAYLOAD_SRC="${SHOAL_PAYLOAD_FILE}"
+    if [[ "$PAYLOAD_IS_GZIP" -eq 1 ]]; then
+      ISO_PAYLOAD_NAME="payload.gz"
+      printf '1\n' > "$ROOT/payload_on_iso_gzip"
+    else
+      ISO_PAYLOAD_NAME="payload"
+      printf '0\n' > "$ROOT/payload_on_iso_gzip"
+    fi
+    printf '%s\n' "$ISO_PAYLOAD_NAME" > "$ROOT/payload_on_iso"
+    echo "payload: on ISO as /${ISO_PAYLOAD_NAME} ($psz bytes gzip=${PAYLOAD_IS_GZIP}) — not in initrd"
+  fi
+elif [[ -n "${SHOAL_EMBEDDED_PAYLOAD:-}" ]]; then
+  printf '%s' "${SHOAL_EMBEDDED_PAYLOAD}" > "$ROOT/payload"
+  chmod 644 "$ROOT/payload"
+fi
+
+# Bake install defaults for init (read by the shell script below).
+printf '%s\n' "$INSTALL_MODE" > "$ROOT/install_mode"
+printf '%s\n' "$INSTALL_TARGET_DEFAULT" > "$ROOT/install_target_default"
+printf '%s\n' "$INSTALL_REBOOT" > "$ROOT/install_reboot"
+printf '%s\n' "$PREP_WIPE_LEVEL" > "$ROOT/prep_wipe_level"
+# Optional NoCloud FAT image for config_drive — on ISO FS (not initrd; can be multi‑MiB).
+ISO_SEED_SRC=""
+if [[ -n "${SHOAL_SEED_IMG:-}" && -r "${SHOAL_SEED_IMG}" ]]; then
+  ISO_SEED_SRC="${SHOAL_SEED_IMG}"
+  printf 'seed.img\n' > "$ROOT/seed_on_iso"
+  echo "seed.img: on ISO as /seed.img ($(wc -c <"${SHOAL_SEED_IMG}" | tr -d ' ') bytes) — not in initrd"
+fi
 
 # Init emits markers then powers off. console=ttyS0 from kernel cmdline.
 cat > "$ROOT/init" << 'INIT'
@@ -99,6 +274,38 @@ for dev in /dev/ttyS0 /dev/console /dev/tty0; do
   fi
 done
 
+# Load modules for SATA CD (ahci), ISO9660, and virtio disk (payload + /dev/vda).
+load_mods() {
+  KVER=""
+  if [ -f /kver ]; then KVER="$(cat /kver 2>/dev/null | tr -d '\n')"; fi
+  if [ -z "$KVER" ]; then KVER="$(uname -r 2>/dev/null || true)"; fi
+  BASE="/lib/modules/$KVER"
+  if [ -n "$KVER" ] && [ -d "$BASE" ]; then
+    # Explicit paths (order matters). Suppress "File exists" if already loaded.
+    for ko in \
+      "$BASE/kernel/drivers/block/virtio_blk.ko" \
+      "$BASE/kernel/drivers/ata/libahci.ko" \
+      "$BASE/kernel/drivers/ata/ahci.ko" \
+      "$BASE/kernel/fs/isofs/isofs.ko"
+    do
+      if [ -f "$ko" ]; then
+        insmod "$ko" 2>/dev/null || true
+      fi
+    done
+    # Catch any remaining .ko we packed
+    for ko in "$BASE"/kernel/*/*.ko "$BASE"/kernel/*/*/*.ko "$BASE"/kernel/*/*/*/*.ko; do
+      [ -f "$ko" ] || continue
+      insmod "$ko" 2>/dev/null || true
+    done
+    modprobe isofs 2>/dev/null || true
+    modprobe ahci 2>/dev/null || true
+    modprobe virtio_blk 2>/dev/null || true
+  fi
+  mdev -s 2>/dev/null || true
+  sleep 2
+}
+load_mods
+
 seq=0
 emit() {
   phase="$1"; percent="$2"; state="$3"; detail="${4:-}"
@@ -107,25 +314,370 @@ emit() {
   printf 'SHOAL|1|%s|%s|%s|%s|%s|%s\n' "$seq" "$ts" "$phase" "$percent" "$state" "$detail"
 }
 
-# Short Phase-2 demonstration sequence (no real disk write).
-emit BOOT 0 OK "marker live image started"
+MODE="simulate"
+if [ -f /install_mode ]; then
+  MODE="$(cat /install_mode 2>/dev/null | tr -d '\n' || echo simulate)"
+fi
+TARGET=""
+if [ -f /install_target_default ]; then
+  TARGET="$(cat /install_target_default 2>/dev/null | tr -d '\n' || true)"
+fi
+# Kernel cmdline overrides (shoal.mode= write|simulate, shoal.target=/dev/vda)
+for x in $(cat /proc/cmdline 2>/dev/null); do
+  case "$x" in
+    shoal.mode=*) MODE="${x#shoal.mode=}" ;;
+    shoal.target=*) TARGET="${x#shoal.target=}" ;;
+  esac
+done
+
+# Resolve payload path: small embeds live at /payload; large OS images live on the CD.
+PAYLOAD=""
+GZIP=0
+CD_MOUNTED=0
+list_block_devs() {
+  # Compact list for marker detail (max ~120 chars).
+  out=""
+  for d in /sys/block/*; do
+    [ -e "$d" ] || continue
+    n="${d##*/}"
+    case "$n" in
+      loop*|ram*|fd*) continue ;;
+    esac
+    out="${out}${n} "
+  done
+  for d in /dev/sr* /dev/cdrom /dev/vd* /dev/sd* /dev/hd*; do
+    [ -e "$d" ] || [ -b "$d" ] || continue
+    out="${out}${d##*/} "
+  done
+  echo "$out"
+}
+
+mount_cd() {
+  mkdir -p /mnt/cd
+  # Retry: modules/device nodes can appear slightly after boot.
+  attempt=0
+  while [ "$attempt" -lt 8 ]; do
+    mdev -s 2>/dev/null || true
+    # Re-try isofs each round
+    if [ -f /kver ]; then
+      k="$(cat /kver 2>/dev/null | tr -d '\n')"
+      insmod "/lib/modules/$k/kernel/fs/isofs/isofs.ko" 2>/dev/null || true
+      insmod "/lib/modules/$k/kernel/drivers/ata/libahci.ko" 2>/dev/null || true
+      insmod "/lib/modules/$k/kernel/drivers/ata/ahci.ko" 2>/dev/null || true
+      insmod "/lib/modules/$k/kernel/drivers/block/virtio_blk.ko" 2>/dev/null || true
+    fi
+    for dev in /dev/sr0 /dev/sr1 /dev/cdrom /dev/hdc /dev/hdb /dev/hda /dev/scd0 /dev/sdb /dev/sdc /dev/sda; do
+      if [ -b "$dev" ] || [ -e "$dev" ]; then
+        if mount -t iso9660 -o ro "$dev" /mnt/cd 2>/dev/null; then
+          CD_MOUNTED=1
+          return 0
+        fi
+        if mount -o ro "$dev" /mnt/cd 2>/dev/null; then
+          CD_MOUNTED=1
+          return 0
+        fi
+      fi
+    done
+    for dev in /dev/sr* /dev/vd* /dev/sd*; do
+      if [ -b "$dev" ]; then
+        if mount -t iso9660 -o ro "$dev" /mnt/cd 2>/dev/null; then
+          CD_MOUNTED=1
+          return 0
+        fi
+      fi
+    done
+    attempt=$((attempt + 1))
+    sleep 1
+  done
+  return 1
+}
+
+if [ -f /payload ]; then
+  PAYLOAD=/payload
+  if [ -f /payload_gzip ]; then GZIP=1; fi
+elif [ -f /payload_on_iso ]; then
+  pname="$(cat /payload_on_iso 2>/dev/null | tr -d '\n')"
+  [ -n "$pname" ] || pname=payload.gz
+  emit BOOT 0 OK "mounting install media for payload=${pname}"
+  if mount_cd; then
+    if [ -f "/mnt/cd/${pname}" ]; then
+      PAYLOAD="/mnt/cd/${pname}"
+    elif [ -f /mnt/cd/payload.gz ]; then
+      PAYLOAD=/mnt/cd/payload.gz
+    elif [ -f /mnt/cd/payload ]; then
+      PAYLOAD=/mnt/cd/payload
+    fi
+    if [ -f /payload_on_iso_gzip ]; then
+      GZIP="$(cat /payload_on_iso_gzip 2>/dev/null | tr -d '\n' || echo 0)"
+    fi
+    case "$PAYLOAD" in
+      *.gz) GZIP=1 ;;
+    esac
+  else
+    devs="$(list_block_devs)"
+    merr=""
+    if [ -b /dev/sr0 ]; then
+      merr="$(mount -t iso9660 -o ro /dev/sr0 /mnt/cd 2>&1 || true)"
+    fi
+    k="$(cat /kver 2>/dev/null | tr -d '\n')"
+    imsg="$(insmod "/lib/modules/$k/kernel/fs/isofs/isofs.ko" 2>&1 || true)"
+    # Keep detail short for SOL marker line length.
+    emit ERROR 0 ERROR "cd mount fail devs=${devs} merr=${merr} insmod=${imsg}"
+  fi
+fi
+
+boot_detail="marker live image started mode=${MODE}"
+if [ -n "$PAYLOAD" ] && [ -f "$PAYLOAD" ]; then
+  psz="$(wc -c <"$PAYLOAD" 2>/dev/null || echo 0)"
+  boot_detail="marker live image started mode=${MODE} payload_bytes=${psz} gzip=${GZIP}"
+fi
+emit BOOT 0 OK "$boot_detail"
 sleep 1
 emit BOOT - HEARTBEAT ""
-sleep 1
-emit IMAGE_WRITE 25 OK "simulated write"
-sleep 1
-emit IMAGE_WRITE - HEARTBEAT ""
-sleep 1
-emit IMAGE_WRITE 75 OK "simulated sync"
-sleep 1
-emit VERIFY 90 OK "ok"
-sleep 1
-emit DONE 100 OK "reboot pending"
+
+REBOOT="0"
+if [ -f /install_reboot ]; then
+  REBOOT="$(cat /install_reboot 2>/dev/null | tr -d '\n' || echo 0)"
+fi
+
+WIPE_LEVEL="discard"
+if [ -f /prep_wipe_level ]; then
+  WIPE_LEVEL="$(cat /prep_wipe_level 2>/dev/null | tr -d '\n' || echo discard)"
+fi
+
+if [ "$MODE" = "prep" ]; then
+  emit PREP_BOOT 0 OK "prep live image started"
+  sleep 1
+  emit PREP_BOOT - HEARTBEAT ""
+  if [ -z "$TARGET" ]; then
+    for cand in /dev/vda /dev/sda /dev/nvme0n1; do
+      if [ -b "$cand" ]; then TARGET="$cand"; break; fi
+    done
+  fi
+  if [ -z "$TARGET" ] || [ ! -b "$TARGET" ]; then
+    emit ERROR 0 ERROR "prep: no wipe target block device"
+    sleep 2
+    /bin/busybox poweroff -f 2>/dev/null || true
+    while true; do sleep 3600; done
+  fi
+  emit PREP_WIPE 10 OK "wipe start target=${TARGET} level=${WIPE_LEVEL}"
+  wiped=0
+  if [ "$WIPE_LEVEL" = "discard" ]; then
+    # busybox may not have blkdiscard; try if present
+    if command -v blkdiscard >/dev/null 2>&1; then
+      if blkdiscard -f "$TARGET" 2>/dev/null; then
+        wiped=1
+        emit PREP_WIPE 80 OK "blkdiscard ok target=${TARGET}"
+      fi
+    fi
+  fi
+  if [ "$wiped" = "0" ]; then
+    # Destroy partition table + FS superblocks (first 64 MiB) — enough for reimage.
+    emit PREP_WIPE 30 OK "zeroing start of ${TARGET}"
+    (
+      while true; do
+        sleep 10
+        emit PREP_WIPE - HEARTBEAT "zeroing ${TARGET}"
+      done
+    ) &
+    HBPID=$!
+    if dd if=/dev/zero of="$TARGET" bs=1M count=64 conv=fsync 2>/dev/null; then
+      kill "$HBPID" 2>/dev/null || true
+      emit PREP_WIPE 90 OK "zeroed 64MiB target=${TARGET}"
+    else
+      kill "$HBPID" 2>/dev/null || true
+      emit ERROR 0 ERROR "prep wipe dd failed target=${TARGET}"
+      sleep 2
+      /bin/busybox poweroff -f 2>/dev/null || true
+      while true; do sleep 3600; done
+    fi
+  fi
+  sync 2>/dev/null || true
+  emit PREP_WIPE 100 OK "wipe finished target=${TARGET}"
+
+  # config_drive: write prebuilt FAT cidata image to end of disk.
+  # seed.img lives on the install ISO (seed_on_iso), not in the initrd.
+  SEED_PATH=""
+  if [ -f /seed_on_iso ]; then
+    emit PREP_SEED 5 OK "mounting media for seed.img"
+    mkdir -p /mnt/cd
+    SEED_PATH=""
+    for tries in 1 2 3 4 5 6 7 8 9 10; do
+      for cd in /dev/sr0 /dev/sr1 /dev/cdrom /dev/vdb /dev/sda; do
+        [ -b "$cd" ] || continue
+        if mount -t iso9660 -o ro "$cd" /mnt/cd 2>/dev/null; then
+          if [ -f /mnt/cd/seed.img ]; then
+            SEED_PATH=/mnt/cd/seed.img
+            break 2
+          fi
+          umount /mnt/cd 2>/dev/null || true
+        fi
+      done
+      sleep 1
+    done
+    if [ -z "$SEED_PATH" ]; then
+      emit ERROR 0 ERROR "prep seed.img not found on install media"
+      sleep 2
+      /bin/busybox poweroff -f 2>/dev/null || true
+      while true; do sleep 3600; done
+    fi
+  elif [ -f /seed.img ]; then
+    SEED_PATH=/seed.img
+  fi
+  if [ -n "$SEED_PATH" ]; then
+    emit PREP_SEED 10 OK "writing config_drive seed to end of ${TARGET}"
+    SEED_BYTES="$(wc -c <"$SEED_PATH" 2>/dev/null | tr -d ' ')"
+    if [ -z "$SEED_BYTES" ] || [ "$SEED_BYTES" = "0" ]; then
+      emit ERROR 0 ERROR "prep seed.img empty"
+      sleep 2
+      /bin/busybox poweroff -f 2>/dev/null || true
+      while true; do sleep 3600; done
+    fi
+    # /sys/block/<name>/size is 512-byte sectors for whole disk.
+    DEVBASE="$(basename "$TARGET")"
+    SECTORS="$(cat /sys/block/${DEVBASE}/size 2>/dev/null || echo 0)"
+    SEED_SECTORS=$(( (SEED_BYTES + 511) / 512 ))
+    if [ -z "$SECTORS" ] || [ "$SECTORS" -le "$SEED_SECTORS" ]; then
+      emit ERROR 0 ERROR "prep seed: disk too small or size unknown target=${TARGET}"
+      sleep 2
+      /bin/busybox poweroff -f 2>/dev/null || true
+      while true; do sleep 3600; done
+    fi
+    SEEK=$(( SECTORS - SEED_SECTORS ))
+    if dd if="$SEED_PATH" of="$TARGET" bs=512 seek="$SEEK" conv=fsync 2>/dev/null; then
+      sync 2>/dev/null || true
+      emit PREP_SEED 100 OK "config_drive seed written label=cidata seek=${SEEK} sectors=${SEED_SECTORS}"
+    else
+      emit ERROR 0 ERROR "prep seed dd failed target=${TARGET}"
+      sleep 2
+      /bin/busybox poweroff -f 2>/dev/null || true
+      while true; do sleep 3600; done
+    fi
+    umount /mnt/cd 2>/dev/null || true
+  fi
+
+  emit PREP_DONE 100 OK "prep complete ready for os install"
+  # Stay powered on with heartbeats so the orchestrator can swap Virtual Media
+  # and ForceRestart into the OS install ISO without losing the serial PTY
+  # (poweroff left nested libvirt serial unusable for the next stage).
+  while true; do
+    sleep 15
+    emit PREP_DONE - HEARTBEAT "awaiting os install media swap"
+  done
+fi
+
+if [ "$MODE" = "write" ] && [ -n "$PAYLOAD" ] && [ -f "$PAYLOAD" ]; then
+  emit DISK_PREP 5 OK "resolving install target"
+  # Resolve write target.
+  if [ -z "$TARGET" ]; then
+    for cand in /dev/vda /dev/sda /dev/nvme0n1; do
+      if [ -b "$cand" ]; then TARGET="$cand"; break; fi
+    done
+  fi
+  if [ -z "$TARGET" ]; then
+    TARGET="/tmp/shoal-install.out"
+    emit IMAGE_WRITE 0 OK "no block device; using file target ${TARGET}"
+  fi
+
+  total="$(wc -c <"$PAYLOAD" 2>/dev/null || echo 0)"
+  if [ -z "$total" ] || [ "$total" = "0" ]; then
+    emit ERROR 0 ERROR "empty payload"
+    sleep 2
+    /bin/busybox poweroff -f 2>/dev/null || true
+    while true; do sleep 3600; done
+  fi
+
+  emit IMAGE_WRITE 0 OK "write start target=${TARGET} bytes=${total} gzip=${GZIP} src=${PAYLOAD}"
+  if [ "$GZIP" = "1" ]; then
+    # Stream-decompress OS image to disk (Phase 7a cloud image path).
+    # Progress heartbeats while gunzip|dd runs (no fine-grained percent).
+    (
+      while true; do
+        sleep 20
+        emit IMAGE_WRITE - HEARTBEAT "gunzip|dd in progress target=${TARGET}"
+      done
+    ) &
+    HBPID=$!
+    if gunzip -c "$PAYLOAD" 2>/dev/null | dd of="$TARGET" bs=4M conv=fsync 2>/dev/null; then
+      kill "$HBPID" 2>/dev/null || true
+      emit IMAGE_WRITE 100 OK "gzip write complete target=${TARGET}"
+    else
+      kill "$HBPID" 2>/dev/null || true
+      emit ERROR 0 ERROR "gunzip|dd failed target=${TARGET}"
+      sleep 2
+      /bin/busybox poweroff -f 2>/dev/null || true
+      while true; do sleep 3600; done
+    fi
+  else
+    # Chunked copy for progress (1 MiB blocks).
+    bs=1048576
+    blocks=$(( total / bs ))
+    rem=$(( total % bs ))
+    written=0
+    i=0
+    while [ "$i" -lt "$blocks" ]; do
+      dd if="$PAYLOAD" of="$TARGET" bs="$bs" count=1 skip="$i" seek="$i" conv=notrunc 2>/dev/null || {
+        emit ERROR 0 ERROR "dd failed at block ${i}"
+        sleep 2
+        /bin/busybox poweroff -f 2>/dev/null || true
+        while true; do sleep 3600; done
+      }
+      written=$(( written + bs ))
+      pct=$(( written * 100 / total ))
+      if [ "$pct" -gt 99 ]; then pct=99; fi
+      emit IMAGE_WRITE "$pct" OK "wrote ${written}/${total}"
+      i=$(( i + 1 ))
+    done
+    if [ "$rem" -gt 0 ]; then
+      dd if="$PAYLOAD" of="$TARGET" bs=1 count="$rem" skip="$written" seek="$written" conv=notrunc 2>/dev/null || {
+        emit ERROR 0 ERROR "dd failed on remainder"
+        sleep 2
+        /bin/busybox poweroff -f 2>/dev/null || true
+        while true; do sleep 3600; done
+      }
+      written=$(( written + rem ))
+    fi
+    emit IMAGE_WRITE 100 OK "write complete target=${TARGET}"
+  fi
+  sync 2>/dev/null || true
+  # Verify size on target when it is a regular file (not for gzip→block).
+  if [ -f "$TARGET" ] && [ "$GZIP" != "1" ]; then
+    tsz="$(wc -c <"$TARGET" 2>/dev/null || echo 0)"
+    if [ "$tsz" = "$total" ]; then
+      emit VERIFY 100 OK "size match bytes=${total}"
+    else
+      emit ERROR 0 ERROR "size mismatch got=${tsz} want=${total}"
+      sleep 2
+      /bin/busybox poweroff -f 2>/dev/null || true
+      while true; do sleep 3600; done
+    fi
+  else
+    emit VERIFY 100 OK "write finished target=${TARGET}"
+  fi
+  emit POSTINSTALL 100 OK "payload installed"
+  emit DONE 100 OK "install write complete"
+else
+  # Phase-2 demonstration sequence (no real disk write).
+  sleep 1
+  emit IMAGE_WRITE 25 OK "simulated write"
+  sleep 1
+  emit IMAGE_WRITE - HEARTBEAT ""
+  sleep 1
+  emit IMAGE_WRITE 75 OK "simulated sync"
+  sleep 1
+  emit VERIFY 90 OK "ok"
+  sleep 1
+  emit DONE 100 OK "reboot pending"
+fi
 
 sleep 1
-# Prefer poweroff so the emulator can observe power transitions.
-/bin/busybox poweroff -f 2>/dev/null || /bin/busybox reboot -f 2>/dev/null || true
-# hang if poweroff unavailable
+if [ "${REBOOT:-0}" = "1" ]; then
+  emit BOOT 100 OK "rebooting into installed system"
+  sleep 1
+  /bin/busybox reboot -f 2>/dev/null || /bin/busybox poweroff -f 2>/dev/null || true
+else
+  /bin/busybox poweroff -f 2>/dev/null || /bin/busybox reboot -f 2>/dev/null || true
+fi
 while true; do sleep 3600; done
 INIT
 chmod 755 "$ROOT/init"
@@ -146,21 +698,45 @@ cp "$ISOLINUX_BIN" "$ISO/boot/isolinux/isolinux.bin"
 if [[ -n "$LDLINUX" ]]; then
   cp "$LDLINUX" "$ISO/boot/isolinux/ldlinux.c32"
 fi
+# Large OS payload on ISO root (streamed from CD by /init — not in initrd).
+if [[ -n "${ISO_SEED_SRC:-}" && -r "${ISO_SEED_SRC}" ]]; then
+  cp "$ISO_SEED_SRC" "$ISO/seed.img"
+  echo "iso: /seed.img ($(wc -c <"$ISO/seed.img" | tr -d ' ') bytes)"
+fi
+if [[ -n "$ISO_PAYLOAD_SRC" && -n "$ISO_PAYLOAD_NAME" ]]; then
+  cp "$ISO_PAYLOAD_SRC" "$ISO/$ISO_PAYLOAD_NAME"
+  chmod 644 "$ISO/$ISO_PAYLOAD_NAME"
+  echo "iso payload: $ISO/$ISO_PAYLOAD_NAME"
+fi
 
-cat > "$ISO/boot/isolinux/isolinux.cfg" << 'CFG'
+# Pass mode/target on kernel cmdline for runtime override.
+CMDLINE="initrd=/boot/initrd.img console=ttyS0,115200n8 console=tty0 quiet shoal.mode=${INSTALL_MODE}"
+if [[ -n "$INSTALL_TARGET_DEFAULT" ]]; then
+  CMDLINE="${CMDLINE} shoal.target=${INSTALL_TARGET_DEFAULT}"
+fi
+cat > "$ISO/boot/isolinux/isolinux.cfg" << CFG
 DEFAULT shoal
 PROMPT 0
 TIMEOUT 10
 LABEL shoal
   KERNEL /boot/vmlinuz
-  APPEND initrd=/boot/initrd.img console=ttyS0,115200n8 console=tty0 quiet
+  APPEND ${CMDLINE}
 CFG
 
+VOLID="SHOAL_MARKER"
+if [[ "$INSTALL_MODE" = "write" ]]; then
+  VOLID="SHOAL_INSTALL"
+elif [[ "$INSTALL_MODE" = "prep" ]]; then
+  VOLID="SHOAL_PREP"
+fi
+
 mkdir -p "$(dirname "$OUT")"
+# -R/-J so payload.gz keeps its name when mounted (not ISO9660 PAYLOAD.GZ;1).
 xorriso -as mkisofs \
   -quiet \
   -o "$OUT" \
-  -V "SHOAL_MARKER" \
+  -V "$VOLID" \
+  -R -J \
   -b boot/isolinux/isolinux.bin \
   -c boot/isolinux/boot.cat \
   -no-emul-boot \
@@ -170,6 +746,6 @@ xorriso -as mkisofs \
 
 chmod 644 "$OUT" 2>/dev/null || true
 SIZE="$(wc -c < "$OUT" | tr -d ' ')"
-echo "built $OUT ($SIZE bytes)"
+echo "built $OUT ($SIZE bytes) mode=$INSTALL_MODE"
 echo "publish: copy into lab ISO dir and serve as http://<lab>:8080/$(basename "$OUT")"
 echo "BMC-reachable (VM lab nodes): http://192.168.124.1:8080/$(basename "$OUT")"

--- a/infra/ansible/roles/marker_iso/tasks/main.yml
+++ b/infra/ansible/roles/marker_iso/tasks/main.yml
@@ -1,6 +1,9 @@
 ---
 # Build and publish the Phase 2 SHOAL marker live ISO into the lab ISO HTTP tree.
 # Primary build host: lab VM (L1). Artifact: {{ shoal_iso_server_dir }}/shoal-marker.iso
+#
+# Also installs config_drive seed tooling (mtools/dosfstools + seed.img builder)
+# so single-CD offline NoCloud seeds can be built on the lab host.
 
 - name: Install marker ISO build packages
   ansible.builtin.apt:
@@ -11,6 +14,9 @@
       - xorriso
       - isolinux
       - syslinux-common
+      # config_drive NoCloud FAT seed.img (build-nocloud-seed-img.sh)
+      - mtools
+      - dosfstools
     state: present
     update_cache: true
     cache_valid_time: 3600
@@ -25,11 +31,37 @@
     mode: "0755"
   become: true
 
-- name: Stage build-marker-iso.sh on target
+# Canonical script lives in infra/scripts; keep role files/ as offline fallback.
+- name: Check for canonical build-marker-iso.sh in repo
+  ansible.builtin.stat:
+    path: "{{ playbook_dir }}/../../scripts/build-marker-iso.sh"
+  register: canonical_marker_iso_script
+
+- name: Stage build-marker-iso.sh from infra/scripts
+  ansible.builtin.copy:
+    src: "{{ playbook_dir }}/../../scripts/build-marker-iso.sh"
+    dest: /tmp/shoal-build-marker-iso.sh
+    mode: "0755"
+  when: canonical_marker_iso_script.stat.exists
+
+- name: Stage build-marker-iso.sh from role files (fallback)
   ansible.builtin.copy:
     src: build-marker-iso.sh
     dest: /tmp/shoal-build-marker-iso.sh
     mode: "0755"
+  when: not canonical_marker_iso_script.stat.exists
+
+- name: Check for build-nocloud-seed-img.sh in repo
+  ansible.builtin.stat:
+    path: "{{ playbook_dir }}/../../scripts/build-nocloud-seed-img.sh"
+  register: canonical_seed_img_script
+
+- name: Stage build-nocloud-seed-img.sh (config_drive tooling)
+  ansible.builtin.copy:
+    src: "{{ playbook_dir }}/../../scripts/build-nocloud-seed-img.sh"
+    dest: /tmp/shoal-build-nocloud-seed-img.sh
+    mode: "0755"
+  when: canonical_seed_img_script.stat.exists
 
 - name: Build and publish shoal-marker.iso
   ansible.builtin.command:
@@ -44,4 +76,5 @@
       Marker ISO published to {{ shoal_iso_server_dir }}/shoal-marker.iso
       Operator URL: http://{{ shoal_service_host | default(shoal_lab_vm_host) }}:{{ shoal_iso_server_port }}/shoal-marker.iso
       BMC (lab net): http://{{ shoal_lab_network_gateway }}:{{ shoal_iso_server_port }}/shoal-marker.iso
+      config_drive packages: mtools dosfstools
       {{ marker_iso_build.stdout | default('') }}

--- a/infra/scripts/build-marker-iso.sh
+++ b/infra/scripts/build-marker-iso.sh
@@ -249,11 +249,12 @@ printf '%s\n' "$INSTALL_MODE" > "$ROOT/install_mode"
 printf '%s\n' "$INSTALL_TARGET_DEFAULT" > "$ROOT/install_target_default"
 printf '%s\n' "$INSTALL_REBOOT" > "$ROOT/install_reboot"
 printf '%s\n' "$PREP_WIPE_LEVEL" > "$ROOT/prep_wipe_level"
-# Optional NoCloud FAT image for config_drive (written after wipe in prep mode).
+# Optional NoCloud FAT image for config_drive — on ISO FS (not initrd; can be multi‑MiB).
+ISO_SEED_SRC=""
 if [[ -n "${SHOAL_SEED_IMG:-}" && -r "${SHOAL_SEED_IMG}" ]]; then
-  cp "${SHOAL_SEED_IMG}" "$ROOT/seed.img"
-  chmod 644 "$ROOT/seed.img"
-  echo "seed.img: embedded from ${SHOAL_SEED_IMG} ($(wc -c <"$ROOT/seed.img" | tr -d ' ') bytes)"
+  ISO_SEED_SRC="${SHOAL_SEED_IMG}"
+  printf 'seed.img\n' > "$ROOT/seed_on_iso"
+  echo "seed.img: on ISO as /seed.img ($(wc -c <"${SHOAL_SEED_IMG}" | tr -d ' ') bytes) — not in initrd"
 fi
 
 # Init emits markers then powers off. console=ttyS0 from kernel cmdline.
@@ -494,11 +495,38 @@ if [ "$MODE" = "prep" ]; then
   sync 2>/dev/null || true
   emit PREP_WIPE 100 OK "wipe finished target=${TARGET}"
 
-  # config_drive (M3 debt): write prebuilt FAT cidata image to end of disk.
-  # Full-disk image_write must not use this path (dd would destroy it).
-  if [ -f /seed.img ]; then
+  # config_drive: write prebuilt FAT cidata image to end of disk.
+  # seed.img lives on the install ISO (seed_on_iso), not in the initrd.
+  SEED_PATH=""
+  if [ -f /seed_on_iso ]; then
+    emit PREP_SEED 5 OK "mounting media for seed.img"
+    mkdir -p /mnt/cd
+    SEED_PATH=""
+    for tries in 1 2 3 4 5 6 7 8 9 10; do
+      for cd in /dev/sr0 /dev/sr1 /dev/cdrom /dev/vdb /dev/sda; do
+        [ -b "$cd" ] || continue
+        if mount -t iso9660 -o ro "$cd" /mnt/cd 2>/dev/null; then
+          if [ -f /mnt/cd/seed.img ]; then
+            SEED_PATH=/mnt/cd/seed.img
+            break 2
+          fi
+          umount /mnt/cd 2>/dev/null || true
+        fi
+      done
+      sleep 1
+    done
+    if [ -z "$SEED_PATH" ]; then
+      emit ERROR 0 ERROR "prep seed.img not found on install media"
+      sleep 2
+      /bin/busybox poweroff -f 2>/dev/null || true
+      while true; do sleep 3600; done
+    fi
+  elif [ -f /seed.img ]; then
+    SEED_PATH=/seed.img
+  fi
+  if [ -n "$SEED_PATH" ]; then
     emit PREP_SEED 10 OK "writing config_drive seed to end of ${TARGET}"
-    SEED_BYTES="$(wc -c </seed.img 2>/dev/null | tr -d ' ')"
+    SEED_BYTES="$(wc -c <"$SEED_PATH" 2>/dev/null | tr -d ' ')"
     if [ -z "$SEED_BYTES" ] || [ "$SEED_BYTES" = "0" ]; then
       emit ERROR 0 ERROR "prep seed.img empty"
       sleep 2
@@ -516,7 +544,7 @@ if [ "$MODE" = "prep" ]; then
       while true; do sleep 3600; done
     fi
     SEEK=$(( SECTORS - SEED_SECTORS ))
-    if dd if=/seed.img of="$TARGET" bs=512 seek="$SEEK" conv=fsync 2>/dev/null; then
+    if dd if="$SEED_PATH" of="$TARGET" bs=512 seek="$SEEK" conv=fsync 2>/dev/null; then
       sync 2>/dev/null || true
       emit PREP_SEED 100 OK "config_drive seed written label=cidata seek=${SEEK} sectors=${SEED_SECTORS}"
     else
@@ -525,6 +553,7 @@ if [ "$MODE" = "prep" ]; then
       /bin/busybox poweroff -f 2>/dev/null || true
       while true; do sleep 3600; done
     fi
+    umount /mnt/cd 2>/dev/null || true
   fi
 
   emit PREP_DONE 100 OK "prep complete ready for os install"
@@ -670,6 +699,10 @@ if [[ -n "$LDLINUX" ]]; then
   cp "$LDLINUX" "$ISO/boot/isolinux/ldlinux.c32"
 fi
 # Large OS payload on ISO root (streamed from CD by /init — not in initrd).
+if [[ -n "${ISO_SEED_SRC:-}" && -r "${ISO_SEED_SRC}" ]]; then
+  cp "$ISO_SEED_SRC" "$ISO/seed.img"
+  echo "iso: /seed.img ($(wc -c <"$ISO/seed.img" | tr -d ' ') bytes)"
+fi
 if [[ -n "$ISO_PAYLOAD_SRC" && -n "$ISO_PAYLOAD_NAME" ]]; then
   cp "$ISO_PAYLOAD_SRC" "$ISO/$ISO_PAYLOAD_NAME"
   chmod 644 "$ISO/$ISO_PAYLOAD_NAME"

--- a/infra/scripts/build-marker-iso.sh
+++ b/infra/scripts/build-marker-iso.sh
@@ -249,6 +249,12 @@ printf '%s\n' "$INSTALL_MODE" > "$ROOT/install_mode"
 printf '%s\n' "$INSTALL_TARGET_DEFAULT" > "$ROOT/install_target_default"
 printf '%s\n' "$INSTALL_REBOOT" > "$ROOT/install_reboot"
 printf '%s\n' "$PREP_WIPE_LEVEL" > "$ROOT/prep_wipe_level"
+# Optional NoCloud FAT image for config_drive (written after wipe in prep mode).
+if [[ -n "${SHOAL_SEED_IMG:-}" && -r "${SHOAL_SEED_IMG}" ]]; then
+  cp "${SHOAL_SEED_IMG}" "$ROOT/seed.img"
+  chmod 644 "$ROOT/seed.img"
+  echo "seed.img: embedded from ${SHOAL_SEED_IMG} ($(wc -c <"$ROOT/seed.img" | tr -d ' ') bytes)"
+fi
 
 # Init emits markers then powers off. console=ttyS0 from kernel cmdline.
 cat > "$ROOT/init" << 'INIT'
@@ -487,6 +493,40 @@ if [ "$MODE" = "prep" ]; then
   fi
   sync 2>/dev/null || true
   emit PREP_WIPE 100 OK "wipe finished target=${TARGET}"
+
+  # config_drive (M3 debt): write prebuilt FAT cidata image to end of disk.
+  # Full-disk image_write must not use this path (dd would destroy it).
+  if [ -f /seed.img ]; then
+    emit PREP_SEED 10 OK "writing config_drive seed to end of ${TARGET}"
+    SEED_BYTES="$(wc -c </seed.img 2>/dev/null | tr -d ' ')"
+    if [ -z "$SEED_BYTES" ] || [ "$SEED_BYTES" = "0" ]; then
+      emit ERROR 0 ERROR "prep seed.img empty"
+      sleep 2
+      /bin/busybox poweroff -f 2>/dev/null || true
+      while true; do sleep 3600; done
+    fi
+    # /sys/block/<name>/size is 512-byte sectors for whole disk.
+    DEVBASE="$(basename "$TARGET")"
+    SECTORS="$(cat /sys/block/${DEVBASE}/size 2>/dev/null || echo 0)"
+    SEED_SECTORS=$(( (SEED_BYTES + 511) / 512 ))
+    if [ -z "$SECTORS" ] || [ "$SECTORS" -le "$SEED_SECTORS" ]; then
+      emit ERROR 0 ERROR "prep seed: disk too small or size unknown target=${TARGET}"
+      sleep 2
+      /bin/busybox poweroff -f 2>/dev/null || true
+      while true; do sleep 3600; done
+    fi
+    SEEK=$(( SECTORS - SEED_SECTORS ))
+    if dd if=/seed.img of="$TARGET" bs=512 seek="$SEEK" conv=fsync 2>/dev/null; then
+      sync 2>/dev/null || true
+      emit PREP_SEED 100 OK "config_drive seed written label=cidata seek=${SEEK} sectors=${SEED_SECTORS}"
+    else
+      emit ERROR 0 ERROR "prep seed dd failed target=${TARGET}"
+      sleep 2
+      /bin/busybox poweroff -f 2>/dev/null || true
+      while true; do sleep 3600; done
+    fi
+  fi
+
   emit PREP_DONE 100 OK "prep complete ready for os install"
   # Stay powered on with heartbeats so the orchestrator can swap Virtual Media
   # and ForceRestart into the OS install ISO without losing the serial PTY

--- a/infra/scripts/build-nocloud-seed-img.sh
+++ b/infra/scripts/build-nocloud-seed-img.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# build-nocloud-seed-img.sh — raw FAT image (LABEL=cidata) for offline NoCloud seed.
+#
+# Used by prep config_drive path: prep live dd's this image to the end of the
+# install disk so cloud-init can find NoCloud without a second Virtual Media.
+#
+# Usage:
+#   SHOAL_SEED_HOSTNAME=node1 ./infra/scripts/build-nocloud-seed-img.sh [/out/seed.img]
+#   SHOAL_SEED_USER_DATA=... SHOAL_SEED_META_DATA=... ./infra/scripts/build-nocloud-seed-img.sh
+set -euo pipefail
+
+OUT="${1:-${SHOAL_SEED_IMG_OUT:-./shoal-nocloud-seed.img}}"
+HOSTNAME="${SHOAL_SEED_HOSTNAME:-${SHOAL_AUTOINSTALL_HOSTNAME:-shoal-node}}"
+INSTANCE_ID="${SHOAL_SEED_INSTANCE_ID:-shoal-${HOSTNAME}}"
+USERNAME="${SHOAL_SEED_USERNAME:-${SHOAL_AUTOINSTALL_USERNAME:-ubuntu}}"
+PASSWORD="${SHOAL_SEED_PASSWORD:-${SHOAL_AUTOINSTALL_PASSWORD:-}}"
+# Size in MiB (prep reserves this many MiB at end of disk).
+SIZE_MIB="${SHOAL_SEED_IMG_SIZE_MIB:-16}"
+
+if ! command -v mkfs.vfat >/dev/null 2>&1; then
+  echo "error: need mkfs.vfat (dosfstools)" >&2
+  exit 1
+fi
+if ! command -v mcopy >/dev/null 2>&1; then
+  echo "error: need mcopy (mtools)" >&2
+  exit 1
+fi
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/shoal-nocloud-seed-img.XXXXXX")"
+cleanup() { rm -rf "$WORK"; }
+trap cleanup EXIT
+
+TREE="$WORK/tree"
+mkdir -p "$TREE"
+
+if [[ -n "${SHOAL_SEED_META_DATA:-}" && -r "${SHOAL_SEED_META_DATA}" ]]; then
+  cp "${SHOAL_SEED_META_DATA}" "$TREE/meta-data"
+else
+  cat >"$TREE/meta-data" <<EOF
+instance-id: ${INSTANCE_ID}
+local-hostname: ${HOSTNAME}
+EOF
+fi
+
+if [[ -n "${SHOAL_SEED_USER_DATA:-}" && -r "${SHOAL_SEED_USER_DATA}" ]]; then
+  cp "${SHOAL_SEED_USER_DATA}" "$TREE/user-data"
+else
+  if [[ -n "$PASSWORD" ]]; then
+    cat >"$TREE/user-data" <<EOF
+#cloud-config
+hostname: ${HOSTNAME}
+manage_etc_hosts: true
+users:
+  - name: ${USERNAME}
+    lock_passwd: false
+    shell: /bin/bash
+    sudo: ALL=(ALL) NOPASSWD:ALL
+ssh_pwauth: true
+chpasswd:
+  expire: false
+  list: |
+    ${USERNAME}:${PASSWORD}
+EOF
+  else
+    cat >"$TREE/user-data" <<EOF
+#cloud-config
+hostname: ${HOSTNAME}
+manage_etc_hosts: true
+users:
+  - name: ${USERNAME}
+    lock_passwd: true
+    shell: /bin/bash
+    sudo: ALL=(ALL) NOPASSWD:ALL
+ssh_pwauth: false
+EOF
+  fi
+fi
+printf 'version: 2\n' >"$TREE/network-config"
+
+mkdir -p "$(dirname "$OUT")"
+rm -f "$OUT"
+dd if=/dev/zero of="$OUT" bs=1M count="$SIZE_MIB" status=none
+# Uppercase volume label is more portable; cloud-init matches cidata/CIDATA.
+mkfs.vfat -n CIDATA -F 16 "$OUT" >/dev/null
+# mtools: map drive as image
+export MTOOLS_SKIP_CHECK=1
+mcopy -i "$OUT" "$TREE/meta-data" ::meta-data
+mcopy -i "$OUT" "$TREE/user-data" ::user-data
+mcopy -i "$OUT" "$TREE/network-config" ::network-config
+chmod 644 "$OUT" 2>/dev/null || true
+SIZE="$(wc -c <"$OUT" | tr -d ' ')"
+echo "built $OUT ($SIZE bytes) FAT label=cidata hostname=${HOSTNAME}"
+echo "embed with SHOAL_SEED_IMG=$OUT when building prep ISO (config_drive)"

--- a/internal/deploy/job/orchestrator.go
+++ b/internal/deploy/job/orchestrator.go
@@ -283,7 +283,9 @@ func (o *Orchestrator) Start(ctx context.Context, req models.StartJobRequest) (m
 		return models.ProvisioningJob{}, fmt.Errorf("job: resolve credentials: %w", err)
 	}
 
-	stages, err := expandStages(req)
+	// Probe CD count early so seed_delivery=auto can choose second_media vs config_drive.
+	nCD := o.probeCDCount(ctx, req, cred)
+	stages, err := expandStages(req, nCD)
 	if err != nil {
 		return models.ProvisioningJob{}, err
 	}
@@ -357,7 +359,7 @@ func (o *Orchestrator) provision(ctx context.Context, job models.ProvisioningJob
 	stages := job.Stages
 	if len(stages) == 0 {
 		var err error
-		stages, err = expandStages(req)
+		stages, err = expandStages(req, 1)
 		if err != nil {
 			return err
 		}
@@ -1079,6 +1081,49 @@ func (o *Orchestrator) checkProfileApproval(ctx context.Context, ref string, app
 		return nil
 	}
 	return fmt.Errorf("job: profile %q requires approval (run: shoal profile approve -ref %s, or pass -approve-destruct)", ref, ref)
+}
+
+// probeCDCount lists CD-capable Virtual Media slots (best-effort; defaults to 1).
+func (o *Orchestrator) probeCDCount(ctx context.Context, req models.StartJobRequest, cred secrets.Credential) int {
+	if o.newBMC == nil {
+		return 1
+	}
+	bmc, err := o.newBMC(redfish.Config{
+		BaseURL:       req.BMCEndpoint,
+		Username:      cred.Username,
+		Password:      cred.Password,
+		AuthMode:      o.authMode,
+		TLSMode:       o.tlsMode,
+		CAFile:        o.caFile,
+		MaxConcurrent: 1,
+	})
+	if err != nil {
+		return 1
+	}
+	if err := bmc.Open(ctx); err != nil {
+		return 1
+	}
+	defer func() { _ = bmc.Close(context.Background()) }()
+	lookup := req.SystemID
+	if lookup == "" {
+		lookup = req.DeviceID
+	}
+	sys, err := bmc.GetSystem(ctx, lookup)
+	if err != nil {
+		sys, err = bmc.GetSystem(ctx, "")
+		if err != nil {
+			return 1
+		}
+	}
+	vms, err := bmc.ListVirtualMedia(ctx, sys.ID)
+	if err != nil {
+		return 1
+	}
+	n := countCDMedia(vms)
+	if n <= 0 {
+		return 1
+	}
+	return n
 }
 
 // resolveISOURL fills req.ISOURL from the profile store when the operator omitted -iso-url.

--- a/internal/deploy/job/stages.go
+++ b/internal/deploy/job/stages.go
@@ -10,11 +10,9 @@ import (
 )
 
 // expandStages derives the stage list for a StartJobRequest (multi-stage design).
-// M1: single os_install. M2: optional prep wipe + os_install.
-// M3: offline seed fields on os_install (second_media / config_drive / auto).
-// M4: scripted_iso + flatcar/ubuntu offline seed (Ignition / NoCloud).
-// M5: operator_iso (ESXi/Windows) with coarse progress — no seed.
-func expandStages(req models.StartJobRequest) ([]models.JobStage, error) {
+// nCD is the BMC CD-capable Virtual Media count used to resolve seed_delivery=auto.
+// Pass 0 to treat as unknown (defaults to 1 for conservative auto resolution).
+func expandStages(req models.StartJobRequest, nCD int) ([]models.JobStage, error) {
 	strategy, err := resolveInstallStrategy(req)
 	if err != nil {
 		return nil, err
@@ -31,13 +29,20 @@ func expandStages(req models.StartJobRequest) ([]models.JobStage, error) {
 		}
 	}
 
-	seedDelivery, seedURL, err := normalizeSeedRequest(req, strategy)
+	requested, seedURL, err := normalizeSeedRequest(req, strategy)
+	if err != nil {
+		return nil, err
+	}
+	if nCD <= 0 {
+		nCD = 1
+	}
+	seedDelivery, err := resolveSeedDelivery(requested, seedURL, strategy, nCD)
 	if err != nil {
 		return nil, err
 	}
 	if strategy == models.InstallStrategyScriptedISO && strings.EqualFold(req.OsFamily, models.OSFamilyFlatcar) {
-		if seedDelivery == models.SeedDeliveryNone || (seedURL == "" && seedDelivery != models.SeedDeliveryConfigDrive) {
-			return nil, fmt.Errorf("job: scripted_iso flatcar requires offline Ignition seed (seed_iso_url + second_media|auto)")
+		if seedDelivery == models.SeedDeliveryNone {
+			return nil, fmt.Errorf("job: scripted_iso flatcar requires offline Ignition seed (second_media or config_drive)")
 		}
 	}
 
@@ -54,6 +59,16 @@ func expandStages(req models.StartJobRequest) ([]models.JobStage, error) {
 	}
 
 	prep := strings.TrimSpace(strings.ToLower(req.Prep))
+	// config_drive seed is written by the prep live image after wipe.
+	if seedDelivery == models.SeedDeliveryConfigDrive {
+		if prep == "" || prep == "skip" {
+			if !req.ApproveDestruct {
+				return nil, fmt.Errorf("job: seed_delivery config_drive requires prep wipe_only and approve_destruct (prep writes cidata after wipe)")
+			}
+			prep = "wipe_only"
+		}
+	}
+
 	switch prep {
 	case "", "skip":
 		return []models.JobStage{osStage}, nil
@@ -83,10 +98,8 @@ func expandStages(req models.StartJobRequest) ([]models.JobStage, error) {
 }
 
 // normalizeSeedRequest applies defaults for seed fields before stage expansion.
-// Final mode for "auto" is chosen at startStage once Virtual Media is listed.
 func normalizeSeedRequest(req models.StartJobRequest, strategy string) (delivery, seedURL string, err error) {
 	if strategy == models.InstallStrategyOperatorISO {
-		// Operator media already contains unattended config.
 		return models.SeedDeliveryNone, "", nil
 	}
 	delivery = strings.TrimSpace(strings.ToLower(req.SeedDelivery))
@@ -120,6 +133,7 @@ func normalizeSeedRequest(req models.StartJobRequest, strategy string) (delivery
 	}
 	if delivery == models.SeedDeliveryAuto && seedURL == "" {
 		// auto without seed URL is a no-op (nothing to deliver).
+		// config_drive may still use seed baked into prep ISO only — use explicit config_drive.
 		return models.SeedDeliveryNone, "", nil
 	}
 	return delivery, seedURL, nil
@@ -138,26 +152,29 @@ func resolveSeedDelivery(requested, seedURL, strategy string, nCD int) (string, 
 	switch req {
 	case models.SeedDeliverySecondMedia:
 		if nCD < 2 {
-			return "", fmt.Errorf("job: seed_delivery second_media needs ≥2 CD-capable Virtual Media slots (found %d); use prepare-time seed for image_write or dual-CD hardware", nCD)
+			return "", fmt.Errorf("job: seed_delivery second_media needs ≥2 CD-capable Virtual Media slots (found %d); use config_drive with prep or dual-CD hardware", nCD)
 		}
 		return models.SeedDeliverySecondMedia, nil
 	case models.SeedDeliveryConfigDrive:
 		if strategy == models.InstallStrategyImageWrite {
 			return "", fmt.Errorf("job: seed_delivery config_drive is incompatible with image_write")
 		}
-		// Prep-stage FAT writer for scripted_iso is not shipped yet.
-		return "", fmt.Errorf("job: seed_delivery config_drive not implemented yet (M3 ships second_media; for image_write use prepare-ubuntu-cloud-payload)")
+		if strategy != models.InstallStrategyScriptedISO && strategy != models.InstallStrategySimulate {
+			return "", fmt.Errorf("job: seed_delivery config_drive requires install_strategy scripted_iso (got %q)", strategy)
+		}
+		return models.SeedDeliveryConfigDrive, nil
 	case models.SeedDeliveryAuto:
 		if nCD >= 2 && strings.TrimSpace(seedURL) != "" {
 			return models.SeedDeliverySecondMedia, nil
 		}
 		if strategy == models.InstallStrategyImageWrite {
-			return "", fmt.Errorf("job: seed_delivery auto: only one Virtual Media slot and image_write cannot use config_drive; bake seed with prepare-ubuntu-cloud-payload or attach seed_iso_url on a dual-CD BMC")
+			return "", fmt.Errorf("job: seed_delivery auto: only one Virtual Media slot and image_write cannot use config_drive; bake seed with prepare-ubuntu-cloud-payload or use dual-CD second_media")
 		}
 		if strategy == models.InstallStrategyScriptedISO {
-			return "", fmt.Errorf("job: seed_delivery auto: scripted_iso needs ≥2 CD slots for second_media (found %d); config_drive not implemented", nCD)
+			// Single CD: prep writes cidata after wipe (seed ISO URL is optional if baked into prep).
+			return models.SeedDeliveryConfigDrive, nil
 		}
-		return "", fmt.Errorf("job: seed_delivery auto: config_drive fallback not implemented yet (need ≥2 CD slots for second_media, found %d)", nCD)
+		return "", fmt.Errorf("job: seed_delivery auto: no mode for strategy %q with %d CD slots", strategy, nCD)
 	default:
 		return "", fmt.Errorf("job: unknown seed_delivery %q", requested)
 	}

--- a/internal/deploy/job/stages_test.go
+++ b/internal/deploy/job/stages_test.go
@@ -12,7 +12,7 @@ func TestExpandStagesSingleOSInstall(t *testing.T) {
 	stages, err := expandStages(models.StartJobRequest{
 		ISOURL:         "http://example/marker.iso",
 		ISOInstallMode: iso.InstallModeAutoinstall,
-	})
+	}, 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -38,7 +38,7 @@ func TestExpandStagesSimulate(t *testing.T) {
 	stages, err := expandStages(models.StartJobRequest{
 		ISOURL:          "http://example/m.iso",
 		InstallStrategy: models.InstallStrategySimulate,
-	})
+	}, 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -52,7 +52,7 @@ func TestExpandStagesWipeOnly(t *testing.T) {
 		ISOURL:     "http://example/os.iso",
 		PrepISOURL: "http://example/prep.iso",
 		Prep:       "wipe_only",
-	})
+	}, 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -72,7 +72,7 @@ func TestExpandStagesWipeOnlyNeedsPrepURL(t *testing.T) {
 	_, err := expandStages(models.StartJobRequest{
 		ISOURL: "http://example/os.iso",
 		Prep:   "wipe_only",
-	})
+	}, 1)
 	if err == nil || !strings.Contains(err.Error(), "prep_iso") {
 		t.Fatalf("got %v", err)
 	}
@@ -85,7 +85,7 @@ func TestExpandStagesScriptedISOFlatcar(t *testing.T) {
 		OsFamily:        models.OSFamilyFlatcar,
 		SeedDelivery:    models.SeedDeliverySecondMedia,
 		SeedISOURL:      "http://example/ignition.iso",
-	})
+	}, 2)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -107,7 +107,7 @@ func TestExpandStagesScriptedISOFlatcarNeedsSeed(t *testing.T) {
 		InstallStrategy: models.InstallStrategyScriptedISO,
 		OsFamily:        models.OSFamilyFlatcar,
 		SeedDelivery:    models.SeedDeliveryNone,
-	})
+	}, 1)
 	if err == nil {
 		t.Fatal("expected missing seed error")
 	}
@@ -118,7 +118,7 @@ func TestExpandStagesScriptedISORejectsESXi(t *testing.T) {
 		ISOURL:          "http://example/esxi.iso",
 		InstallStrategy: models.InstallStrategyScriptedISO,
 		OsFamily:        models.OSFamilyESXi,
-	})
+	}, 1)
 	if err == nil {
 		t.Fatal("expected esxi+scripted_iso error")
 	}
@@ -129,7 +129,7 @@ func TestExpandStagesOperatorISO(t *testing.T) {
 		ISOURL:          "http://example/esxi.iso",
 		InstallStrategy: models.InstallStrategyOperatorISO,
 		OsFamily:        models.OSFamilyESXi,
-	})
+	}, 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -154,7 +154,7 @@ func TestExpandStagesOperatorISOWithPrep(t *testing.T) {
 		Prep:            "wipe_only",
 		InstallStrategy: models.InstallStrategyOperatorISO,
 		OsFamily:        models.OSFamilyWindows,
-	})
+	}, 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -173,7 +173,7 @@ func TestExpandStagesSeedSecondMedia(t *testing.T) {
 		SeedDelivery:    models.SeedDeliverySecondMedia,
 		SeedISOURL:      "http://example/cidata.iso",
 		OsFamily:        "ubuntu",
-	})
+	}, 2)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -194,7 +194,7 @@ func TestExpandStagesRejectsConfigDriveImageWrite(t *testing.T) {
 		ISOURL:          "http://example/os.iso",
 		InstallStrategy: models.InstallStrategyImageWrite,
 		SeedDelivery:    models.SeedDeliveryConfigDrive,
-	})
+	}, 1)
 	if err == nil || !strings.Contains(err.Error(), "config_drive") {
 		t.Fatalf("got %v", err)
 	}
@@ -229,6 +229,47 @@ func TestResolveSeedDelivery(t *testing.T) {
 	_, err = resolveSeedDelivery(models.SeedDeliveryConfigDrive, "", models.InstallStrategyImageWrite, 1)
 	if err == nil {
 		t.Fatal("expected config_drive+image_write error")
+	}
+	// config_drive + scripted_iso
+	got, err = resolveSeedDelivery(models.SeedDeliveryConfigDrive, "", models.InstallStrategyScriptedISO, 1)
+	if err != nil || got != models.SeedDeliveryConfigDrive {
+		t.Fatalf("config_drive scripted: %q %v", got, err)
+	}
+	// auto + scripted + 1 CD → config_drive
+	got, err = resolveSeedDelivery(models.SeedDeliveryAuto, "http://s/seed.iso", models.InstallStrategyScriptedISO, 1)
+	if err != nil || got != models.SeedDeliveryConfigDrive {
+		t.Fatalf("auto single scripted: %q %v", got, err)
+	}
+}
+
+func TestExpandStagesConfigDriveRequiresPrep(t *testing.T) {
+	_, err := expandStages(models.StartJobRequest{
+		ISOURL:          "http://example/live.iso",
+		InstallStrategy: models.InstallStrategyScriptedISO,
+		OsFamily:        models.OSFamilyUbuntu,
+		SeedDelivery:    models.SeedDeliveryConfigDrive,
+		Prep:            "skip",
+	}, 1)
+	if err == nil {
+		t.Fatal("expected config_drive without approve/prep to fail")
+	}
+	stages, err := expandStages(models.StartJobRequest{
+		ISOURL:          "http://example/live.iso",
+		InstallStrategy: models.InstallStrategyScriptedISO,
+		OsFamily:        models.OSFamilyUbuntu,
+		SeedDelivery:    models.SeedDeliveryConfigDrive,
+		PrepISOURL:      "http://example/prep.iso",
+		ApproveDestruct: true,
+		Prep:            "skip", // auto-upgraded to wipe_only
+	}, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(stages) != 2 {
+		t.Fatalf("len=%d", len(stages))
+	}
+	if stages[1].SeedDelivery != models.SeedDeliveryConfigDrive {
+		t.Fatalf("seed=%s", stages[1].SeedDelivery)
 	}
 }
 


### PR DESCRIPTION
## Summary

Implements multi-stage **config_drive** (M3 debt / §4.3.2): offline NoCloud seed on **single-CD** BMCs by writing a FAT `CIDATA` image at the **end of disk** during the **prep** stage.

- **`build-nocloud-seed-img.sh`** — 16 MiB FAT seed (`user-data` / `meta-data` / `network-config`)
- **Prep live** (`SHOAL_SEED_IMG=…`): `seed.img` lives on the **ISO FS** (not initrd); after wipe, prep mounts media, `dd`s seed to end of disk, emits `PREP_SEED` / `PREP_DONE`
- **`seed_delivery=auto`**: ≥2 CD → `second_media`; 1 CD + `scripted_iso` → **`config_drive`**
- **Still forbidden** with `image_write` (full-disk dd)
- Early CD count probe at `Start` so stage expansion includes prep when needed
- **Lab Ansible**: `mtools` + `dosfstools` via `host_prereqs`, lab VM cloud-init, and `marker_iso` (stages seed builder script)
- Docs: design + lab-runbook (nested SOL serial-ssh example + lab AC)

```bash
./infra/scripts/build-nocloud-seed-img.sh /tmp/cidata.img
sudo env SHOAL_INSTALL_MODE=prep SHOAL_SEED_IMG=/tmp/cidata.img \
  ./infra/scripts/build-marker-iso.sh /srv/iso/shoal-prep-seed.iso
# deploy: scripted_iso + seed_delivery=auto|config_drive + prep wipe_only …
```

## Test plan

- [x] `go test ./...` / unit resolve + expand config_drive
- [x] seed.img builder smoke (`mdir` shows files, label CIDATA)
- [x] Lab (nested sushy, 1 CD, rebuilt with Ansible tooling): prep `PREP_DONE` → `os_install` `seed_delivery=config_drive` → **provisioned**
  - Job `5fd665212443a9faecaebd362405e081` on rebuilt lab (~75s)