### PR TITLE
feat(observe): real Redfish SOL transport (redfish_sol), never IPMI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -281,6 +281,7 @@ go run ./cmd/shoal deploy run \
 | `SHOAL_FEWSHOT_DIR` | Append-only learned few-shot JSONL (confirm learning). Lab Ansible default: `/var/lib/shoal/fewshot` via `shoal_fewshot_dir` + `env.j2`. Empty disables confirm |
 | `SHOAL_PROFILE_DIR` | JSON provisioning profiles + approval records (Phase 5b). Lab Ansible default: `/var/lib/shoal/profiles` via `shoal_profile_dir` + `env.j2`. Empty disables non-spike profile load |
 | `SHOAL_API_TOKEN` | Phase 6d: if non-empty, require `Authorization: Bearer …` for `/v1/*`. Empty = open (lab default). Never log. |
+| `SHOAL_SERIAL_TRANSPORT` | `libvirt` (default, unchanged lab behavior) \| `redfish_sol`. Orchestrator-wide default; `StartJobRequest.serial_transport` overrides per job. Real-hardware only; see `docs/real-hardware-sol-runbook.md`. |
 
 
 Full table and Ansible extension points: design doc §8.1.
@@ -422,7 +423,12 @@ Live-server remaster (`SHOAL_UBUNTU_ISO`) is alternate/stretch. **7b/7c deferred
   Leaving them set bricks the next boot.
 - **SOL ownership:** Observe holds the single SOL session for a node during a
   job (register via `watchport`). Lab uses libvirt serial; real hardware uses
-  Redfish/IPMI SOL transports behind `sol.Transport`.
+  the `redfish_sol` transport (`internal/observe/sol/redfish_transport.go` +
+  `internal/common/redfish/sol.go`) behind `sol.Transport`. **Redfish only —
+  never raw IPMI**, even for BMCs that only advertise IPMI SOL. `redfish_sol`
+  is unit-tested only (sushy-tools has no SOL); see
+  `docs/real-hardware-sol-runbook.md` before relying on it against real
+  hardware.
 - Capture real Redfish responses into the **record/replay corpus**
   (`testdata/redfish/`) when you hit a new vendor/firmware shape, and add a
   fixture-based test. Pin gofish version in `go.mod`.

--- a/NOTICE
+++ b/NOTICE
@@ -39,6 +39,11 @@ github.com/stmcginnis/gofish
   License:  BSD-3-Clause
   Copyright (c) 2019, Sean McGinnis
 
+github.com/coder/websocket
+  Version:  v1.8.12
+  License:  ISC
+  Copyright (c) 2023 Anmol Sethi <hi@nhooyr.io>
+
 golang.org/x/crypto
   Version:  v0.31.0
   License:  BSD-3-Clause

--- a/SHOAL_COMPREHENSIVE_DESIGN_AND_IMPLEMENTATION_PLAN.md
+++ b/SHOAL_COMPREHENSIVE_DESIGN_AND_IMPLEMENTATION_PLAN.md
@@ -1151,6 +1151,8 @@ Implementation notes:
 | `github.com/stmcginnis/gofish` | runtime (required) | Redfish sessions, Virtual Media, boot override, power — adopted **day one** so Phase 2 is not blocked on a greenfield Redfish client. Wrapped behind `internal/common/redfish`; types do not leak to call sites. |
 | `github.com/jackc/pgx/v5` | runtime (default) | Postgres driver for lab telemetry/jobs DB on `:5433` |
 | `modernc.org/sqlite` | runtime (optional demo) | Pure-Go SQLite if someone runs without Compose; not required for lab ACs |
+| `github.com/coder/websocket` | runtime (required) | Real Redfish SOL transport: native WebSocket SOL dial for recognized BMC vendors (`internal/common/redfish/sol.go`); gofish has no client-side streaming/WebSocket support. Context-native `Read`/`Close` fits the cancellation-bounded `sol.Transport` contract. |
+| `golang.org/x/crypto` (`ssh` subpackage) | runtime (required) | Real Redfish SOL transport: SSH fallback for `OpenSOL` when — and only when — Redfish's own capability metadata (`ComputerSystem.SerialConsole.SSH`) advertises SSH, using password auth against BMC credentials. Was already an indirect transitive dependency (pulled in by gofish/pgx); promoted to direct use in `internal/common/redfish/sol.go`. Never used for raw IPMI. |
 | `honnef.co/go/tools/cmd/staticcheck` | toolchain | Static analysis beyond `go vet`; not linked into binary |
 
 **Toolchain install (AGENTS / CI):**

