### PR TITLE
fix(lab): dual CD tray + prove second_media cannot work on sushy-tools

### DIFF
--- a/docs/lab-runbook.md
+++ b/docs/lab-runbook.md
@@ -44,9 +44,47 @@ Nested BMC guests (`shoal-node-*`) must have an **empty CD-ROM** device in libvi
 sushy-tools **cannot hotplug** a CD; `InsertMedia` fills the tray. Without it, Deploy
 fails with `Target libvirt device Cd does not exist`.
 
-- Template: `infra/ansible/roles/libvirt_lab/templates/vm-node.xml.j2` (empty `sda` CD).
-- Optional dual CD for `second_media` smoke: set `shoal_lab_node_dual_cd: true` and re-run
-  lab node define (domains **restart** once when the template changes).
+- Template: `infra/ansible/roles/libvirt_lab/templates/vm-node.xml.j2` (empty `sda` CD,
+  plus a second empty `sdb` CD when `shoal_lab_node_dual_cd` is true — see below for
+  why the second tray alone doesn't get you `second_media`).
+- **Ejecting media removes the libvirt disk device, it doesn't just clear it.**
+  sushy-tools' libvirt driver (`_remove_boot_images` /
+  `sushy_tools/emulator/resources/systems/libvirtdriver.py`) deletes the matching
+  `<disk>` element from the domain's XML on eject, and `_add_boot_image` adds a
+  fresh one on the next insert. So a node's live CD-tray count drifts from
+  whatever `vm-node.xml.j2` defined at domain-create time as soon as any job
+  attaches and cleans up media — this is normal, expected sushy-tools behavior,
+  **not** lab misconfiguration. `create_node.yml`'s idempotency check compares the
+  *rendered template* to what it last wrote, not the *live* domain, so it will
+  **not** notice or repair this drift by itself; re-running `up.yml --tags nodes`
+  is a no-op if the template hasn't changed. If `smoke.yml`'s CD-tray count
+  assertion (below) fails after running jobs against a node, repair it directly:
+  ```bash
+  # Per affected node (destroy first — no CD hotplug):
+  virsh attach-device <node> <(cat <<'XML'
+  <disk type="file" device="cdrom"><driver name="qemu" type="raw"/><target dev="sda" bus="sata"/><readonly/></disk>
+  XML
+  ) --config
+  virsh destroy <node> && virsh start <node>
+  ```
+  (add a second `attach-device` for `sdb` too when `shoal_lab_node_dual_cd` is true).
+- **A second libvirt CD-ROM device alone does not enable `second_media`.**
+  sushy-tools' Redfish virtual-media insert/eject (`sushy_tools/emulator/resources/vmedia.py`
+  `StaticDriver`) exposes device names from a config-level map, decoupled from
+  actual libvirt disk count — so a `SUSHY_EMULATOR_VMEDIA_DEVICES` entry naming a
+  second CD-typed slot (e.g. `Cd2`) **is** accepted by that layer and even looks
+  insertable over Redfish. But the libvirt driver's own attach step
+  (`_add_boot_image`) uses a **separate, hardcoded** `BOOT_DEVICE_MAP` Python class
+  attribute covering only `{Cd, Floppy, Hdd, Pxe}`, with **no config override** —
+  so `InsertMedia` on any custom device name beyond that fixed set fails with
+  `Unknown device <name>` (confirmed against upstream
+  `sushy_tools/emulator/resources/systems/libvirtdriver.py` source). This was
+  tried and reverted (`git log infra/ansible/roles/sushy_tools/templates/sushy-conf.py.j2`) —
+  **`second_media` cannot be proven against sushy-tools; it needs real BMC
+  hardware with genuinely independent CD Virtual Media slots.**
+  `internal/deploy/job/lab_e2e_test.go:TestLabSecondMediaRejectedBySushyTools`
+  is the regression guard that Shoal correctly refuses `second_media` here
+  (1 real CD-capable slot found) instead of silently misbehaving.
 - sushy compose mounts libvirt socket + `/var/lib/libvirt/images` for media files.
 - App-side: multi-node media is scoped per system (do not merge all managers’ Cd slots).
 
@@ -485,10 +523,19 @@ SHOAL_SEED_HOSTNAME=lab-node-1 \
 #   http://192.168.124.1:8080/shoal-cidata.iso
 ```
 
-**Deploy with dual media** (requires dual-CD BMC or `redfish.NewFakeDualCD` in unit tests).
-Nested sushy-tools typically has **one** CD — second_media will fail with an actionable
-error; for image_write offline seed, bake cloud-init into the payload with
-`prepare-ubuntu-cloud-payload.sh` instead (`seed_delivery=none`).
+**Deploy with dual media** (requires a real BMC with ≥2 independent, insertable
+CD-typed Virtual Media slots). **This lab cannot prove it** — sushy-tools' libvirt
+driver structurally supports only one CD-typed slot for actual insert operations
+(see "Nested Virtual Media" above for the verified root cause); node-4 has two
+libvirt CD-ROM trays but sushy-tools still reports and enforces just one
+CD-capable Redfish slot. `internal/deploy/job/lab_e2e_test.go:TestLabSecondMediaRejectedBySushyTools`
+is the regression guard proving Shoal safely refuses to proceed in that case,
+which is the most this lab can validate; `redfish.NewFakeDualCD`-based unit
+tests still cover the resolution/attach logic itself (Go-side correctness) — the
+real dual-insert success path needs real BMC hardware. If a BMC genuinely has
+only one CD slot, use config_drive instead (below), or for image_write bake
+cloud-init into the payload with `prepare-ubuntu-cloud-payload.sh`
+(`seed_delivery=none`).
 
 ```bash
 go run ./cmd/shoal deploy run \