--- a/docs/real-hardware-sol-runbook.md
+++ b/docs/real-hardware-sol-runbook.md
@@ -1,0 +1,145 @@
+# Real-hardware Redfish SOL runbook
+
+`internal/common/redfish/sol.go` (`BMC.OpenSOL`) and the `redfish_sol` serial
+transport (`internal/observe/sol/redfish_transport.go`,
+`internal/observe/sol/factory.go`) are **unit-tested only** — sushy-tools
+(the lab BMC simulator) has no SOL support at all, so nothing in this repo's
+automated test suite proves this works against a real BMC. This doc is the
+checklist for the first time a human runs it against real hardware.
+
+Read this before pointing `redfish_sol` at a real BMC, and update it (or the
+candidate list in `sol.go`) with what you learn — the initial WebSocket
+candidate URLs are **unverified guesses**, not documented vendor APIs.
+
+## What's implemented, and how
+
+- **Redfish only.** No IPMI (`ipmitool`) is ever used, regardless of what a
+  BMC advertises. This is a hard project rule, not a v1 limitation.
+- **Discovery order** (`OpenSOL`): classify the BMC vendor from
+  `Manufacturer`/`Model`/manager hints (Dell, Supermicro recognized; same
+  `detectVendor` used by OEM screenshot capture) → try native WebSocket SOL
+  candidates for that vendor → if that's unsupported or fails, check whether
+  Redfish's own capability metadata
+  (`ComputerSystem.SerialConsole.SSH.ServiceEnabled` /
+  `Manager.SerialConsole`) advertises SSH, and if so, open an SSH session
+  (password auth, BMC credentials) using the `ConsoleEntryCommand` Redfish
+  itself provides when present → otherwise, `*redfish.SOLUnsupportedError`
+  with a full debug trail.
+- **Telnet is never attempted** (deferred; a Telnet-only BMC is reported as
+  unsupported, not implemented).
+- **WebSocket candidates are placeholders.** No vendor publishes a documented
+  client-pull plain-text SOL-over-WebSocket endpoint. Real iDRAC/Supermicro
+  console redirection is typically an HTML5/binary KVM protocol, not
+  line-oriented SOL — the candidates in `solWSCandidates` (`sol.go`) are
+  best-effort guesses in the same spirit as the OEM screenshot-capture
+  candidate list, and are very likely to fail until someone finds the real
+  endpoint on real firmware (see "What to do when it fails" below).
+
+## Prerequisites
+
+- A real BMC reachable from the Shoal host, ideally Dell iDRAC or Supermicro
+  first (matches the vendor detection already wired up).
+- `SHOAL_REDFISH_TLS_MODE` set appropriately for that BMC's certificate
+  (`off` | `insecure` | `custom_ca` — see AGENTS.md §3.3 / §7 for the full
+  matrix). Most real BMCs use self-signed certs; `insecure` is the common
+  starting point for a first test, not a production recommendation.
+- `SHOAL_REDFISH_AUTH_MODE=basic` — the native WebSocket SOL path in this
+  slice only supports basic auth (`session` mode dials are explicitly
+  skipped with a debug-trail note, not silently attempted).
+- BMC credentials via `SHOAL_BMC_USERNAME` / `SHOAL_BMC_PASSWORD`, or a
+  per-job `bmc_username`/`bmc_password` on `StartJobRequest` (stored to the
+  secrets backend as usual).
+
+## How to opt in
+
+Either set the orchestrator-wide default:
+
+```bash
+export SHOAL_SERIAL_TRANSPORT=redfish_sol
+```
+
+or override per job on `StartJobRequest`:
+
+```json
+{ "serial_transport": "redfish_sol", "bmc_endpoint": "https://<real-bmc>", ... }
+```
+
+Note: `validate.StartJobRequest` cannot see the config-wide default (it only
+validates the request as submitted), so **`serial_target` is still required
+on the request** even when relying purely on `SHOAL_SERIAL_TRANSPORT`. The
+orchestrator ignores `serial_target` once `redfish_sol` is selected — the
+watch's `Target` becomes `bmc_endpoint` instead. This is a deliberate v1
+tradeoff (safe/explicit over clever); don't "fix" it by threading config into
+`validate` without discussing the tradeoff first.
+
+## Step-by-step per-vendor checklist
+
+1. Start a job against the real BMC with `redfish_sol` selected (see above).
+2. Check the Shoal logs for `sol watch registered` with
+   `target=<bmc_endpoint>` — confirms `WatchSession.Transport == "redfish_sol"`
+   reached the watch service.
+3. If the job proceeds normally (SOL markers flow), it worked — note in this
+   file which vendor/firmware/candidate URL it was (WebSocket or SSH) so the
+   next person doesn't have to rediscover it.
+4. If the job stalls or errors, look for `*redfish.SOLUnsupportedError` (or a
+   wrapped WebSocket/SSH dial error) in the logs/job error field. The error
+   text includes the full `[]CaptureDebugStep` trail: every candidate URL
+   tried, HTTP status, and a redacted body preview (never a password/token —
+   see `sanitizePreview`).
+5. Dell iDRAC first, then Supermicro — matches the existing OEM
+   screenshot-capture precedent (`internal/common/redfish/screenshot.go`),
+   so both features can eventually share field notes about the same BMCs.
+
+## What to do when it fails (expected on the first attempt)
+
+The WebSocket candidates in `solWSCandidates` (`internal/common/redfish/sol.go`)
+are unverified. When you find the real endpoint on real firmware:
+
+1. Capture it from the BMC's own web console (browser devtools → Network →
+   WS filter) while opening its virtual console/SOL viewer.
+2. Add it to the candidate list in `solWSCandidates`, keeping the existing
+   debug-trail-on-every-attempt discipline.
+3. Add a fixture-style unit test following the pattern in
+   `internal/common/redfish/sol_test.go` (`newFakeSOLServer` +
+   `TestOpenSOL_WebSocketDell_Success`) so the working shape is regression-tested.
+4. Update this doc's checklist with the vendor/firmware version that worked.
+
+If the BMC's console turns out to be a binary/graphical KVM protocol rather
+than line-oriented SOL text (the likely outcome for most vendors), `redfish_sol`
+is not the right transport for that BMC — fall back to `SHOAL_SERIAL_TRANSPORT=libvirt`
+(lab only) or leave it as a documented gap; do not force IPMI or a
+graphics-OCR hack into the SOL progress loop (Golden Rule 5: OCR is for
+graphics-only failure screens, never the primary progress channel).
+
+## Known limitations (as of this PR)
+
+- **No SSH host-key pinning.** The SSH fallback uses
+  `ssh.InsecureIgnoreHostKey()` — BMC SSH host keys are not verified. This
+  mirrors the reality that operators don't pin these today, but it is a real
+  gap, not an oversight; revisit if this transport sees production use.
+- **Telnet is not implemented** — a Telnet-only BMC is reported as
+  unsupported, not a crash.
+- **Raw IPMI is never attempted**, even if a BMC only advertises IPMI SOL.
+  This is intentional and permanent (project rule: Redfish only).
+- **WebSocket candidate URLs are unverified** against any real vendor
+  firmware as of this PR — see "What to do when it fails" above.
+- **BMC concurrent-session limits are not load-tested.** `OpenSOL` opens a
+  short-lived discovery session (closed before returning) plus one
+  long-lived WS/SSH connection per active watch — this is the minimum
+  possible footprint, but real BMCs (e.g. iDRAC's default ~6 session cap)
+  have not been tested under concurrent Shoal load.
+- **`session` Redfish auth mode is not supported for the native WebSocket
+  path** — it's explicitly skipped (see the debug trail) rather than
+  guessed at; only `basic` auth has been wired for WS candidate dials.
+
+## Rollback
+
+`redfish_sol` is opt-in and additive. To revert to the existing (lab-proven)
+behavior:
+
+```bash
+unset SHOAL_SERIAL_TRANSPORT   # or export SHOAL_SERIAL_TRANSPORT=libvirt
+```
+
+or omit `serial_transport` on the `StartJobRequest`. Nothing about the
+default `libvirt` path changes as part of this feature.

--- a/docs/third-party-licenses.md
+++ b/docs/third-party-licenses.md
@@ -193,6 +193,30 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.```
 
 ---
 
+## github.com/coder/websocket
+
+- **Module:** `github.com/coder/websocket`
+- **Version:** `v1.8.12`
+- **SPDX:** ISC
+
+```
+Copyright (c) 2023 Anmol Sethi <hi@nhooyr.io>
+
+Permission to use, copy, modify, and distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+```
+
+---
+
 ## golang.org/x/crypto
 
 - **Module:** `golang.org/x/crypto`

--- a/go.mod
+++ b/go.mod
@@ -3,15 +3,17 @@ module github.com/mattcburns/shoal
 go 1.22
 
 require (
+	github.com/coder/websocket v1.8.12
 	github.com/jackc/pgx/v5 v5.7.4
 	github.com/stmcginnis/gofish v0.20.0
+	golang.org/x/crypto v0.31.0
 )
 
 require (
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
-	golang.org/x/crypto v0.31.0 // indirect
 	golang.org/x/sync v0.10.0 // indirect
+	golang.org/x/sys v0.28.0 // indirect
 	golang.org/x/text v0.21.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/coder/websocket v1.8.12 h1:5bUXkEPPIbewrnkU8LTCLVaxi4N4J8ahufH2vlo4NAo=
+github.com/coder/websocket v1.8.12/go.mod h1:LNVeNrXQZfe5qhS9ALED3uA+l5pPqvwXg3CKoDBB2gs=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -22,6 +24,10 @@ golang.org/x/crypto v0.31.0 h1:ihbySMvVjLAeSH1IbfcRTkD/iNscyz8rGzjF/E5hV6U=
 golang.org/x/crypto v0.31.0/go.mod h1:kDsLvtWBEx7MV9tJOj9bnXsPbxwJQ6csT/x4KIN4Ssk=
 golang.org/x/sync v0.10.0 h1:3NQrjDixjgGwUOCaF8w2+VYHv0Ve/vGYSbdkTa98gmQ=
 golang.org/x/sync v0.10.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
+golang.org/x/sys v0.28.0 h1:Fksou7UEQUWlKvIdsqzJmUmCX3cZuD2+P3XyyzwMhlA=
+golang.org/x/sys v0.28.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/term v0.27.0 h1:WP60Sv1nlK1T6SupCHbXzSaN0b9wUmsPoRS9b61A23Q=
+golang.org/x/term v0.27.0/go.mod h1:iMsnZpn0cago0GOrHO2+Y7u7JPn5AylBrcoWkElMTSM=
 golang.org/x/text v0.21.0 h1:zyQAAkrwaneQ066sspRyJaG9VNi/YJ1NfzcGB3hZ/qo=
 golang.org/x/text v0.21.0/go.mod h1:4IBbMaMmOPCJ8SecivzSH54+73PCFmPWxNTLm+vZkEQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -188,12 +188,21 @@ func cmdServe(args []string) int {
 		// Wire Orchestrator so cancel works and orphans are reconciled on boot.
 		secretBackend := openSecrets(cfg)
 		watchSvc := sol.NewWatchService(log, nil)
-		watchSvc.NewTransport = sol.NewTransportFactory(sol.SSHSerialConfig{
-			Host:    cfg.SerialSSHHost,
-			User:    cfg.SerialSSHUser,
-			KeyPath: cfg.SerialSSHKey,
-			UseSudo: cfg.SerialSSHSudo,
-		})
+		watchSvc.NewTransport = sol.NewCombinedTransportFactory(
+			sol.RedfishSOLConfig{
+				NewBMC:   redfish.NewBMC,
+				Secrets:  secretBackend,
+				AuthMode: cfg.RedfishAuthMode,
+				TLSMode:  cfg.RedfishTLSMode,
+				CAFile:   cfg.RedfishCAFile,
+			},
+			sol.SSHSerialConfig{
+				Host:    cfg.SerialSSHHost,
+				User:    cfg.SerialSSHUser,
+				KeyPath: cfg.SerialSSHKey,
+				UseSudo: cfg.SerialSSHSudo,
+			},
+		)
 		var nb netbox.LifecycleWriter
 		if cfg.NetBoxURL != "" && cfg.NetBoxToken != "" {
 			nb = netbox.New(cfg.NetBoxURL, cfg.NetBoxToken)
@@ -208,20 +217,21 @@ func cmdServe(args []string) int {
 			}
 		}
 		orchOpts := job.Options{
-			Log:                 log,
-			Store:               store,
-			Secrets:             secretBackend,
-			NewBMC:              redfish.NewBMC,
-			Watches:             watchSvc,
-			NetBox:              nb,
-			Profiles:            profStore,
-			ISOBaseURL:          cfg.ISOBaseURL,
-			ISOPublishDir:       cfg.ISOPublishDir,
-			ISODynamic:          cfg.ISODynamic,
-			AuthMode:            cfg.RedfishAuthMode,
-			TLSMode:             cfg.RedfishTLSMode,
-			CAFile:              cfg.RedfishCAFile,
-			ReconcileFailOrphan: cfg.ReconcileFailOrphans,
+			Log:                    log,
+			Store:                  store,
+			Secrets:                secretBackend,
+			NewBMC:                 redfish.NewBMC,
+			Watches:                watchSvc,
+			NetBox:                 nb,
+			Profiles:               profStore,
+			ISOBaseURL:             cfg.ISOBaseURL,
+			ISOPublishDir:          cfg.ISOPublishDir,
+			ISODynamic:             cfg.ISODynamic,
+			AuthMode:               cfg.RedfishAuthMode,
+			TLSMode:                cfg.RedfishTLSMode,
+			CAFile:                 cfg.RedfishCAFile,
+			ReconcileFailOrphan:    cfg.ReconcileFailOrphans,
+			DefaultSerialTransport: cfg.SerialTransport,
 		}
 		if cfg.ISOPublishDir != "" && cfg.ISOBaseURL != "" {
 			orchOpts.ISOBuilder = iso.NewScriptBuilder(cfg.ISOBuildScript, log)

--- a/internal/cli/deploy.go
+++ b/internal/cli/deploy.go
@@ -78,6 +78,7 @@ func cmdDeployRun(args []string) int {
 	seedISO := fs.String("seed-iso-url", os.Getenv("SHOAL_SEED_ISO_URL"), "BMC-reachable seed ISO (NoCloud or Ignition)")
 	osFamily := fs.String("os-family", "", "ubuntu|flatcar|esxi|windows")
 	stageTimeout := fs.Duration("stage-timeout", 0, "coarse wait for operator_iso/scripted_iso (default 60m)")
+	serialTransport := fs.String("serial-transport", cfg.SerialTransport, "libvirt|redfish_sol serial transport (see docs/real-hardware-sol-runbook.md)")
 	sshHost := fs.String("serial-ssh-host", cfg.SerialSSHHost, "SSH host for nested libvirt serial (VM mode)")
 	sshUser := fs.String("serial-ssh-user", cfg.SerialSSHUser, "SSH user for serial delegate")
 	sshKey := fs.String("serial-ssh-key", cfg.SerialSSHKey, "SSH private key for serial delegate")
@@ -117,6 +118,7 @@ func cmdDeployRun(args []string) int {
 		BMCUsername:      *bmcUser,
 		BMCPassword:      *bmcPass,
 		SerialTarget:     *serial,
+		SerialTransport:  *serialTransport,
 		SystemID:         *systemID,
 		StallTimeout:     *stallTimeout,
 		ApproveDestruct:  *approveDestruct,
@@ -153,12 +155,21 @@ func cmdDeployRun(args []string) int {
 
 	// Wire Observe watch service with progress from orchestrator (two-step inject).
 	watchSvc := sol.NewWatchService(log, nil)
-	watchSvc.NewTransport = sol.NewTransportFactory(sol.SSHSerialConfig{
-		Host:    cfg.SerialSSHHost,
-		User:    cfg.SerialSSHUser,
-		KeyPath: cfg.SerialSSHKey,
-		UseSudo: cfg.SerialSSHSudo,
-	})
+	watchSvc.NewTransport = sol.NewCombinedTransportFactory(
+		sol.RedfishSOLConfig{
+			NewBMC:   redfish.NewBMC,
+			Secrets:  secretBackend,
+			AuthMode: cfg.RedfishAuthMode,
+			TLSMode:  cfg.RedfishTLSMode,
+			CAFile:   cfg.RedfishCAFile,
+		},
+		sol.SSHSerialConfig{
+			Host:    cfg.SerialSSHHost,
+			User:    cfg.SerialSSHUser,
+			KeyPath: cfg.SerialSSHKey,
+			UseSudo: cfg.SerialSSHSudo,
+		},
+	)
 	var nb netbox.LifecycleWriter
 	if cfg.NetBoxURL != "" && cfg.NetBoxToken != "" {
 		nb = netbox.New(cfg.NetBoxURL, cfg.NetBoxToken)
@@ -177,21 +188,22 @@ func cmdDeployRun(args []string) int {
 		isoBuilder = iso.NewScriptBuilder(cfg.ISOBuildScript, log)
 	}
 	orch := job.NewOrchestrator(job.Options{
-		Log:                 log,
-		Store:               store,
-		Secrets:             secretBackend,
-		NewBMC:              redfish.NewBMC,
-		Watches:             watchSvc,
-		NetBox:              nb,
-		Profiles:            profStore,
-		ISOBaseURL:          cfg.ISOBaseURL,
-		ISOBuilder:          isoBuilder,
-		ISOPublishDir:       cfg.ISOPublishDir,
-		ISODynamic:          cfg.ISODynamic,
-		AuthMode:            cfg.RedfishAuthMode,
-		TLSMode:             cfg.RedfishTLSMode,
-		CAFile:              cfg.RedfishCAFile,
-		ReconcileFailOrphan: cfg.ReconcileFailOrphans,
+		Log:                    log,
+		Store:                  store,
+		Secrets:                secretBackend,
+		NewBMC:                 redfish.NewBMC,
+		Watches:                watchSvc,
+		NetBox:                 nb,
+		Profiles:               profStore,
+		ISOBaseURL:             cfg.ISOBaseURL,
+		ISOBuilder:             isoBuilder,
+		ISOPublishDir:          cfg.ISOPublishDir,
+		ISODynamic:             cfg.ISODynamic,
+		AuthMode:               cfg.RedfishAuthMode,
+		TLSMode:                cfg.RedfishTLSMode,
+		CAFile:                 cfg.RedfishCAFile,
+		ReconcileFailOrphan:    cfg.ReconcileFailOrphans,
+		DefaultSerialTransport: cfg.SerialTransport,
 	})
 	defer orch.Stop()
 	watchSvc.SetProgress(orch.ProgressPort())
@@ -314,27 +326,37 @@ func cmdDeployCancel(args []string) int {
 	// Cancel needs a live orchestrator with BMC factory for cleanup.
 	secretBackend := openSecrets(cfg)
 	watchSvc := sol.NewWatchService(log, nil)
-	watchSvc.NewTransport = sol.NewTransportFactory(sol.SSHSerialConfig{
-		Host:    cfg.SerialSSHHost,
-		User:    cfg.SerialSSHUser,
-		KeyPath: cfg.SerialSSHKey,
-		UseSudo: cfg.SerialSSHSudo,
-	})
+	watchSvc.NewTransport = sol.NewCombinedTransportFactory(
+		sol.RedfishSOLConfig{
+			NewBMC:   redfish.NewBMC,
+			Secrets:  secretBackend,
+			AuthMode: cfg.RedfishAuthMode,
+			TLSMode:  cfg.RedfishTLSMode,
+			CAFile:   cfg.RedfishCAFile,
+		},
+		sol.SSHSerialConfig{
+			Host:    cfg.SerialSSHHost,
+			User:    cfg.SerialSSHUser,
+			KeyPath: cfg.SerialSSHKey,
+			UseSudo: cfg.SerialSSHSudo,
+		},
+	)
 	var nb netbox.LifecycleWriter
 	if cfg.NetBoxURL != "" && cfg.NetBoxToken != "" {
 		nb = netbox.New(cfg.NetBoxURL, cfg.NetBoxToken)
 	}
 	orch := job.NewOrchestrator(job.Options{
-		Log:                 log,
-		Store:               store,
-		Secrets:             secretBackend,
-		NewBMC:              redfish.NewBMC,
-		Watches:             watchSvc,
-		NetBox:              nb,
-		AuthMode:            cfg.RedfishAuthMode,
-		TLSMode:             cfg.RedfishTLSMode,
-		CAFile:              cfg.RedfishCAFile,
-		ReconcileFailOrphan: cfg.ReconcileFailOrphans,
+		Log:                    log,
+		Store:                  store,
+		Secrets:                secretBackend,
+		NewBMC:                 redfish.NewBMC,
+		Watches:                watchSvc,
+		NetBox:                 nb,
+		AuthMode:               cfg.RedfishAuthMode,
+		TLSMode:                cfg.RedfishTLSMode,
+		CAFile:                 cfg.RedfishCAFile,
+		ReconcileFailOrphan:    cfg.ReconcileFailOrphans,
+		DefaultSerialTransport: cfg.SerialTransport,
 	})
 	defer orch.Stop()
 	watchSvc.SetProgress(orch.ProgressPort())

--- a/internal/common/config/config.go
+++ b/internal/common/config/config.go
@@ -39,6 +39,10 @@ type Config struct {
 	SerialSSHKey  string
 	// SerialSSHSudo runs remote virsh/cat with sudo -n (default true when host set).
 	SerialSSHSudo bool
+	// SerialTransport is the orchestrator-wide default serial transport
+	// ("libvirt" | "redfish_sol") when a job doesn't override it via
+	// StartJobRequest.SerialTransport. Default "libvirt" (unchanged behavior).
+	SerialTransport string
 	// FewShotDir is append-only learned few-shot JSONL storage (empty = learning disabled).
 	FewShotDir string
 	// ProfileDir is JSON profile store for Phase 5b (empty disables profile load/approve).
@@ -76,6 +80,7 @@ func Load() (Config, error) {
 		SerialSSHUser:        envOr("SHOAL_SERIAL_SSH_USER", "lab"),
 		SerialSSHKey:         envOr("SHOAL_SERIAL_SSH_KEY", ""),
 		SerialSSHSudo:        true,
+		SerialTransport:      strings.ToLower(envOr("SHOAL_SERIAL_TRANSPORT", "libvirt")),
 		FewShotDir:           os.Getenv("SHOAL_FEWSHOT_DIR"),
 		ProfileDir:           os.Getenv("SHOAL_PROFILE_DIR"),
 		APIToken:             os.Getenv("SHOAL_API_TOKEN"),
@@ -133,6 +138,11 @@ func (c Config) validateBasics() error {
 	}
 	if c.RedfishTLSMode == "custom_ca" && c.RedfishCAFile == "" {
 		return fmt.Errorf("config: SHOAL_REDFISH_CA_FILE required when TLS mode is custom_ca")
+	}
+	switch c.SerialTransport {
+	case "libvirt", "redfish_sol":
+	default:
+		return fmt.Errorf("config: invalid SHOAL_SERIAL_TRANSPORT %q", c.SerialTransport)
 	}
 	if c.AIProvider != "" {
 		switch c.AIProvider {

--- a/internal/common/models/models.go
+++ b/internal/common/models/models.go
@@ -237,13 +237,19 @@ type WatchSession struct {
 	ID           string        `json:"id"`
 	JobID        string        `json:"job_id"`
 	DeviceID     string        `json:"device_id"`
-	Transport    string        `json:"transport"` // "libvirt" | "redfish_sol" | "ipmi_sol"
-	Target       string        `json:"target"`    // console path or BMC URI
+	Transport    string        `json:"transport"` // "libvirt" | "redfish_sol"
+	Target       string        `json:"target"`    // console path (libvirt) or BMC base URL (redfish_sol)
 	StartedAt    time.Time     `json:"started_at"`
 	StallTimeout time.Duration `json:"stall_timeout"` // e.g. 90s; 0 = watch default
 	// StallDisabled skips the silence stall timer (M5 operator_iso coarse progress).
 	// Zero StallTimeout still means default when StallDisabled is false.
 	StallDisabled bool `json:"stall_disabled,omitempty"`
+	// RedfishSystemID selects the ComputerSystem when Transport == "redfish_sol"
+	// (a BMC base URL may host multiple systems). Empty = single-system BMC.
+	RedfishSystemID string `json:"redfish_system_id,omitempty"`
+	// CredentialRef resolves BMC username/password via the secrets backend when
+	// Transport == "redfish_sol". Never the raw secret (Golden Rule 3).
+	CredentialRef string `json:"credential_ref,omitempty"`
 }
 
 // DeviceIdentity is NetBox-facing identity fields.
@@ -264,10 +270,15 @@ type StartJobRequest struct {
 	BMCEndpoint string `json:"bmc_endpoint"`           // Redfish base URL
 	BMCUsername string `json:"bmc_username,omitempty"` // stored to secrets; not logged
 	BMCPassword string `json:"bmc_password,omitempty"` // stored to secrets; never returned
-	// SerialTarget is libvirt domain or SOL target. Optional for operator_iso (M5 coarse).
-	SerialTarget  string `json:"serial_target"`
-	SystemID      string `json:"system_id,omitempty"`
-	CredentialRef string `json:"credential_ref,omitempty"` // alt: pre-seeded secret (skip user/pass)
+	// SerialTarget is libvirt domain or SOL target. Optional for operator_iso (M5 coarse)
+	// and for serial_transport=redfish_sol (target is derived from BMCEndpoint instead).
+	SerialTarget string `json:"serial_target"`
+	// SerialTransport overrides the orchestrator's default serial transport for this
+	// job ("libvirt" | "redfish_sol"). Empty = orchestrator default (SHOAL_SERIAL_TRANSPORT,
+	// itself defaulting to "libvirt" so existing lab behavior is unchanged).
+	SerialTransport string `json:"serial_transport,omitempty"`
+	SystemID        string `json:"system_id,omitempty"`
+	CredentialRef   string `json:"credential_ref,omitempty"` // alt: pre-seeded secret (skip user/pass)
 	// StallTimeout is the SOL silence window before ReportStall (0 = Orchestrator default).
 	// Ignored for operator_iso (stall disabled under coarse progress).
 	StallTimeout time.Duration `json:"stall_timeout,omitempty"`

--- a/internal/common/redfish/bmc.go
+++ b/internal/common/redfish/bmc.go
@@ -1,6 +1,10 @@
 package redfish
 
-import "context"
+import (
+	"context"
+	"fmt"
+	"io"
+)
 
 // BMC is the only Redfish surface Deploy/Observe import.
 // Implementation uses gofish under the hood; types do not leak.
@@ -32,7 +36,54 @@ type BMC interface {
 	// File/operator capture is preferred in lab; this path is for real BMC hardware.
 	// On failure, returned Screenshot.Debug (and error text) include probe steps without secrets.
 	CaptureScreenshot(ctx context.Context, systemID string, kind ScreenshotKind) (Screenshot, error)
+	// OpenSOL opens a serial-over-LAN byte stream for systemID. It tries native
+	// Redfish WebSocket SOL for recognized vendors (Dell, Supermicro) first, then
+	// falls back to SSH only when Redfish's own capability metadata
+	// (ComputerSystem.HostSerialConsole.SSH / Manager.SerialConsole) advertises SSH
+	// as enabled. Never uses raw IPMI, regardless of what a BMC advertises. If a BMC
+	// advertises only IPMI/Oem/Telnet connect types with no working native WS and no
+	// advertised SSH, OpenSOL returns *SOLUnsupportedError. ctx cancellation aborts
+	// discovery/dial; this is the first BMC method that owns a long-lived connection
+	// rather than one round trip, so callers must cancel ctx to release it.
+	OpenSOL(ctx context.Context, systemID string) (SOLStream, error)
 }
 
 // Factory constructs a BMC from config (composition root injects this).
 type Factory func(cfg Config) (BMC, error)
+
+// SOLConnectKind records which real mechanism produced a SOLStream.
+type SOLConnectKind string
+
+const (
+	// SOLConnectWebSocket is a native Redfish/OEM WebSocket SOL stream.
+	SOLConnectWebSocket SOLConnectKind = "websocket"
+	// SOLConnectSSH is an SSH session opened only because Redfish's own
+	// capability metadata advertised SSH as the BMC's serial console transport.
+	SOLConnectSSH SOLConnectKind = "ssh"
+)
+
+// SOLStream is an open SOL byte stream plus how it was obtained. Callers read
+// raw bytes; line-splitting/marker parsing happens above this package.
+type SOLStream struct {
+	io.ReadCloser
+	Vendor VendorID
+	Kind   SOLConnectKind
+	// Debug is ordered discovery/connect steps for operator diagnosis on real
+	// hardware (never contains secrets — see sanitizePreview).
+	Debug []CaptureDebugStep
+}
+
+// SOLUnsupportedError is returned when a BMC has no usable Redfish-discovered
+// SOL path: no native WebSocket candidate worked and Redfish's own metadata
+// did not advertise SSH (Telnet-only and IPMI/Oem-only BMCs land here too —
+// Telnet is deferred and raw IPMI is never attempted).
+type SOLUnsupportedError struct {
+	Vendor       VendorID
+	ConnectTypes []string // observed enabled serial-console protocols, e.g. "IPMI", "Telnet"
+	Debug        []CaptureDebugStep
+}
+
+func (e *SOLUnsupportedError) Error() string {
+	return fmt.Sprintf("redfish: SOL unsupported for vendor %q (connect types: %v)\n%s",
+		e.Vendor, e.ConnectTypes, formatDebug(e.Debug))
+}

--- a/internal/common/redfish/fake.go
+++ b/internal/common/redfish/fake.go
@@ -3,6 +3,8 @@ package redfish
 import (
 	"context"
 	"fmt"
+	"io"
+	"strings"
 	"sync"
 )
 
@@ -31,6 +33,10 @@ type Fake struct {
 	// Screenshot is returned by CaptureScreenshot when set.
 	Screenshot    *Screenshot
 	ScreenshotErr error
+
+	// SOLStream / SOLErr are returned by OpenSOL when set.
+	SOLStream SOLStream
+	SOLErr    error
 }
 
 // NewFake returns a Fake with one system and one CD virtual media slot.
@@ -257,6 +263,28 @@ func (f *Fake) CaptureScreenshot(_ context.Context, _ string, kind ScreenshotKin
 			Message: "fake BMC has no screenshot (set Fake.Screenshot for tests)",
 		}},
 	}, fmt.Errorf("fake: screenshot not configured")
+}
+
+func (f *Fake) OpenSOL(_ context.Context, _ string) (SOLStream, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.SOLErr != nil {
+		return SOLStream{}, f.SOLErr
+	}
+	if f.SOLStream.ReadCloser == nil {
+		return SOLStream{}, fmt.Errorf("fake: SOL not configured (set Fake.SOLStream for tests)")
+	}
+	return f.SOLStream, nil
+}
+
+// NewFakeSOLLines returns a SOLStream that yields the given lines (each
+// newline-terminated) from an in-memory reader — a test helper for OpenSOL
+// consumers that don't need to drive a live io.Pipe.
+func NewFakeSOLLines(kind SOLConnectKind, lines ...string) SOLStream {
+	return SOLStream{
+		ReadCloser: io.NopCloser(strings.NewReader(strings.Join(lines, "\n") + "\n")),
+		Kind:       kind,
+	}
 }
 
 // MediaInserted reports whether any media is inserted (test helper).

--- a/internal/common/redfish/lab_integration_test.go
+++ b/internal/common/redfish/lab_integration_test.go
@@ -4,6 +4,7 @@ package redfish_test
 
 import (
 	"context"
+	"errors"
 	"os"
 	"testing"
 	"time"
@@ -153,6 +154,67 @@ func TestLabListSELAndSensors(t *testing.T) {
 		t.Fatalf("ListSensors: %v", err)
 	}
 	t.Logf("sensors: %d", len(sensors))
+}
+
+// TestLabOpenSOLReportsUnsupported exercises OpenSOL's discovery path against
+// the real lab sushy-tools BMC over the network. sushy-tools implements no
+// SOL capability at all (no HostSerialConsole, no WebSocket console), so the
+// only correct outcome is a clean *redfish.SOLUnsupportedError — this proves
+// discovery (system/manager resolution, vendor classification, capability
+// reads) works against a real Redfish service without crashing or hanging,
+// not that SOL streaming itself works (that needs real hardware; see
+// docs/real-hardware-sol-runbook.md). Non-destructive: never touches virtual
+// media, boot override, or power state.
+func TestLabOpenSOLReportsUnsupported(t *testing.T) {
+	base := envOr("SHOAL_BMC_URL", "http://192.168.122.100:8001")
+	user := os.Getenv("SHOAL_BMC_USERNAME")
+	pass := os.Getenv("SHOAL_BMC_PASSWORD")
+	if user == "" || pass == "" {
+		t.Skip("SHOAL_BMC_USERNAME/PASSWORD required")
+	}
+	wantName := envOr("SHOAL_SYSTEM_NAME", "shoal-node-1")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	bmc, err := redfish.NewBMC(redfish.Config{
+		BaseURL: base, Username: user, Password: pass,
+		AuthMode: "basic", TLSMode: "off", MaxConcurrent: 1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := bmc.Open(ctx); err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = bmc.Close(context.Background()) }()
+
+	systems, err := bmc.ListSystems(ctx)
+	if err != nil || len(systems) == 0 {
+		t.Fatalf("systems: %v n=%d", err, len(systems))
+	}
+	sysID := systems[0].ID
+	for _, s := range systems {
+		if s.Name == wantName {
+			sysID = s.ID
+			break
+		}
+	}
+	t.Logf("using system id=%s", sysID)
+
+	stream, err := bmc.OpenSOL(ctx, sysID)
+	if err == nil {
+		_ = stream.Close()
+		t.Fatalf("expected SOLUnsupportedError from sushy-tools (no SOL support), got success: %+v", stream)
+	}
+	var unsupported *redfish.SOLUnsupportedError
+	if !errors.As(err, &unsupported) {
+		t.Fatalf("expected *redfish.SOLUnsupportedError, got %T: %v", err, err)
+	}
+	t.Logf("OpenSOL correctly reported unsupported: vendor=%s connect_types=%v", unsupported.Vendor, unsupported.ConnectTypes)
+	for _, step := range unsupported.Debug {
+		t.Logf("  debug: phase=%s vendor=%s ok=%v msg=%q", step.Phase, step.Vendor, step.OK, step.Message)
+	}
 }
 
 func envOr(k, d string) string {

--- a/internal/common/redfish/sol.go
+++ b/internal/common/redfish/sol.go
@@ -1,0 +1,338 @@
+package redfish
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	gofishredfish "github.com/stmcginnis/gofish/redfish"
+	"golang.org/x/crypto/ssh"
+
+	"github.com/coder/websocket"
+)
+
+// OpenSOL opens a serial-over-LAN byte stream for systemID.
+//
+// Discovery order: classify the BMC vendor (reused from screenshot.go), try
+// native Redfish/OEM WebSocket SOL candidates for recognized vendors (Dell,
+// Supermicro — unverified placeholder endpoints; see docs/real-hardware-sol-runbook.md),
+// then — only if Redfish's own capability metadata
+// (ComputerSystem.SerialConsole.SSH / Manager.SerialConsole) advertises SSH —
+// fall back to an SSH session using the ComputerSystem-provided
+// ConsoleEntryCommand when present. Raw IPMI is never attempted, and a
+// Telnet-only BMC is treated as unsupported (deferred, not implemented).
+func (c *client) OpenSOL(ctx context.Context, systemID string) (SOLStream, error) {
+	var dbg []CaptureDebugStep
+	add := func(step CaptureDebugStep) {
+		if step.At.IsZero() {
+			step.At = time.Now().UTC()
+		}
+		if len(step.BodyPreview) > 400 {
+			step.BodyPreview = step.BodyPreview[:400] + "…"
+		}
+		dbg = append(dbg, step)
+	}
+
+	api, err := c.apiClient()
+	if err != nil {
+		return SOLStream{}, err
+	}
+
+	sys, err := c.computerSystem(systemID)
+	if err != nil {
+		add(CaptureDebugStep{Phase: "detect", OK: false, Message: "get system: " + err.Error()})
+		return SOLStream{}, err
+	}
+	add(CaptureDebugStep{
+		Phase: "detect", OK: true,
+		Message: fmt.Sprintf("system id=%s name=%s manufacturer=%s model=%s", sys.ID, sys.Name, sys.Manufacturer, sys.Model),
+	})
+
+	var mgrHints []string
+	managers, mErr := api.Service.Managers()
+	if mErr != nil {
+		add(CaptureDebugStep{Phase: "detect", OK: false, Message: "list managers: " + mErr.Error()})
+	} else {
+		for _, m := range managers {
+			add(CaptureDebugStep{
+				Phase: "detect", OK: true,
+				Message: fmt.Sprintf("manager id=%s name=%s model=%s odata=%s serial_console_types=%v",
+					m.ID, m.Name, m.Model, m.ODataID, m.SerialConsole.ConnectTypesSupported),
+			})
+			mgrHints = append(mgrHints, m.Name, m.Model, m.ID)
+		}
+	}
+
+	vendor := detectVendor(append([]string{sys.Manufacturer, sys.Model}, mgrHints...)...)
+	add(CaptureDebugStep{Phase: "detect", Vendor: string(vendor), OK: true, Message: fmt.Sprintf("classified vendor=%s", vendor)})
+
+	observed := observedConnectTypes(sys.SerialConsole, managers)
+
+	if vendor == VendorDell || vendor == VendorSupermicro {
+		if stream, wsErr := c.tryWebSocketSOL(ctx, vendor, managers, add); wsErr == nil {
+			stream.Debug = dbg
+			return stream, nil
+		}
+	}
+
+	if sys.SerialConsole.SSH.ServiceEnabled {
+		if stream, sshErr := c.trySSHSOL(ctx, sys, vendor, add); sshErr == nil {
+			stream.Debug = dbg
+			return stream, nil
+		} else {
+			add(CaptureDebugStep{Phase: "probe", Vendor: string(vendor), OK: false, Message: "ssh fallback failed: " + sshErr.Error()})
+		}
+	}
+
+	add(CaptureDebugStep{
+		Phase: "probe", Vendor: string(vendor), OK: false,
+		Message: fmt.Sprintf("no supported SOL path (native WS unsupported/failed, Redfish did not advertise SSH); observed connect types: %v", observed),
+	})
+	return SOLStream{}, &SOLUnsupportedError{Vendor: vendor, ConnectTypes: observed, Debug: dbg}
+}
+
+// observedConnectTypes summarizes enabled serial-console protocols from
+// Redfish's own metadata, for reporting in SOLUnsupportedError.
+func observedConnectTypes(host gofishredfish.HostSerialConsole, managers []*gofishredfish.Manager) []string {
+	var out []string
+	if host.SSH.ServiceEnabled {
+		out = append(out, "SSH")
+	}
+	if host.Telnet.ServiceEnabled {
+		out = append(out, "Telnet")
+	}
+	if host.IPMI.ServiceEnabled {
+		out = append(out, "IPMI")
+	}
+	for _, m := range managers {
+		for _, ct := range m.SerialConsole.ConnectTypesSupported {
+			out = append(out, "Manager:"+string(ct))
+		}
+	}
+	return out
+}
+
+// --- Native WebSocket SOL (Dell, Supermicro) ---
+//
+// No vendor publishes documented, verified client-pull plain-text SOL over
+// WebSocket at time of writing; Dell iDRAC and Supermicro console redirection
+// is typically an HTML5/binary KVM protocol, not line-oriented SOL. The
+// candidates below are unverified placeholders following the same
+// probe-and-record pattern as captureDell/captureSupermicro in screenshot.go.
+// docs/real-hardware-sol-runbook.md tracks closing this gap on real hardware.
+
+func (c *client) tryWebSocketSOL(ctx context.Context, vendor VendorID, managers []*gofishredfish.Manager, add func(CaptureDebugStep)) (SOLStream, error) {
+	if !strings.EqualFold(c.cfg.AuthMode, "basic") && c.cfg.AuthMode != "" {
+		add(CaptureDebugStep{
+			Phase: "probe", Vendor: string(vendor), OK: false,
+			Message: fmt.Sprintf("websocket SOL auth for redfish_auth_mode=%q not implemented (only basic); skipping WS candidates", c.cfg.AuthMode),
+		})
+		return SOLStream{}, fmt.Errorf("redfish: websocket sol: unsupported auth mode %q", c.cfg.AuthMode)
+	}
+
+	candidates := solWSCandidates(vendor, c.cfg.BaseURL, managers)
+	if len(candidates) == 0 {
+		return SOLStream{}, fmt.Errorf("redfish: no websocket SOL candidates for vendor %q", vendor)
+	}
+
+	httpClient, err := c.httpClient()
+	if err != nil {
+		return SOLStream{}, err
+	}
+	header := http.Header{}
+	if c.cfg.Username != "" || c.cfg.Password != "" {
+		header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(c.cfg.Username+":"+c.cfg.Password)))
+	}
+
+	var lastErr error
+	for _, candURL := range candidates {
+		start := time.Now()
+		add(CaptureDebugStep{Phase: "request", Vendor: string(vendor), Method: http.MethodGet, URL: candURL, Message: "websocket SOL dial (unverified candidate)"})
+		conn, resp, dialErr := websocket.Dial(ctx, candURL, &websocket.DialOptions{
+			HTTPClient: httpClient,
+			HTTPHeader: header,
+		})
+		elapsed := time.Since(start).Milliseconds()
+		if dialErr != nil {
+			status := 0
+			if resp != nil {
+				status = resp.StatusCode
+			}
+			add(CaptureDebugStep{
+				Phase: "request", Vendor: string(vendor), Method: http.MethodGet, URL: candURL,
+				StatusCode: status, OK: false, Message: sanitizePreview(dialErr.Error()), ElapsedMS: elapsed,
+			})
+			lastErr = dialErr
+			continue
+		}
+		add(CaptureDebugStep{Phase: "request", Vendor: string(vendor), Method: http.MethodGet, URL: candURL, OK: true, Message: "websocket connected", ElapsedMS: elapsed})
+		return SOLStream{
+			ReadCloser: websocket.NetConn(context.Background(), conn, websocket.MessageText),
+			Vendor:     vendor,
+			Kind:       SOLConnectWebSocket,
+		}, nil
+	}
+	if lastErr == nil {
+		lastErr = fmt.Errorf("no candidates")
+	}
+	return SOLStream{}, fmt.Errorf("redfish: websocket sol: %w", lastErr)
+}
+
+// solWSCandidates returns unverified, best-effort candidate WebSocket SOL URLs
+// for a vendor. base is the BMC's Config.BaseURL (http(s)://host[:port]).
+func solWSCandidates(vendor VendorID, base string, managers []*gofishredfish.Manager) []string {
+	u, err := url.Parse(base)
+	if err != nil {
+		return nil
+	}
+	wsScheme := "ws"
+	if strings.EqualFold(u.Scheme, "https") {
+		wsScheme = "wss"
+	}
+	wsBase := wsScheme + "://" + u.Host
+
+	var names []string
+	for _, m := range managers {
+		names = append(names, strings.TrimSuffix(m.ODataID, "/"))
+	}
+	if len(names) == 0 {
+		names = []string{""}
+	}
+
+	var out []string
+	switch vendor {
+	case VendorDell:
+		for range names {
+			// iDRAC virtual console websocket paths observed across firmware in
+			// community tooling; not part of any public Dell API reference.
+			out = append(out,
+				wsBase+"/console",
+				wsBase+"/wsman/virtualconsole",
+			)
+		}
+	case VendorSupermicro:
+		for range names {
+			out = append(out,
+				wsBase+"/kvms/0",
+				wsBase+"/console/sol",
+			)
+		}
+	}
+	return out
+}
+
+// --- SSH fallback (Redfish-advertised only; never raw IPMI, never guessed) ---
+
+func (c *client) trySSHSOL(ctx context.Context, sys *gofishredfish.ComputerSystem, vendor VendorID, add func(CaptureDebugStep)) (SOLStream, error) {
+	proto := sys.SerialConsole.SSH
+	host, err := sshHost(c.cfg.BaseURL)
+	if err != nil {
+		add(CaptureDebugStep{Phase: "probe", Vendor: string(vendor), OK: false, Message: "resolve BMC host: " + err.Error()})
+		return SOLStream{}, err
+	}
+	port := proto.Port
+	if port <= 0 {
+		port = 22
+	}
+	addr := net.JoinHostPort(host, strconv.Itoa(port))
+
+	add(CaptureDebugStep{
+		Phase: "request", Vendor: string(vendor), Method: "SSH", URL: addr,
+		Message: fmt.Sprintf("dial SSH SOL (Redfish-advertised; console_entry_command=%q)", proto.ConsoleEntryCommand),
+	})
+
+	sshCfg := &ssh.ClientConfig{
+		User: c.cfg.Username,
+		Auth: []ssh.AuthMethod{ssh.Password(c.cfg.Password)},
+		// BMC SSH host keys are not pinned by operators today; this is a
+		// documented limitation (see docs/real-hardware-sol-runbook.md), not an
+		// oversight — Redfish itself is what authorized using SSH here.
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(), //nolint:gosec
+		Timeout:         10 * time.Second,
+	}
+
+	dialer := &net.Dialer{Timeout: sshCfg.Timeout}
+	conn, err := dialer.DialContext(ctx, "tcp", addr)
+	if err != nil {
+		add(CaptureDebugStep{Phase: "request", Vendor: string(vendor), Method: "SSH", URL: addr, OK: false, Message: err.Error()})
+		return SOLStream{}, fmt.Errorf("redfish: ssh sol dial: %w", err)
+	}
+	sshConn, chans, reqs, err := ssh.NewClientConn(conn, addr, sshCfg)
+	if err != nil {
+		_ = conn.Close()
+		add(CaptureDebugStep{Phase: "request", Vendor: string(vendor), Method: "SSH", URL: addr, OK: false, Message: err.Error()})
+		return SOLStream{}, fmt.Errorf("redfish: ssh sol handshake: %w", err)
+	}
+	cl := ssh.NewClient(sshConn, chans, reqs)
+	session, err := cl.NewSession()
+	if err != nil {
+		_ = cl.Close()
+		add(CaptureDebugStep{Phase: "request", Vendor: string(vendor), Method: "SSH", URL: addr, OK: false, Message: err.Error()})
+		return SOLStream{}, fmt.Errorf("redfish: ssh sol session: %w", err)
+	}
+	if err := session.RequestPty("vt100", 24, 80, ssh.TerminalModes{}); err != nil {
+		_ = session.Close()
+		_ = cl.Close()
+		add(CaptureDebugStep{Phase: "request", Vendor: string(vendor), Method: "SSH", URL: addr, OK: false, Message: "request pty: " + err.Error()})
+		return SOLStream{}, fmt.Errorf("redfish: ssh sol pty: %w", err)
+	}
+	stdout, err := session.StdoutPipe()
+	if err != nil {
+		_ = session.Close()
+		_ = cl.Close()
+		return SOLStream{}, fmt.Errorf("redfish: ssh sol stdout: %w", err)
+	}
+
+	if cmd := strings.TrimSpace(proto.ConsoleEntryCommand); cmd != "" {
+		err = session.Start(cmd)
+	} else {
+		err = session.Shell()
+	}
+	if err != nil {
+		_ = session.Close()
+		_ = cl.Close()
+		add(CaptureDebugStep{Phase: "request", Vendor: string(vendor), Method: "SSH", URL: addr, OK: false, Message: "start console: " + err.Error()})
+		return SOLStream{}, fmt.Errorf("redfish: ssh sol start: %w", err)
+	}
+	add(CaptureDebugStep{Phase: "request", Vendor: string(vendor), Method: "SSH", URL: addr, OK: true, Message: "ssh sol session started"})
+
+	return SOLStream{
+		ReadCloser: &sshSOLReadCloser{stdout: stdout, session: session, client: cl},
+		Vendor:     vendor,
+		Kind:       SOLConnectSSH,
+	}, nil
+}
+
+func sshHost(base string) (string, error) {
+	u, err := url.Parse(base)
+	if err != nil {
+		return "", fmt.Errorf("parse BaseURL: %w", err)
+	}
+	host := u.Hostname()
+	if host == "" {
+		return "", fmt.Errorf("BaseURL %q has no host", base)
+	}
+	return host, nil
+}
+
+// sshSOLReadCloser adapts an ssh.Session's stdout + owning session/client into
+// a single io.ReadCloser so Close() releases the whole SSH connection.
+type sshSOLReadCloser struct {
+	stdout  io.Reader
+	session *ssh.Session
+	client  *ssh.Client
+}
+
+func (r *sshSOLReadCloser) Read(p []byte) (int, error) { return r.stdout.Read(p) }
+
+func (r *sshSOLReadCloser) Close() error {
+	_ = r.session.Close()
+	return r.client.Close()
+}

--- a/internal/common/redfish/sol_test.go
+++ b/internal/common/redfish/sol_test.go
@@ -1,0 +1,376 @@
+package redfish
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"golang.org/x/crypto/ssh"
+
+	"github.com/coder/websocket"
+)
+
+// --- fake Redfish HTTP server (drives real gofish parsing, not a mock of *client) ---
+
+type fakeSOLServerOpts struct {
+	systemJSON  string // body for /redfish/v1/Systems/1
+	managerJSON string // body for /redfish/v1/Managers/1
+	wsPaths     []string
+}
+
+func newFakeSOLServer(t *testing.T, opts fakeSOLServerOpts) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/redfish/v1/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"@odata.id": "/redfish/v1/",
+			"Id": "RootService",
+			"Name": "Root Service",
+			"RedfishVersion": "1.9.0",
+			"Systems": {"@odata.id": "/redfish/v1/Systems"},
+			"Managers": {"@odata.id": "/redfish/v1/Managers"}
+		}`)
+	})
+	mux.HandleFunc("/redfish/v1/Systems", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"@odata.id": "/redfish/v1/Systems",
+			"Name": "Systems Collection",
+			"Members@odata.count": 1,
+			"Members": [{"@odata.id": "/redfish/v1/Systems/1"}]
+		}`)
+	})
+	mux.HandleFunc("/redfish/v1/Systems/1", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, opts.systemJSON)
+	})
+	mux.HandleFunc("/redfish/v1/Managers", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"@odata.id": "/redfish/v1/Managers",
+			"Name": "Managers Collection",
+			"Members@odata.count": 1,
+			"Members": [{"@odata.id": "/redfish/v1/Managers/1"}]
+		}`)
+	})
+	mux.HandleFunc("/redfish/v1/Managers/1", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		body := opts.managerJSON
+		if body == "" {
+			body = `{"@odata.id": "/redfish/v1/Managers/1", "Id": "1", "Name": "Manager"}`
+		}
+		_, _ = io.WriteString(w, body)
+	})
+	for _, p := range opts.wsPaths {
+		mux.HandleFunc(p, func(w http.ResponseWriter, r *http.Request) {
+			conn, err := websocket.Accept(w, r, nil)
+			if err != nil {
+				return
+			}
+			defer conn.Close(websocket.StatusNormalClosure, "")
+			_ = conn.Write(r.Context(), websocket.MessageText, []byte("SHOAL|1|1|2026-07-19T00:00:00Z|BOOT|1|OK|ws-hello\n"))
+			// Keep reading so the client's close-handshake frame is answered
+			// promptly instead of forcing the client to wait out its close timeout.
+			for {
+				if _, _, err := conn.Read(r.Context()); err != nil {
+					return
+				}
+			}
+		})
+	}
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func openFakeClient(t *testing.T, baseURL string) *client {
+	t.Helper()
+	bmc, err := NewBMC(Config{BaseURL: baseURL, Username: "admin", Password: "password", AuthMode: "basic"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	c := bmc.(*client)
+	if err := c.Open(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = c.Close(context.Background()) })
+	return c
+}
+
+const systemJSONNoConsole = `{
+	"@odata.id": "/redfish/v1/Systems/1",
+	"Id": "1",
+	"Name": "System.1",
+	"Manufacturer": "Shoal Virtual",
+	"Model": "sushy",
+	"PowerState": "On"
+}`
+
+func systemJSONWithHostSerialConsole(ssh, telnet, ipmi bool, sshPort int) string {
+	b := func(v bool) string {
+		if v {
+			return "true"
+		}
+		return "false"
+	}
+	return fmt.Sprintf(`{
+		"@odata.id": "/redfish/v1/Systems/1",
+		"Id": "1",
+		"Name": "System.1",
+		"Manufacturer": "Shoal Virtual",
+		"Model": "sushy",
+		"PowerState": "On",
+		"SerialConsole": {
+			"MaxConcurrentSessions": 1,
+			"SSH": {"ServiceEnabled": %s, "Port": %d},
+			"Telnet": {"ServiceEnabled": %s, "Port": 23},
+			"IPMI": {"ServiceEnabled": %s, "Port": 623}
+		}
+	}`, b(ssh), sshPort, b(telnet), b(ipmi))
+}
+
+const systemJSONDellNoConsole = `{
+	"@odata.id": "/redfish/v1/Systems/1",
+	"Id": "1",
+	"Name": "System.1",
+	"Manufacturer": "Dell Inc.",
+	"Model": "PowerEdge R640",
+	"PowerState": "On"
+}`
+
+// --- fake SSH server (proves the Redfish-advertised SSH fallback end to end) ---
+
+func startFakeSSHServer(t *testing.T, user, pass string, lines []string) int {
+	t.Helper()
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	signer, err := ssh.NewSignerFromKey(priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := &ssh.ServerConfig{
+		PasswordCallback: func(conn ssh.ConnMetadata, password []byte) (*ssh.Permissions, error) {
+			if conn.User() == user && string(password) == pass {
+				return nil, nil
+			}
+			return nil, fmt.Errorf("fake ssh: bad credentials")
+		},
+	}
+	cfg.AddHostKey(signer)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+
+	go func() {
+		for {
+			nConn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go serveFakeSSHConn(nConn, cfg, lines)
+		}
+	}()
+
+	return ln.Addr().(*net.TCPAddr).Port
+}
+
+func serveFakeSSHConn(nConn net.Conn, cfg *ssh.ServerConfig, lines []string) {
+	sConn, chans, reqs, err := ssh.NewServerConn(nConn, cfg)
+	if err != nil {
+		return
+	}
+	defer sConn.Close()
+	go ssh.DiscardRequests(reqs)
+	for newChannel := range chans {
+		if newChannel.ChannelType() != "session" {
+			_ = newChannel.Reject(ssh.UnknownChannelType, "unsupported channel type")
+			continue
+		}
+		channel, requests, err := newChannel.Accept()
+		if err != nil {
+			continue
+		}
+		go func(in <-chan *ssh.Request, ch ssh.Channel) {
+			for req := range in {
+				switch req.Type {
+				case "pty-req":
+					_ = req.Reply(true, nil)
+				case "shell", "exec":
+					_ = req.Reply(true, nil)
+					go func() {
+						for _, l := range lines {
+							_, _ = io.WriteString(ch, l+"\n")
+						}
+						_ = ch.Close()
+					}()
+				default:
+					_ = req.Reply(false, nil)
+				}
+			}
+		}(requests, channel)
+	}
+}
+
+// --- tests ---
+
+func TestOpenSOL_SSHAdvertised_Success(t *testing.T) {
+	sshLines := []string{"SHOAL|1|1|2026-07-19T00:00:00Z|BOOT|1|OK|ssh-hello"}
+	sshPort := startFakeSSHServer(t, "admin", "password", sshLines)
+
+	srv := newFakeSOLServer(t, fakeSOLServerOpts{
+		systemJSON: systemJSONWithHostSerialConsole(true, false, false, sshPort),
+	})
+	c := openFakeClient(t, srv.URL)
+
+	stream, err := c.OpenSOL(context.Background(), "1")
+	if err != nil {
+		t.Fatalf("OpenSOL: %v", err)
+	}
+	defer stream.Close()
+	if stream.Kind != SOLConnectSSH {
+		t.Fatalf("kind = %q, want ssh", stream.Kind)
+	}
+
+	buf := make([]byte, 4096)
+	n, _ := io.ReadFull(stream, buf[:len(sshLines[0])+1])
+	got := string(buf[:n])
+	if !strings.Contains(got, "ssh-hello") {
+		t.Fatalf("stream content = %q, want it to contain %q", got, "ssh-hello")
+	}
+}
+
+func TestOpenSOL_IPMIOnly_Unsupported(t *testing.T) {
+	srv := newFakeSOLServer(t, fakeSOLServerOpts{
+		systemJSON: systemJSONWithHostSerialConsole(false, false, true, 623),
+	})
+	c := openFakeClient(t, srv.URL)
+
+	_, err := c.OpenSOL(context.Background(), "1")
+	if err == nil {
+		t.Fatal("expected unsupported error for IPMI-only BMC")
+	}
+	var unsupported *SOLUnsupportedError
+	if !errors.As(err, &unsupported) {
+		t.Fatalf("expected *SOLUnsupportedError, got %T: %v", err, err)
+	}
+	found := false
+	for _, ct := range unsupported.ConnectTypes {
+		if ct == "IPMI" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("ConnectTypes = %v, want it to include IPMI", unsupported.ConnectTypes)
+	}
+}
+
+func TestOpenSOL_TelnetOnly_Unsupported(t *testing.T) {
+	srv := newFakeSOLServer(t, fakeSOLServerOpts{
+		systemJSON: systemJSONWithHostSerialConsole(false, true, false, 23),
+	})
+	c := openFakeClient(t, srv.URL)
+
+	_, err := c.OpenSOL(context.Background(), "1")
+	if err == nil {
+		t.Fatal("expected unsupported error for Telnet-only BMC (deferred, not implemented)")
+	}
+	var unsupported *SOLUnsupportedError
+	if !errors.As(err, &unsupported) {
+		t.Fatalf("expected *SOLUnsupportedError, got %T: %v", err, err)
+	}
+}
+
+func TestOpenSOL_NoConsole_Unsupported(t *testing.T) {
+	srv := newFakeSOLServer(t, fakeSOLServerOpts{systemJSON: systemJSONNoConsole})
+	c := openFakeClient(t, srv.URL)
+
+	_, err := c.OpenSOL(context.Background(), "1")
+	var unsupported *SOLUnsupportedError
+	if !errors.As(err, &unsupported) {
+		t.Fatalf("expected *SOLUnsupportedError, got %T: %v", err, err)
+	}
+	if unsupported.Vendor != VendorUnknown {
+		t.Fatalf("vendor = %q, want unknown", unsupported.Vendor)
+	}
+}
+
+func TestOpenSOL_WebSocketDell_Success(t *testing.T) {
+	srv := newFakeSOLServer(t, fakeSOLServerOpts{
+		systemJSON: systemJSONDellNoConsole,
+		wsPaths:    []string{"/console"},
+	})
+	c := openFakeClient(t, srv.URL)
+
+	stream, err := c.OpenSOL(context.Background(), "1")
+	if err != nil {
+		t.Fatalf("OpenSOL: %v", err)
+	}
+	defer stream.Close()
+	if stream.Kind != SOLConnectWebSocket {
+		t.Fatalf("kind = %q, want websocket", stream.Kind)
+	}
+	if stream.Vendor != VendorDell {
+		t.Fatalf("vendor = %q, want dell", stream.Vendor)
+	}
+
+	buf := make([]byte, 256)
+	n, err := stream.Read(buf)
+	if err != nil && n == 0 {
+		t.Fatalf("read: %v", err)
+	}
+	if !strings.Contains(string(buf[:n]), "ws-hello") {
+		t.Fatalf("stream content = %q, want it to contain ws-hello", string(buf[:n]))
+	}
+}
+
+func TestOpenSOL_WebSocketCandidatesFail_Unsupported(t *testing.T) {
+	// Dell vendor but no WS handler registered at any candidate path (404s),
+	// and no SSH advertised either -> unsupported, proving the fallthrough.
+	srv := newFakeSOLServer(t, fakeSOLServerOpts{systemJSON: systemJSONDellNoConsole})
+	c := openFakeClient(t, srv.URL)
+
+	_, err := c.OpenSOL(context.Background(), "1")
+	var unsupported *SOLUnsupportedError
+	if !errors.As(err, &unsupported) {
+		t.Fatalf("expected *SOLUnsupportedError, got %T: %v", err, err)
+	}
+	if unsupported.Vendor != VendorDell {
+		t.Fatalf("vendor = %q, want dell", unsupported.Vendor)
+	}
+}
+
+func TestOpenSOL_DebugTrailRedactsSecrets(t *testing.T) {
+	srv := newFakeSOLServer(t, fakeSOLServerOpts{
+		systemJSON: systemJSONWithHostSerialConsole(false, false, true, 623),
+	})
+	c := openFakeClient(t, srv.URL)
+
+	_, err := c.OpenSOL(context.Background(), "1")
+	var unsupported *SOLUnsupportedError
+	if !errors.As(err, &unsupported) {
+		t.Fatalf("expected *SOLUnsupportedError, got %T: %v", err, err)
+	}
+	for _, step := range unsupported.Debug {
+		if strings.Contains(strings.ToLower(step.Message), "password") ||
+			strings.Contains(strings.ToLower(step.BodyPreview), "password") {
+			t.Fatalf("debug step leaked a password-like value: %+v", step)
+		}
+	}
+	if !strings.Contains(err.Error(), "IPMI") {
+		t.Fatalf("error text = %q, want it to mention observed IPMI connect type", err.Error())
+	}
+}

--- a/internal/common/validate/validate.go
+++ b/internal/common/validate/validate.go
@@ -216,8 +216,16 @@ func StartJobRequest(r models.StartJobRequest) error {
 	strategy := strings.TrimSpace(r.InstallStrategy)
 	operatorISO := strategy == models.InstallStrategyOperatorISO
 	scriptedISO := strategy == models.InstallStrategyScriptedISO
-	// Coarse progress strategies may omit serial (operator_iso / scripted_iso).
-	if strings.TrimSpace(r.SerialTarget) == "" && !operatorISO && !scriptedISO {
+	serialTransport := strings.TrimSpace(r.SerialTransport)
+	switch serialTransport {
+	case "", "libvirt", "redfish_sol":
+	default:
+		return fmt.Errorf("validate: unknown serial_transport %q", serialTransport)
+	}
+	redfishSOL := serialTransport == "redfish_sol"
+	// Coarse progress strategies may omit serial (operator_iso / scripted_iso), as may
+	// redfish_sol (target is derived from bmc_endpoint, not serial_target).
+	if strings.TrimSpace(r.SerialTarget) == "" && !operatorISO && !scriptedISO && !redfishSOL {
 		return fmt.Errorf("validate: serial_target is required")
 	}
 	hasUserPass := r.BMCUsername != "" || r.BMCPassword != ""

--- a/internal/deploy/job/orchestrator.go
+++ b/internal/deploy/job/orchestrator.go
@@ -52,21 +52,22 @@ const (
 
 // Orchestrator owns lifecycle transitions, BMC actions, and cleanup.
 type Orchestrator struct {
-	log           *slog.Logger
-	store         jobstore.Store
-	secrets       secrets.Backend
-	newBMC        redfish.Factory
-	watches       watchport.WatchRegistrar
-	netbox        netbox.LifecycleWriter // optional; identity lifecycle only
-	profiles      profile.Store          // optional; Phase 5b approval gate
-	isoBaseURL    string                 // Phase 5c: resolve profile iso_base → URL
-	isoBuilder    iso.Builder            // optional Phase 6a dynamic build
-	isoPublishDir string
-	isoDynamic    bool // SHOAL_ISO_DYNAMIC: build when ISOURL empty + publish configured
-	authMode      string
-	tlsMode       string
-	caFile        string
-	failOrphan    bool
+	log                    *slog.Logger
+	store                  jobstore.Store
+	secrets                secrets.Backend
+	newBMC                 redfish.Factory
+	watches                watchport.WatchRegistrar
+	netbox                 netbox.LifecycleWriter // optional; identity lifecycle only
+	profiles               profile.Store          // optional; Phase 5b approval gate
+	isoBaseURL             string                 // Phase 5c: resolve profile iso_base → URL
+	isoBuilder             iso.Builder            // optional Phase 6a dynamic build
+	isoPublishDir          string
+	isoDynamic             bool // SHOAL_ISO_DYNAMIC: build when ISOURL empty + publish configured
+	authMode               string
+	tlsMode                string
+	caFile                 string
+	failOrphan             bool
+	defaultSerialTransport string
 
 	mu       sync.Mutex
 	running  map[string]*runState // jobID -> state
@@ -130,6 +131,10 @@ type Options struct {
 	TLSMode             string
 	CAFile              string
 	ReconcileFailOrphan bool
+	// DefaultSerialTransport is the orchestrator-wide serial transport
+	// ("libvirt" | "redfish_sol") used when StartJobRequest.SerialTransport is
+	// empty. Empty here means "libvirt" (unchanged behavior).
+	DefaultSerialTransport string
 }
 
 // NewOrchestrator constructs an Orchestrator and starts the terminal worker.
@@ -150,24 +155,25 @@ func NewOrchestrator(opts Options) *Orchestrator {
 		tlsMode = "off"
 	}
 	o := &Orchestrator{
-		log:           log,
-		store:         opts.Store,
-		secrets:       opts.Secrets,
-		newBMC:        opts.NewBMC,
-		watches:       opts.Watches,
-		netbox:        opts.NetBox,
-		profiles:      opts.Profiles,
-		isoBaseURL:    opts.ISOBaseURL,
-		isoBuilder:    opts.ISOBuilder,
-		isoPublishDir: opts.ISOPublishDir,
-		isoDynamic:    opts.ISODynamic,
-		authMode:      auth,
-		tlsMode:       tlsMode,
-		caFile:        opts.CAFile,
-		failOrphan:    opts.ReconcileFailOrphan, // composition root passes config default true
-		running:       make(map[string]*runState),
-		terminal:      make(chan terminalEvent, 64),
-		stopCh:        make(chan struct{}),
+		log:                    log,
+		store:                  opts.Store,
+		secrets:                opts.Secrets,
+		newBMC:                 opts.NewBMC,
+		watches:                opts.Watches,
+		netbox:                 opts.NetBox,
+		profiles:               opts.Profiles,
+		isoBaseURL:             opts.ISOBaseURL,
+		isoBuilder:             opts.ISOBuilder,
+		isoPublishDir:          opts.ISOPublishDir,
+		isoDynamic:             opts.ISODynamic,
+		authMode:               auth,
+		tlsMode:                tlsMode,
+		caFile:                 opts.CAFile,
+		failOrphan:             opts.ReconcileFailOrphan, // composition root passes config default true
+		defaultSerialTransport: opts.DefaultSerialTransport,
+		running:                make(map[string]*runState),
+		terminal:               make(chan terminalEvent, 64),
+		stopCh:                 make(chan struct{}),
 	}
 	o.wg.Add(1)
 	go o.terminalLoop()
@@ -551,29 +557,46 @@ func (o *Orchestrator) startStage(ctx context.Context, job models.ProvisioningJo
 		_ = o.store.UpdateRuntime(ctx, job.ID, sys.ID, sessionID, rs.credential)
 	}
 
+	transport := o.resolveSerialTransport(req)
 	serialTarget := strings.TrimSpace(req.SerialTarget)
-	if serialTarget != "" {
+	target := serialTarget
+	redfishSystemID := ""
+	credRef := ""
+	switch transport {
+	case "redfish_sol":
+		target = req.BMCEndpoint
+		redfishSystemID = sys.ID
+		credRef = rs.credential
+	case "libvirt", "":
+		if serialTarget == "" && !coarse {
+			_ = bmc.CleanupMediaAndBoot(ctx, sys.ID)
+			return fmt.Errorf("serial_target is required for marker-based stages")
+		}
+	default:
+		_ = bmc.CleanupMediaAndBoot(ctx, sys.ID)
+		return fmt.Errorf("job: unsupported serial_transport %q", transport)
+	}
+	if target != "" {
 		stall := rs.stallTimeout
 		if stall <= 0 {
 			stall = DefaultSOLStall
 		}
 		session := models.WatchSession{
-			ID:            sessionID,
-			JobID:         job.ID,
-			DeviceID:      req.DeviceID,
-			Transport:     "libvirt",
-			Target:        serialTarget,
-			StartedAt:     time.Now().UTC(),
-			StallTimeout:  stall,
-			StallDisabled: coarse,
+			ID:              sessionID,
+			JobID:           job.ID,
+			DeviceID:        req.DeviceID,
+			Transport:       transport,
+			Target:          target,
+			RedfishSystemID: redfishSystemID,
+			CredentialRef:   credRef,
+			StartedAt:       time.Now().UTC(),
+			StallTimeout:    stall,
+			StallDisabled:   coarse,
 		}
 		if err := o.watches.Register(ctx, session); err != nil {
 			_ = bmc.CleanupMediaAndBoot(ctx, sys.ID)
 			return fmt.Errorf("register watch: %w", err)
 		}
-	} else if !coarse {
-		_ = bmc.CleanupMediaAndBoot(ctx, sys.ID)
-		return fmt.Errorf("serial_target is required for marker-based stages")
 	}
 	rs.stageStarted = time.Now().UTC()
 	rs.solReopens = 0
@@ -653,6 +676,20 @@ func (o *Orchestrator) armCoarseDeadline(jobID string, rs *runState, deadline ti
 func intPtr(n int) *int { return &n }
 
 // reopenSOL re-registers the SOL watch after an early stream drop (stage handoff).
+// resolveSerialTransport picks the serial transport for a job: the per-job
+// StartJobRequest.SerialTransport override wins when set, else the
+// orchestrator-wide default (Options.DefaultSerialTransport /
+// SHOAL_SERIAL_TRANSPORT), else "libvirt" (unchanged existing behavior).
+func (o *Orchestrator) resolveSerialTransport(req models.StartJobRequest) string {
+	if t := strings.TrimSpace(req.SerialTransport); t != "" {
+		return t
+	}
+	if o.defaultSerialTransport != "" {
+		return o.defaultSerialTransport
+	}
+	return "libvirt"
+}
+
 func (o *Orchestrator) reopenSOL(jobID string) {
 	o.mu.Lock()
 	rs := o.running[jobID]
@@ -683,14 +720,25 @@ func (o *Orchestrator) reopenSOL(jobID string) {
 	if stall <= 0 {
 		stall = DefaultSOLStall
 	}
+	transport := o.resolveSerialTransport(rs.req)
+	target := rs.serialTarget
+	redfishSystemID := ""
+	credRef := ""
+	if transport == "redfish_sol" {
+		target = rs.bmcURL
+		redfishSystemID = rs.systemID
+		credRef = rs.credential
+	}
 	session := models.WatchSession{
-		ID:           sessionID,
-		JobID:        jobID,
-		DeviceID:     rs.deviceID,
-		Transport:    "libvirt",
-		Target:       rs.serialTarget,
-		StartedAt:    time.Now().UTC(),
-		StallTimeout: stall,
+		ID:              sessionID,
+		JobID:           jobID,
+		DeviceID:        rs.deviceID,
+		Transport:       transport,
+		Target:          target,
+		RedfishSystemID: redfishSystemID,
+		CredentialRef:   credRef,
+		StartedAt:       time.Now().UTC(),
+		StallTimeout:    stall,
 	}
 	if err := o.watches.Register(context.Background(), session); err != nil {
 		o.log.Error("sol reopen failed", "job_id", jobID, "err", err.Error())

--- a/internal/deploy/job/redfish_sol_wiring_test.go
+++ b/internal/deploy/job/redfish_sol_wiring_test.go
@@ -1,0 +1,204 @@
+package job_test
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"sync"
+	"testing"
+
+	"github.com/mattcburns/shoal/internal/common/models"
+	"github.com/mattcburns/shoal/internal/common/netbox"
+	"github.com/mattcburns/shoal/internal/common/redfish"
+	"github.com/mattcburns/shoal/internal/common/secrets"
+	"github.com/mattcburns/shoal/internal/deploy/job"
+	"github.com/mattcburns/shoal/internal/deploy/jobstore"
+)
+
+// recordingWatch is a watchport.WatchRegistrar that records the last
+// WatchSession passed to Register instead of opening a real transport — it
+// isolates "did the orchestrator build the right session fields" from SOL
+// transport/marker plumbing, which is covered separately in internal/observe/sol.
+type recordingWatch struct {
+	mu      sync.Mutex
+	last    models.WatchSession
+	regErr  error
+	regHits int
+}
+
+func (r *recordingWatch) Register(_ context.Context, session models.WatchSession) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.last = session
+	r.regHits++
+	return r.regErr
+}
+
+func (r *recordingWatch) Unregister(_ context.Context, _ string) error { return nil }
+
+func (r *recordingWatch) lastSession() models.WatchSession {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.last
+}
+
+func newRedfishSOLTestFixtures(t *testing.T) (*jobstore.Memory, *secrets.Memory, *redfish.Fake, *netbox.Memory, *slog.Logger) {
+	t.Helper()
+	store := jobstore.NewMemory()
+	sec := secrets.NewMemory()
+	fakeBMC := redfish.NewFake()
+	nb := netbox.NewMemory()
+	ctx := context.Background()
+	_, _ = nb.UpsertDevice(ctx, models.DeviceIdentity{
+		Serial: "lab-node-1", LifecycleState: models.StateDiscovered,
+	})
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	return store, sec, fakeBMC, nb, log
+}
+
+// TestOrchestratorRedfishSOLTransportSelectedPerJob proves a per-job
+// StartJobRequest.SerialTransport="redfish_sol" override produces a
+// WatchSession with Transport/Target/RedfishSystemID/CredentialRef wired from
+// req.BMCEndpoint + the resolved system id + the job's credential ref —
+// never "libvirt", never a raw password.
+func TestOrchestratorRedfishSOLTransportSelectedPerJob(t *testing.T) {
+	ctx := context.Background()
+	store, sec, fakeBMC, nb, log := newRedfishSOLTestFixtures(t)
+	watch := &recordingWatch{}
+
+	orch := job.NewOrchestrator(job.Options{
+		Log:     log,
+		Store:   store,
+		Secrets: sec,
+		NewBMC: func(cfg redfish.Config) (redfish.BMC, error) {
+			return fakeBMC, nil
+		},
+		Watches:             watch,
+		NetBox:              nb,
+		AuthMode:            "basic",
+		TLSMode:             "off",
+		ReconcileFailOrphan: true,
+	})
+	defer orch.Stop()
+
+	_, err := orch.Start(ctx, models.StartJobRequest{
+		DeviceID:        "lab-node-1",
+		BMCEndpoint:     "http://bmc.test",
+		BMCUsername:     "admin",
+		BMCPassword:     "secret",
+		SerialTransport: "redfish_sol",
+		ISOURL:          "http://iso/shoal-marker.iso",
+	})
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+
+	session := watch.lastSession()
+	if session.Transport != "redfish_sol" {
+		t.Fatalf("transport = %q, want redfish_sol", session.Transport)
+	}
+	if session.Target != "http://bmc.test" {
+		t.Fatalf("target = %q, want bmc_endpoint", session.Target)
+	}
+	if session.RedfishSystemID == "" {
+		t.Fatal("expected RedfishSystemID to be set from the resolved system")
+	}
+	if session.CredentialRef == "" {
+		t.Fatal("expected CredentialRef to be set (never a raw password)")
+	}
+}
+
+// TestOrchestratorRedfishSOLTransportSelectedByDefault proves the
+// orchestrator-wide Options.DefaultSerialTransport applies when a job doesn't
+// override it, and that "libvirt" remains the fallback when neither is set.
+func TestOrchestratorRedfishSOLTransportSelectedByDefault(t *testing.T) {
+	ctx := context.Background()
+	store, sec, fakeBMC, nb, log := newRedfishSOLTestFixtures(t)
+	watch := &recordingWatch{}
+
+	orch := job.NewOrchestrator(job.Options{
+		Log:     log,
+		Store:   store,
+		Secrets: sec,
+		NewBMC: func(cfg redfish.Config) (redfish.BMC, error) {
+			return fakeBMC, nil
+		},
+		Watches:                watch,
+		NetBox:                 nb,
+		AuthMode:               "basic",
+		TLSMode:                "off",
+		ReconcileFailOrphan:    true,
+		DefaultSerialTransport: "redfish_sol",
+	})
+	defer orch.Stop()
+
+	_, err := orch.Start(ctx, models.StartJobRequest{
+		DeviceID:    "lab-node-1",
+		BMCEndpoint: "http://bmc.test",
+		BMCUsername: "admin",
+		BMCPassword: "secret",
+		// validate.StartJobRequest cannot see Options.DefaultSerialTransport (it
+		// only validates the request itself), so serial_target is still required
+		// here even though the orchestrator will end up ignoring it in favor of
+		// bmc_endpoint — this is the documented v1 tradeoff (safe/explicit over
+		// clever; see docs/real-hardware-sol-runbook.md). No per-job
+		// SerialTransport override is set; the config default should still win.
+		SerialTarget: "lab-node-1",
+		ISOURL:       "http://iso/shoal-marker.iso",
+	})
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+
+	session := watch.lastSession()
+	if session.Transport != "redfish_sol" {
+		t.Fatalf("transport = %q, want redfish_sol (from Options.DefaultSerialTransport)", session.Transport)
+	}
+	if session.Target != "http://bmc.test" {
+		t.Fatalf("target = %q, want bmc_endpoint (serial_target must be ignored for redfish_sol)", session.Target)
+	}
+}
+
+// TestOrchestratorSerialTransportDefaultsToLibvirt proves that with neither a
+// per-job override nor a config default, behavior is unchanged from before
+// this feature existed.
+func TestOrchestratorSerialTransportDefaultsToLibvirt(t *testing.T) {
+	ctx := context.Background()
+	store, sec, fakeBMC, nb, log := newRedfishSOLTestFixtures(t)
+	watch := &recordingWatch{}
+
+	orch := job.NewOrchestrator(job.Options{
+		Log:     log,
+		Store:   store,
+		Secrets: sec,
+		NewBMC: func(cfg redfish.Config) (redfish.BMC, error) {
+			return fakeBMC, nil
+		},
+		Watches:             watch,
+		NetBox:              nb,
+		AuthMode:            "basic",
+		TLSMode:             "off",
+		ReconcileFailOrphan: true,
+	})
+	defer orch.Stop()
+
+	_, err := orch.Start(ctx, models.StartJobRequest{
+		DeviceID:     "lab-node-1",
+		BMCEndpoint:  "http://bmc.test",
+		BMCUsername:  "admin",
+		BMCPassword:  "secret",
+		SerialTarget: "lab-node-1",
+		ISOURL:       "http://iso/shoal-marker.iso",
+	})
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+
+	session := watch.lastSession()
+	if session.Transport != "libvirt" {
+		t.Fatalf("transport = %q, want libvirt (default unchanged)", session.Transport)
+	}
+	if session.Target != "lab-node-1" {
+		t.Fatalf("target = %q, want serial_target", session.Target)
+	}
+}

--- a/internal/observe/sol/factory.go
+++ b/internal/observe/sol/factory.go
@@ -1,0 +1,50 @@
+package sol
+
+import (
+	"fmt"
+
+	"github.com/mattcburns/shoal/internal/common/models"
+	"github.com/mattcburns/shoal/internal/common/redfish"
+	"github.com/mattcburns/shoal/internal/common/secrets"
+)
+
+// RedfishSOLConfig configures the native Redfish SOL transport shared across
+// all watch sessions (per-job data — BMC URL, system id, credential ref —
+// comes from the WatchSession itself).
+type RedfishSOLConfig struct {
+	NewBMC   redfish.Factory // e.g. redfish.NewBMC
+	Secrets  secrets.Backend // resolves WatchSession.CredentialRef
+	AuthMode string          // mirrors Config.RedfishAuthMode
+	TLSMode  string          // mirrors Config.RedfishTLSMode
+	CAFile   string          // mirrors Config.RedfishCAFile
+}
+
+// NewCombinedTransportFactory dispatches on session.Transport:
+//   - "redfish_sol": native Redfish SOL (WebSocket, or SSH iff Redfish's own
+//     capability metadata advertised it). Never IPMI.
+//   - "libvirt", "": existing SSH/local libvirt tailing (delegates to
+//     NewTransportFactory(sshCfg)).
+//   - anything else (including the legacy "ipmi_sol"): a transport whose
+//     Open() always errors — no silent fallback to libvirt, and raw IPMI is
+//     never attempted.
+func NewCombinedTransportFactory(rfCfg RedfishSOLConfig, sshCfg SSHSerialConfig) func(models.WatchSession) Transport {
+	sshFactory := NewTransportFactory(sshCfg)
+	return func(session models.WatchSession) Transport {
+		switch session.Transport {
+		case "redfish_sol":
+			return &RedfishTransport{
+				NewBMC:        rfCfg.NewBMC,
+				AuthMode:      rfCfg.AuthMode,
+				TLSMode:       rfCfg.TLSMode,
+				CAFile:        rfCfg.CAFile,
+				SystemID:      session.RedfishSystemID,
+				Secrets:       rfCfg.Secrets,
+				CredentialRef: session.CredentialRef,
+			}
+		case "libvirt", "":
+			return sshFactory(session)
+		default:
+			return &errorTransport{err: fmt.Errorf("sol: unsupported serial transport %q", session.Transport)}
+		}
+	}
+}

--- a/internal/observe/sol/factory_test.go
+++ b/internal/observe/sol/factory_test.go
@@ -1,0 +1,88 @@
+package sol_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/mattcburns/shoal/internal/common/models"
+	"github.com/mattcburns/shoal/internal/common/redfish"
+	"github.com/mattcburns/shoal/internal/common/secrets"
+	"github.com/mattcburns/shoal/internal/observe/sol"
+)
+
+func TestCombinedTransportFactoryDispatch(t *testing.T) {
+	rfCfg := sol.RedfishSOLConfig{
+		NewBMC:  func(redfish.Config) (redfish.BMC, error) { return redfish.NewFake(), nil },
+		Secrets: secrets.NewMemory(),
+	}
+	sshCfg := sol.SSHSerialConfig{} // empty Host => local libvirt path
+
+	factory := sol.NewCombinedTransportFactory(rfCfg, sshCfg)
+
+	t.Run("redfish_sol dispatches to RedfishTransport", func(t *testing.T) {
+		tr := factory(models.WatchSession{Transport: "redfish_sol", Target: "http://bmc"})
+		if _, ok := tr.(*sol.RedfishTransport); !ok {
+			t.Fatalf("got %T, want *sol.RedfishTransport", tr)
+		}
+	})
+
+	t.Run("libvirt dispatches to local LibvirtTransport (no ssh host configured)", func(t *testing.T) {
+		tr := factory(models.WatchSession{Transport: "libvirt", Target: "domain-1"})
+		if _, ok := tr.(*sol.LibvirtTransport); !ok {
+			t.Fatalf("got %T, want *sol.LibvirtTransport", tr)
+		}
+	})
+
+	t.Run("empty transport dispatches to local LibvirtTransport", func(t *testing.T) {
+		tr := factory(models.WatchSession{Target: "domain-1"})
+		if _, ok := tr.(*sol.LibvirtTransport); !ok {
+			t.Fatalf("got %T, want *sol.LibvirtTransport", tr)
+		}
+	})
+
+	t.Run("unknown transport errors, never falls back to libvirt", func(t *testing.T) {
+		tr := factory(models.WatchSession{Transport: "bogus", Target: "x"})
+		if _, ok := tr.(*sol.LibvirtTransport); ok {
+			t.Fatal("unknown transport must not silently become LibvirtTransport")
+		}
+		_, err := tr.Open(context.Background(), "x")
+		if err == nil {
+			t.Fatal("expected Open to error for unknown transport")
+		}
+	})
+
+	t.Run("legacy ipmi_sol errors, never attempts raw IPMI or libvirt", func(t *testing.T) {
+		tr := factory(models.WatchSession{Transport: "ipmi_sol", Target: "x"})
+		if _, ok := tr.(*sol.LibvirtTransport); ok {
+			t.Fatal("ipmi_sol must not silently become LibvirtTransport")
+		}
+		if _, ok := tr.(*sol.RedfishTransport); ok {
+			t.Fatal("ipmi_sol must not be routed to the Redfish transport")
+		}
+		_, err := tr.Open(context.Background(), "x")
+		if err == nil {
+			t.Fatal("expected Open to error for ipmi_sol")
+		}
+	})
+}
+
+// TestCombinedTransportFactorySSHHost proves the libvirt/SSH dispatch still
+// honors an SSH delegate host, matching NewTransportFactory's own contract.
+func TestCombinedTransportFactorySSHHost(t *testing.T) {
+	rfCfg := sol.RedfishSOLConfig{
+		NewBMC: func(redfish.Config) (redfish.BMC, error) { return redfish.NewFake(), nil },
+	}
+	sshCfg := sol.SSHSerialConfig{Host: "lab-host"}
+	factory := sol.NewCombinedTransportFactory(rfCfg, sshCfg)
+
+	tr := factory(models.WatchSession{Transport: "libvirt", Target: "domain-1"})
+	if _, ok := tr.(*sol.SSHLibvirtTransport); !ok {
+		t.Fatalf("got %T, want *sol.SSHLibvirtTransport", tr)
+	}
+
+	// Absolute path targets always stay local regardless of configured SSH host.
+	tr2 := factory(models.WatchSession{Transport: "libvirt", Target: "/dev/pts/3"})
+	if _, ok := tr2.(*sol.LibvirtTransport); !ok {
+		t.Fatalf("got %T, want *sol.LibvirtTransport for absolute path target", tr2)
+	}
+}

--- a/internal/observe/sol/redfish_transport.go
+++ b/internal/observe/sol/redfish_transport.go
@@ -1,0 +1,134 @@
+package sol
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/mattcburns/shoal/internal/common/redfish"
+	"github.com/mattcburns/shoal/internal/common/secrets"
+)
+
+// RedfishTransport implements Transport over redfish.BMC.OpenSOL. It opens its
+// own short-lived BMC session distinct from any BMC the orchestrator already
+// holds open for virtual media/power — discovery happens entirely inside
+// OpenSOL, so only the resulting WS/SSH stream is held for the life of the
+// watch, minimizing pressure on real-BMC concurrent-session limits.
+//
+// Credentials are never resolved until Open(ctx, ...) so the lookup can be
+// bound to the caller's context; WatchSession/RedfishTransport only ever
+// carry the opaque CredentialRef, never a raw password (Golden Rule 3).
+type RedfishTransport struct {
+	NewBMC   redfish.Factory
+	AuthMode string
+	TLSMode  string
+	CAFile   string
+	SystemID string
+
+	// Secrets resolves CredentialRef into a username/password at Open time.
+	Secrets       secrets.Backend
+	CredentialRef string
+
+	mu     sync.Mutex
+	bmc    redfish.BMC
+	stream redfish.SOLStream
+	cancel context.CancelFunc
+}
+
+// Open dials target (a Redfish BMC base URL), opens the SOL stream for
+// SystemID via redfish.BMC.OpenSOL, and adapts the raw byte stream into a
+// line channel using the same bufio.Scanner pattern as LibvirtTransport.Open.
+func (t *RedfishTransport) Open(ctx context.Context, target string) (<-chan string, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if target == "" {
+		return nil, fmt.Errorf("sol: empty redfish BMC target")
+	}
+	if t.NewBMC == nil {
+		return nil, fmt.Errorf("sol: redfish transport missing NewBMC factory")
+	}
+
+	var cred secrets.Credential
+	if t.CredentialRef != "" {
+		if t.Secrets == nil {
+			return nil, fmt.Errorf("sol: redfish transport has credential_ref but no secrets backend")
+		}
+		var err error
+		cred, err = t.Secrets.Get(ctx, t.CredentialRef)
+		if err != nil {
+			return nil, fmt.Errorf("sol: redfish transport: resolve credential_ref: %w", err)
+		}
+	}
+
+	bmc, err := t.NewBMC(redfish.Config{
+		BaseURL:  target,
+		Username: cred.Username,
+		Password: cred.Password,
+		AuthMode: t.AuthMode,
+		TLSMode:  t.TLSMode,
+		CAFile:   t.CAFile,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("sol: redfish transport: new bmc: %w", err)
+	}
+	if err := bmc.Open(ctx); err != nil {
+		return nil, fmt.Errorf("sol: redfish transport: open bmc: %w", err)
+	}
+
+	stream, err := bmc.OpenSOL(ctx, t.SystemID)
+	if err != nil {
+		_ = bmc.Close(context.Background())
+		return nil, fmt.Errorf("sol: redfish transport: open sol: %w", err)
+	}
+
+	t.bmc = bmc
+	t.stream = stream
+	scanCtx, cancel := context.WithCancel(ctx)
+	t.cancel = cancel
+
+	ch := make(chan string, 32)
+	go func() {
+		defer close(ch)
+		sc := bufio.NewScanner(stream)
+		buf := make([]byte, 0, 64*1024)
+		sc.Buffer(buf, 1024*1024)
+		for sc.Scan() {
+			select {
+			case <-scanCtx.Done():
+				return
+			case ch <- sc.Text():
+			}
+		}
+	}()
+	return ch, nil
+}
+
+// Close cancels the scan loop and releases the SOL stream and BMC session.
+// Both releases are best-effort so Close never blocks past what the
+// underlying stream/BMC implementation itself takes (WatchService.Unregister
+// bounds the caller-side wait separately).
+func (t *RedfishTransport) Close() error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.cancel != nil {
+		t.cancel()
+		t.cancel = nil
+	}
+	var firstErr error
+	if t.stream.ReadCloser != nil {
+		if err := t.stream.Close(); err != nil {
+			firstErr = err
+		}
+		t.stream = redfish.SOLStream{}
+	}
+	if t.bmc != nil {
+		if err := t.bmc.Close(context.Background()); err != nil && firstErr == nil {
+			firstErr = err
+		}
+		t.bmc = nil
+	}
+	return firstErr
+}
+
+var _ Transport = (*RedfishTransport)(nil)

--- a/internal/observe/sol/redfish_transport_test.go
+++ b/internal/observe/sol/redfish_transport_test.go
@@ -1,0 +1,125 @@
+package sol_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/mattcburns/shoal/internal/common/redfish"
+	"github.com/mattcburns/shoal/internal/observe/sol"
+)
+
+func TestRedfishTransportOpenReadsLines(t *testing.T) {
+	fake := redfish.NewFake()
+	fake.SOLStream = redfish.NewFakeSOLLines(redfish.SOLConnectSSH,
+		"SHOAL|1|1|2026-07-19T00:00:00Z|BOOT|1|OK|hi",
+		"SHOAL|1|2|2026-07-19T00:00:01Z|DONE|100|OK|bye",
+	)
+
+	tr := &sol.RedfishTransport{
+		NewBMC:   func(redfish.Config) (redfish.BMC, error) { return fake, nil },
+		SystemID: "1",
+	}
+
+	lines, err := tr.Open(context.Background(), "http://127.0.0.1:9999")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+
+	var got []string
+	deadline := time.After(2 * time.Second)
+	for i := 0; i < 2; i++ {
+		select {
+		case l, ok := <-lines:
+			if !ok {
+				t.Fatal("channel closed early")
+			}
+			got = append(got, l)
+		case <-deadline:
+			t.Fatal("timed out waiting for lines")
+		}
+	}
+	if got[0] != "SHOAL|1|1|2026-07-19T00:00:00Z|BOOT|1|OK|hi" {
+		t.Fatalf("line 0 = %q", got[0])
+	}
+	if err := tr.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+}
+
+func TestRedfishTransportOpenSurfacesNewBMCError(t *testing.T) {
+	tr := &sol.RedfishTransport{
+		NewBMC:   func(redfish.Config) (redfish.BMC, error) { return nil, fmt.Errorf("boom") },
+		SystemID: "1",
+	}
+	if _, err := tr.Open(context.Background(), "http://127.0.0.1:9999"); err == nil {
+		t.Fatal("expected error from NewBMC failure")
+	}
+}
+
+func TestRedfishTransportOpenSurfacesOpenSOLError(t *testing.T) {
+	fake := redfish.NewFake()
+	fake.SOLErr = fmt.Errorf("no sol path")
+	tr := &sol.RedfishTransport{
+		NewBMC:   func(redfish.Config) (redfish.BMC, error) { return fake, nil },
+		SystemID: "1",
+	}
+	if _, err := tr.Open(context.Background(), "http://127.0.0.1:9999"); err == nil {
+		t.Fatal("expected error from OpenSOL failure")
+	}
+}
+
+func TestRedfishTransportOpenRequiresTarget(t *testing.T) {
+	tr := &sol.RedfishTransport{
+		NewBMC: func(redfish.Config) (redfish.BMC, error) { return redfish.NewFake(), nil },
+	}
+	if _, err := tr.Open(context.Background(), ""); err == nil {
+		t.Fatal("expected error for empty target")
+	}
+}
+
+// TestRedfishTransportCloseUnblocksScan proves Close() releases a scan loop
+// blocked on a read with no data available — the same contract
+// LibvirtTransport relies on (ctx is only observed between successful scans,
+// not while blocked inside one; closing the underlying stream is what
+// unblocks a pending Read).
+func TestRedfishTransportCloseUnblocksScan(t *testing.T) {
+	pr, pw := io.Pipe()
+	t.Cleanup(func() { _ = pw.Close() })
+
+	fake := redfish.NewFake()
+	fake.SOLStream = redfish.SOLStream{ReadCloser: pr, Kind: redfish.SOLConnectSSH}
+
+	tr := &sol.RedfishTransport{
+		NewBMC:   func(redfish.Config) (redfish.BMC, error) { return fake, nil },
+		SystemID: "1",
+	}
+
+	lines, err := tr.Open(context.Background(), "http://127.0.0.1:9999")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+
+	closeDone := make(chan error, 1)
+	go func() { closeDone <- tr.Close() }()
+
+	select {
+	case err := <-closeDone:
+		if err != nil {
+			t.Fatalf("Close: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Close did not return promptly while a read was blocked")
+	}
+
+	select {
+	case _, ok := <-lines:
+		if ok {
+			t.Fatal("expected channel to close after Close(), got a value")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for channel close after Close()")
+	}
+}

--- a/internal/observe/sol/transport.go
+++ b/internal/observe/sol/transport.go
@@ -19,6 +19,14 @@ type Transport interface {
 	Close() error
 }
 
+// errorTransport fails Open with a fixed error. Used for unrecognized
+// session.Transport values so unknown/unwired transports fail loudly instead
+// of silently running as libvirt (or anything else).
+type errorTransport struct{ err error }
+
+func (e *errorTransport) Open(context.Context, string) (<-chan string, error) { return nil, e.err }
+func (e *errorTransport) Close() error                                        { return nil }
+
 // ReaderTransport reads lines from an io.Reader (tests / injected pipes).
 type ReaderTransport struct {
 	mu     sync.Mutex

--- a/internal/observe/sol/watch.go
+++ b/internal/observe/sol/watch.go
@@ -49,7 +49,11 @@ func NewWatchService(log *slog.Logger, progress jobport.JobProgress) *WatchServi
 			case "libvirt", "":
 				return &LibvirtTransport{}
 			default:
-				return &LibvirtTransport{}
+				// Unrecognized transport (including "redfish_sol" when the
+				// composition root hasn't wired a real factory, or any
+				// legacy/typo value) must fail loudly rather than silently
+				// tailing a libvirt console that doesn't exist.
+				return &errorTransport{err: fmt.Errorf("sol: unsupported serial transport %q", session.Transport)}
 			}
 		},
 	}

--- a/internal/observe/sol/watch_test.go
+++ b/internal/observe/sol/watch_test.go
@@ -169,3 +169,35 @@ func TestWatchServiceStall(t *testing.T) {
 	}
 	t.Fatal("stall not reported")
 }
+
+// TestWatchServiceDefaultTransportRejectsUnknown proves the default
+// NewTransport factory (used when a caller never wires a combinator) fails
+// loudly for an unrecognized session.Transport instead of silently tailing a
+// libvirt console that doesn't exist.
+func TestWatchServiceDefaultTransportRejectsUnknown(t *testing.T) {
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	prog := &recordingProgress{}
+	w := sol.NewWatchService(log, prog) // default NewTransport, not overridden
+
+	err := w.Register(context.Background(), models.WatchSession{
+		ID: "s1", JobID: "j1", DeviceID: "d1",
+		Transport: "redfish_sol", Target: "x",
+		StallTimeout: time.Minute,
+	})
+	if err == nil {
+		t.Fatal("expected error for unwired redfish_sol transport, got nil")
+	}
+	if w.ActiveCount() != 0 {
+		t.Fatalf("expected no active watch after failed Open, got %d", w.ActiveCount())
+	}
+
+	// A legacy/typo value must also fail, never silently fall back to libvirt.
+	err = w.Register(context.Background(), models.WatchSession{
+		ID: "s2", JobID: "j2", DeviceID: "d2",
+		Transport: "ipmi_sol", Target: "x",
+		StallTimeout: time.Minute,
+	})
+	if err == nil {
+		t.Fatal("expected error for ipmi_sol transport, got nil")
+	}
+}


### PR DESCRIPTION
## Summary

- Implements the previously-reserved `redfish_sol` serial transport. `WatchSession.Transport` has long documented `"libvirt" | "redfish_sol" | "ipmi_sol"` but only `libvirt` (and lab SSH-libvirt) actually worked — `redfish_sol` silently fell back to tailing a libvirt console that doesn't exist. That silent-fallback bug is fixed for *any* unrecognized transport, not just this one.
- **Redfish only, permanently** — no `ipmi_sol` is implemented or ever will be; raw IPMI (`ipmitool` or an IPMI library) is never used, even for BMCs that only advertise IPMI SOL.
- Discovery order (`internal/common/redfish/sol.go`, `BMC.OpenSOL`): classify vendor → try native WebSocket SOL candidates for recognized vendors (Dell/Supermicro; candidates are **documented, unverified placeholders** — no vendor publishes a client-pull plain-text SOL-over-WS API) → fall back to SSH *only* when Redfish's own capability metadata (`ComputerSystem.SerialConsole.SSH`) advertises it → otherwise a clean `*SOLUnsupportedError` with a full, secret-redacted debug trail. Telnet is explicitly deferred (reported unsupported, not implemented).
- New serial-transport selection: per-job `StartJobRequest.serial_transport` override (also a new `-serial-transport` CLI flag), orchestrator-wide `SHOAL_SERIAL_TRANSPORT` default. Default remains `"libvirt"` — existing lab behavior is unchanged unless explicitly opted in.
- New dependencies (design doc §7.1 / `NOTICE` / `docs/third-party-licenses.md` updated in this PR): `github.com/coder/websocket` (ISC) for the native SOL stream, and `golang.org/x/crypto` promoted from indirect to direct for SSH password auth against BMC credentials.
- `docs/real-hardware-sol-runbook.md`: honest checklist for the first real-hardware validation pass — sushy-tools has zero SOL capability, so this feature is unit-tested plus one live negative-path lab check, not real-hardware-validated.

## Test plan

- [x] `gofmt -l .` clean
- [x] `go vet ./...` clean
- [x] `staticcheck ./...` clean
- [x] `go test ./...` — full suite green, including new unit tests: fake-WS-server and fake-SSH-server driven `OpenSOL` discovery tests (real gofish parsing against `httptest` fixtures, not mocks), `RedfishTransport`/`NewCombinedTransportFactory` tests, orchestrator transport-selection wiring tests
- [x] Live lab integration test (`-tags=integration`) run against the real sushy-tools BMC (`192.168.122.100:8001`): `OpenSOL` correctly resolves the real system/managers over the network and returns a clean `*SOLUnsupportedError` (sushy-tools has no SOL support) — no crash, no hang, no false positive. Non-destructive (never touches virtual media/boot/power).
- [ ] Real-hardware WS/SSH streaming validation — **not done**, requires real Dell/Supermicro/etc. hardware; tracked in `docs/real-hardware-sol-runbook.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)