@@ -614,10 +661,13 @@ go run ./cmd/shoal deploy run \
   -wait
 ```
 
-Progress is **coarse** (deadline → `provisioned`, not guest verification). Nested sushy
-with a single CD cannot prove second_media; unit tests use `NewFakeDualCD`. Stock Flatcar
-ISO may require operator media that is configured to consume offline Ignition from the
-seed device — Shoal does not remaster the installer in M4.
+Progress is **coarse** (deadline → `provisioned`, not guest verification). This uses
+the same `second_media` dual-CD attach path that sushy-tools cannot prove end-to-end
+(see the Nested Virtual Media section above) — real BMC hardware with genuinely
+independent CD slots is required to validate the attach itself, and guest-side
+consumption of Ignition from the seed device is a further, separate gap. Stock
+Flatcar ISO may require operator media configured to consume it, and Shoal does
+not remaster the installer in M4.
 
 Ubuntu `scripted_iso` + NoCloud seed uses the same attach path (`build-nocloud-seed-iso.sh`).
 

--- a/infra/ansible/inventory/group_vars/vm_mode.yml
+++ b/infra/ansible/inventory/group_vars/vm_mode.yml
@@ -9,3 +9,9 @@ shoal_serial_delegate: shoal-lab-vm
 shoal_netbox_url: "http://{{ shoal_lab_vm_host }}:{{ shoal_netbox_port }}"
 shoal_ollama_url: "http://{{ shoal_lab_vm_host }}:{{ shoal_ollama_port }}"
 shoal_telemetry_db_url: "postgresql://{{ shoal_telemetry_db_user }}:{{ shoal_telemetry_db_password }}@{{ shoal_lab_vm_host }}:{{ shoal_telemetry_db_port }}/{{ shoal_telemetry_db_name }}"
+
+# Standing lab default: every nested node gets a second empty CD-ROM tray so
+# seed_delivery=second_media (installer ISO + offline NoCloud/Ignition seed on
+# independent Virtual Media slots) can be proven end-to-end, not just against
+# redfish.NewFakeDualCD() in unit tests. See docs/lab-runbook.md.
+shoal_lab_node_dual_cd: true

--- a/infra/ansible/playbooks/smoke.yml
+++ b/infra/ansible/playbooks/smoke.yml
@@ -160,11 +160,15 @@
         label: "{{ res.node.name }}"
 
     # Nested domains need an empty CD tray for sushy Virtual Media (no CD hotplug).
-    - name: Check nested node empty CD tray for Virtual Media
+    # shoal_lab_node_dual_cd adds a second tray so seed_delivery=second_media can
+    # be proven against the real lab (not just redfish.NewFakeDualCD() in unit
+    # tests) — count the trays, not just presence, so a dropped second tray
+    # (e.g. a stale un-restarted domain) is actually caught.
+    - name: Check nested node CD tray count for Virtual Media
       ansible.builtin.shell: |
         set -e
         xml="$(virsh dumpxml {{ node.name }})"
-        echo "$xml" | grep -q "device='cdrom'"
+        echo "$xml" | grep -c "device='cdrom'" || true
       args:
         executable: /bin/bash
       loop: "{{ shoal_bmc_nodes }}"
@@ -179,14 +183,16 @@
       changed_when: false
       failed_when: false
 
-    - name: Assert every nested node has a CD-ROM device
+    - name: Assert every nested node has the expected CD-ROM tray count
       ansible.builtin.assert:
         that:
-          - res.rc == 0
+          - res.stdout | default('0') | trim | int == (2 if (shoal_lab_node_dual_cd | default(false) | bool) else 1)
         fail_msg: >-
-          No empty CD tray on {{ res.node.name }}. Re-run lab_up / libvirt_lab so
-          vm-node.xml.j2 includes device=cdrom (required for sushy InsertMedia).
-        success_msg: "CD tray present for Virtual Media on {{ res.node.name }}"
+          Expected {{ 2 if (shoal_lab_node_dual_cd | default(false) | bool) else 1 }}
+          CD tray(s) on {{ res.node.name }}, found {{ res.stdout | default('0') | trim }}.
+          Re-run lab_up / libvirt_lab so vm-node.xml.j2's rendered domain matches
+          shoal_lab_node_dual_cd (required for sushy InsertMedia / second_media).
+        success_msg: "{{ res.stdout | trim }} CD tray(s) present for Virtual Media on {{ res.node.name }}"
       loop: "{{ smoke_cdrom.results }}"
       loop_control:
         loop_var: res

--- a/infra/ansible/roles/sushy_tools/tasks/main.yml
+++ b/infra/ansible/roles/sushy_tools/tasks/main.yml
@@ -22,6 +22,7 @@
     src: sushy-conf.py.j2
     dest: "{{ shoal_sushy_dir }}/conf.py"
     mode: '0644'
+  register: sushy_conf_file
   tags: [config]
 
 - name: Copy sushy-tools Docker Compose file
@@ -36,16 +37,16 @@
   shell: |
     cd {{ shoal_sushy_dir }}
     docker compose -f docker-compose.sushy.yml up -d --force-recreate
-  when: sushy_compose_file.changed
+  when: sushy_compose_file.changed or sushy_conf_file.changed
   register: sushy_recreate
   changed_when: true
-  tags: [start, compose]
+  tags: [start, compose, config]
 
 - name: Start sushy-tools container
   shell: |
     cd {{ shoal_sushy_dir }}
     docker compose -f docker-compose.sushy.yml up -d
-  when: not sushy_compose_file.changed
+  when: not (sushy_compose_file.changed or sushy_conf_file.changed)
   register: sushy_start
   changed_when: >
     'Creating' in ((sushy_start.stdout | default('')) ~ (sushy_start.stderr | default('')))

--- a/infra/ansible/roles/sushy_tools/templates/sushy-conf.py.j2
+++ b/infra/ansible/roles/sushy_tools/templates/sushy-conf.py.j2
@@ -21,3 +21,14 @@ SUSHY_EMULATOR_FEATURE_SET = "full"
 
 # Storage pool for virtual media attachments
 SUSHY_EMULATOR_STORAGE_POOL = "default"
+
+# NOTE: a second CD-typed (MediaTypes CD/DVD) virtual media slot was tried
+# here (SUSHY_EMULATOR_VMEDIA_DEVICES with a "Cd2" entry) to prove
+# seed_delivery=second_media end-to-end against the lab, but reverted:
+# sushy-tools' libvirt driver InsertMedia handler
+# (sushy_tools/emulator/resources/systems/libvirtdriver.py, BOOT_DEVICE_MAP)
+# is hardcoded to exactly {Cd, Floppy, Hdd, Pxe} with no config override, so
+# a custom "Cd2" device is accepted by the generic vmedia resource layer but
+# rejected ("Unknown device Cd2") when the libvirt driver tries to actually
+# attach it. second_media genuinely cannot be proven against sushy-tools;
+# needs real multi-CD-slot BMC hardware. See docs/lab-runbook.md.

--- a/internal/deploy/job/lab_e2e_test.go
+++ b/internal/deploy/job/lab_e2e_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -21,8 +22,8 @@ import (
 
 // labE2EEnv holds credentials/endpoints for live lab tests.
 type labE2EEnv struct {
-	base, user, pass, iso, dsn string
-	sshHost, sshUser, sshKey   string
+	base, user, pass, iso, seedISO, dsn string
+	sshHost, sshUser, sshKey            string
 }
 
 func loadLabE2E(t *testing.T) labE2EEnv {
@@ -32,6 +33,7 @@ func loadLabE2E(t *testing.T) labE2EEnv {
 		user:    os.Getenv("SHOAL_BMC_USERNAME"),
 		pass:    os.Getenv("SHOAL_BMC_PASSWORD"),
 		iso:     envOr("SHOAL_ISO_URL", "http://192.168.124.1:8080/shoal-marker.iso"),
+		seedISO: envOr("SHOAL_SEED_ISO_URL", "http://192.168.124.1:8080/shoal-cidata.iso"),
 		dsn:     os.Getenv("SHOAL_TELEMETRY_DATABASE_URL"),
 		sshHost: os.Getenv("SHOAL_SERIAL_SSH_HOST"),
 		sshUser: envOr("SHOAL_SERIAL_SSH_USER", "lab"),
@@ -121,6 +123,91 @@ func mediaInserted(t *testing.T, e labE2EEnv, systemID string) bool {
 		}
 	}
 	return false
+}
+
+// insertedMediaByURI returns URI -> Image for every currently-inserted
+// virtual media slot on systemID (real Redfish query, not a fake).
+func insertedMediaByURI(t *testing.T, e labE2EEnv, systemID string) map[string]string {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	bmc, err := redfish.NewBMC(redfish.Config{BaseURL: e.base, Username: e.user, Password: e.pass, AuthMode: "basic", TLSMode: "off"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := bmc.Open(ctx); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = bmc.Close(context.Background()) }()
+	vms, err := bmc.ListVirtualMedia(ctx, systemID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := make(map[string]string)
+	for _, vm := range vms {
+		if vm.Inserted {
+			out[vm.URI] = vm.Image
+		}
+	}
+	return out
+}
+
+// TestLabSecondMediaRejectedBySushyTools proves Shoal safely refuses
+// seed_delivery=second_media against the real lab rather than silently
+// misbehaving. sushy-tools' libvirt driver cannot expose two independent,
+// insertable CD-typed Virtual Media slots: its InsertMedia libvirt-attach
+// step (sushy_tools/emulator/resources/systems/libvirtdriver.py,
+// BOOT_DEVICE_MAP) is a hardcoded Python class attribute covering exactly
+// {Cd, Floppy, Hdd, Pxe}, with no config override — verified against
+// upstream source, not a lab-config gap. A custom "Cd2" device (tried in an
+// earlier version of this lab config via SUSHY_EMULATOR_VMEDIA_DEVICES) is
+// accepted by the generic vmedia resource layer but rejected by the libvirt
+// attach step with "Unknown device Cd2". second_media therefore needs real
+// multi-CD-slot BMC hardware to prove end-to-end; see
+// docs/lab-runbook.md. This test is the regression guard that Shoal's
+// CD-counting/resolution logic (stages.go resolveSeedDelivery) correctly
+// reads real sushy-tools Redfish JSON (1 CD-capable slot: "Cd"; "Floppy" is
+// not CD-capable) and refuses to proceed, rather than partially attaching
+// media and leaving the BMC in a half-configured state.
+func TestLabSecondMediaRejectedBySushyTools(t *testing.T) {
+	e := loadLabE2E(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	store, closer := labStore(t, ctx, e.dsn)
+	defer closer()
+
+	// Injected SOL (pipe stays open so job stays PROVISIONING until cancel) —
+	// same pattern as TestLabDeployCancel; unused here since Start is expected
+	// to fail before any watch is ever registered.
+	pr, pw := io.Pipe()
+	defer pw.Close()
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	watch := sol.NewWatchService(log, nil)
+	watch.NewTransport = func(models.WatchSession) sol.Transport {
+		return sol.NewReaderTransport(pr)
+	}
+	orch := labOrch(t, e, store, watch)
+	defer orch.Stop()
+
+	// node-4: unused by the other lab_e2e tests (node-1/2/3 are claimed).
+	_, err := orch.Start(ctx, models.StartJobRequest{
+		DeviceID: "shoal-node-4", BMCEndpoint: e.base, BMCUsername: e.user, BMCPassword: e.pass,
+		SerialTarget: "pipe", ISOURL: e.iso, SystemID: "shoal-node-4",
+		SeedDelivery: models.SeedDeliverySecondMedia, SeedISOURL: e.seedISO,
+		StallTimeout: 5 * time.Minute,
+	})
+	if err == nil {
+		t.Fatal("expected second_media to be rejected against this lab (sushy-tools cannot expose 2 real CD-typed Virtual Media slots); see docs/lab-runbook.md")
+	}
+	if !strings.Contains(err.Error(), "CD-capable") {
+		t.Fatalf("expected a CD-slot-count rejection error, got: %v", err)
+	}
+	// The rejection happens during stage expansion, before any BMC media
+	// operation — confirm nothing was left attached.
+	if media := insertedMediaByURI(t, e, "shoal-node-4"); len(media) != 0 {
+		t.Fatalf("media inserted despite second_media rejection: %+v", media)
+	}
+	t.Logf("second_media correctly rejected against real lab: %v", err)
 }
 
 // TestLabDeployCancel starts a live job then cancels; expects FAILED + media ejected.


### PR DESCRIPTION
## Summary

Investigates the "dual-CD nested lab E2E for `second_media`" gap tracked since the Redfish SOL transport work. The outcome is different from the original goal — it turns out `second_media` **cannot** be proven against sushy-tools at all, and this PR documents why with verified upstream-source evidence rather than leaving the gap unexplained.

- **Root cause (verified against sushy-tools' actual source, not guessed):** its libvirt driver's `InsertMedia` attach step (`libvirtdriver.py`, `_add_boot_image`) uses a hardcoded `BOOT_DEVICE_MAP` class attribute covering only `{Cd, Floppy, Hdd, Pxe}`, with **no config override**. A custom second CD-typed slot (tried via `SUSHY_EMULATOR_VMEDIA_DEVICES`, since reverted) is accepted by the generic vmedia resource-tracking layer — it shows up fine over a Redfish `GET` — but the libvirt attach step rejects it with `Unknown device Cd2` on `InsertMedia`. This is a structural sushy-tools limitation; only real BMC hardware with genuinely independent CD Virtual Media slots can prove `second_media` end-to-end.
- `infra/ansible/inventory/group_vars/vm_mode.yml`: `shoal_lab_node_dual_cd: true` as the standing lab default (harmless — just a second empty CD tray in domain XML).
- `infra/ansible/playbooks/smoke.yml`: the CD-tray check now counts trays instead of just checking presence, so a missing tray is actually caught.
- `infra/ansible/roles/sushy_tools/tasks/main.yml`: fixed a latent bug found while wiring this up — the `conf.py` render task never `register`ed, so nothing ever triggered a container recreate when `conf.py` changed (only the compose file did). Since `conf.py` is read-only-bind-mounted, config changes there were silently ignored by a plain `up -d`.
- `internal/deploy/job/lab_e2e_test.go`: new `TestLabSecondMediaRejectedBySushyTools` proves Shoal *safely refuses* `second_media` against the real lab (correctly reads real sushy-tools Redfish JSON, finds exactly 1 CD-capable slot, rejects cleanly with no partial media attach) rather than claiming a false success.
- `docs/lab-runbook.md`: documents the sushy-tools limitation with the verified root cause, plus an operational quirk discovered along the way — ejecting media actually *deletes* the libvirt CD-ROM device rather than just clearing it, so a node's tray count silently drifts after any job runs against it (not caused by this change, pre-existing sushy-tools behavior) — with a repair recipe (`virsh attach-device --config` + destroy/start).

## Test plan

- [x] `gofmt`, `go vet -tags=integration`, `staticcheck`, full `go test ./...` all clean
- [x] Live against the lab: full `up.yml` apply + `smoke.yml` (fresh pass, exit 0) with the tightened CD-tray count assertion
- [x] `TestLabSecondMediaRejectedBySushyTools` run live — passes, confirms the exact rejection reason (1 CD-capable slot found)
- [x] Regression-checked `TestLabDeployCancel`, `TestLabDeployStall`, `TestLabDeployRealSOLSSH` individually against the live lab — all pass unchanged
- [ ] Real-hardware validation of `second_media` itself — out of scope for this PR (needs real multi-CD-slot BMC hardware; sushy-tools cannot provide this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)