### PR TITLE
feat(api): NetBox telemetry UI backend slice (N1-N3)

### DIFF
--- a/docs/netbox-telemetry-ui-design.md
+++ b/docs/netbox-telemetry-ui-design.md
@@ -1,6 +1,6 @@
 # NetBox integration: visual telemetry, events, and job context
 
-**Status:** Design draft (implementation not started)  
+**Status:** Backend API slice (N1-N3) implemented; NetBox plugin (N4+) not started  
 **Date:** July 2026  
 **Audience:** Human architect + coding agents  
 **Related:** Design SoT `SHOAL_COMPREHENSIVE_DESIGN_AND_IMPLEMENTATION_PLAN.md` (v2.0.9+);
@@ -189,12 +189,13 @@ MVP may use the existing single token with plugin only calling GET routes.
 
 | Method | Path | Purpose |
 |--------|------|---------|
-| `GET` | `/v1/devices/{id}/jobs?limit=&state=` | Recent jobs for device |
-| `GET` | `/v1/devices/{id}/sensors?since=&limit=` or latest-per-sensor | Sensors tab |
-| `GET` | `/v1/jobs/{id}/log?since=&limit=` | Job log lines from `job_log` (if populated) |
-| `GET` | `/v1/devices/{id}/summary` (optional) | Single round-trip: status + last N events + active job |
+| `GET` | ✅ `/v1/devices/{id}/jobs?limit=&state=` | Recent jobs for device |
+| `GET` | ✅ `/v1/devices/{id}/sensors?since=&limit=` | Sensors tab (flat since/limit list, newest-first; no "latest-per-sensor" query yet — dedupe client-side if needed) |
+| `GET` | ✅ `/v1/jobs/{id}/log?since=&limit=` | Job log lines from `job_log`, oldest-first (empty until a writer exists — see N3) |
+| `GET` | `/v1/devices/{id}/summary` (optional) | Not implemented. Single round-trip: status + last N events + active job |
 
-**Query conventions:** RFC3339 `since`, bounded `limit` (cap e.g. 200–500), stable JSON
+**Query conventions:** RFC3339 `since`, bounded `limit` (cap 200, enforced on the three
+new endpoints above — existing `status`/`events` endpoints are unchanged), stable JSON
 shapes, empty lists not 404.
 
 **Auth:** Same Bearer gate as other `/v1/*` when token configured.
@@ -340,10 +341,10 @@ NetBox plugin ──GET jobs by device──► Shoal
 | Slice | Deliverable | AC |
 |-------|-------------|-----|
 | **N0** | This design merged | Docs only |
-| **N1** | Shoal API: `GET /v1/devices/{id}/jobs` (+ tests) | Unit + optional lab |
-| **N2** | Shoal API: sensors latest (and/or since) | Unit; poll writes visible |
-| **N3** | Shoal API: `GET /v1/jobs/{id}/log` if `job_log` writers exist; else stub/doc | Honest empty state |
-| **N4** | NetBox custom fields + config context for Shoal base URL / device id | Lab bootstrap |
+| **N1** | ✅ Shoal API: `GET /v1/devices/{id}/jobs` (+ tests) | Done — `jobstore.Store.ListByDevice`, unit + lab-integration tests |
+| **N2** | ✅ Shoal API: sensors latest (and/or since) | Done — `GET /v1/devices/{id}/sensors`, unit + lab-integration tests |
+| **N3** | ✅ Shoal API: `GET /v1/jobs/{id}/log` | Done — honest empty state confirmed: `job_log` has no production writer yet (`WriteJobLog` is only called from tests), so this endpoint correctly returns `{"lines":[]}` until a writer lands; that writer work is a separate, not-yet-scoped slice |
+| **N4** | NetBox custom fields + config context for Shoal base URL / device id | Lab bootstrap — not started |
 | **N5** | NetBox plugin MVP: Status + Events tabs | Lab demo from device page |
 | **N6** | Plugin Jobs + Sensors tabs | Lab demo |
 | **N7** | Optional Grafana dashboard + plugin link | Lab compose |

--- a/internal/api/auth_test.go
+++ b/internal/api/auth_test.go
@@ -56,6 +56,34 @@ func TestAPIAuthProtectsV1(t *testing.T) {
 	_ = json.Unmarshal(rr.Body.Bytes(), &body)
 }
 
+// TestAPIAuthProtectsNewTelemetryRoutes covers the N1-N3 routes explicitly —
+// the auth gate is a blanket /v1/ prefix match (TestAPIAuthProtectsV1 already
+// proves the mechanism), but each new route is checked individually so a
+// future refactor that accidentally registers one outside /v1/ is caught.
+func TestAPIAuthProtectsNewTelemetryRoutes(t *testing.T) {
+	s := api.New(config.Config{APIToken: "secret-token"}, nil)
+	for _, path := range []string{
+		"/v1/devices/x/jobs",
+		"/v1/devices/x/sensors",
+		"/v1/jobs/x/log",
+	} {
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		s.Handler().ServeHTTP(rr, req)
+		if rr.Code != http.StatusUnauthorized {
+			t.Fatalf("%s: want 401 without bearer, got %d", path, rr.Code)
+		}
+
+		rr = httptest.NewRecorder()
+		req = httptest.NewRequest(http.MethodGet, path, nil)
+		req.Header.Set("Authorization", "Bearer secret-token")
+		s.Handler().ServeHTTP(rr, req)
+		if rr.Code == http.StatusUnauthorized {
+			t.Fatalf("%s: valid bearer still unauthorized", path)
+		}
+	}
+}
+
 func TestAPIAuthRejectsWrongToken(t *testing.T) {
 	s := api.New(config.Config{APIToken: "secret-token"}, nil)
 	rr := httptest.NewRecorder()

--- a/internal/api/devices.go
+++ b/internal/api/devices.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/mattcburns/shoal/internal/common/models"
+	"github.com/mattcburns/shoal/internal/common/telemetry"
 	"github.com/mattcburns/shoal/internal/observe"
 )
 
@@ -71,5 +72,86 @@ func (s *Server) handleDeviceEvents(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]any{
 		"device_id": id,
 		"events":    evs,
+	})
+}
+
+func (s *Server) handleDeviceJobs(w http.ResponseWriter, r *http.Request) {
+	if s.jobs == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]any{
+			"error": "job store not configured",
+		})
+		return
+	}
+	id := r.PathValue("id")
+	if id == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "missing device id"})
+		return
+	}
+	limit := 50
+	if v := r.URL.Query().Get("limit"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			limit = n
+		}
+	}
+	if limit > maxListLimit {
+		limit = maxListLimit
+	}
+	// state is not validated against the LifecycleState enum: an unrecognized
+	// value simply matches no rows, mirroring how an unparseable `since`
+	// elsewhere falls back to "no filter" rather than 400.
+	state := models.LifecycleState(r.URL.Query().Get("state"))
+	jobs, err := s.jobs.ListByDevice(r.Context(), id, state, limit)
+	if err != nil {
+		s.log.Error("list device jobs", "err", err.Error())
+		writeJSON(w, http.StatusInternalServerError, map[string]any{"error": "internal error"})
+		return
+	}
+	if jobs == nil {
+		jobs = []models.ProvisioningJob{}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"device_id": id,
+		"jobs":      jobs,
+	})
+}
+
+func (s *Server) handleDeviceSensors(w http.ResponseWriter, r *http.Request) {
+	if s.observe == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]any{
+			"error": "observe not configured",
+		})
+		return
+	}
+	id := r.PathValue("id")
+	if id == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "missing device id"})
+		return
+	}
+	limit := 50
+	if v := r.URL.Query().Get("limit"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			limit = n
+		}
+	}
+	if limit > maxListLimit {
+		limit = maxListLimit
+	}
+	var since time.Time
+	if v := r.URL.Query().Get("since"); v != "" {
+		if t, err := time.Parse(time.RFC3339, v); err == nil {
+			since = t
+		}
+	}
+	readings, err := s.observe.ListSensors(r.Context(), id, since, limit)
+	if err != nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]any{"error": err.Error()})
+		return
+	}
+	if readings == nil {
+		readings = []telemetry.SensorReading{}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"device_id": id,
+		"readings":  readings,
 	})
 }

--- a/internal/api/devices_test.go
+++ b/internal/api/devices_test.go
@@ -69,3 +69,117 @@ func TestDeviceEventsWithoutTelemetry(t *testing.T) {
 		t.Fatalf("status %d", rr.Code)
 	}
 }
+
+func TestDeviceJobs(t *testing.T) {
+	jobs := jobstore.NewMemory()
+	ctx := context.Background()
+	older := time.Now().UTC().Add(-time.Hour)
+	newer := time.Now().UTC()
+	_ = jobs.Insert(ctx, models.ProvisioningJob{
+		ID: "j-old", DeviceID: "n2", State: models.StateProvisioned, UpdatedAt: &older,
+	})
+	_ = jobs.Insert(ctx, models.ProvisioningJob{
+		ID: "j-new", DeviceID: "n2", State: models.StateFailed, UpdatedAt: &newer,
+	})
+	_ = jobs.Insert(ctx, models.ProvisioningJob{
+		ID: "j-other", DeviceID: "other", State: models.StateProvisioned, UpdatedAt: &newer,
+	})
+	s := api.New(config.Config{}, nil).WithJobStore(jobs)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/devices/n2/jobs", nil)
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status %d body=%s", rr.Code, rr.Body.String())
+	}
+	var body struct {
+		DeviceID string                   `json:"device_id"`
+		Jobs     []models.ProvisioningJob `json:"jobs"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if len(body.Jobs) != 2 || body.Jobs[0].ID != "j-new" {
+		t.Fatalf("want [j-new j-old] newest-first, got %+v", body.Jobs)
+	}
+
+	rr = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/v1/devices/n2/jobs?state=failed", nil)
+	s.Handler().ServeHTTP(rr, req)
+	body.Jobs = nil
+	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if len(body.Jobs) != 1 || body.Jobs[0].ID != "j-new" {
+		t.Fatalf("state filter: %+v", body.Jobs)
+	}
+
+	rr = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/v1/devices/unknown/jobs", nil)
+	s.Handler().ServeHTTP(rr, req)
+	var empty map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &empty); err != nil {
+		t.Fatal(err)
+	}
+	if empty["jobs"] == nil {
+		t.Fatal("jobs must be [] not null")
+	}
+}
+
+func TestDeviceJobsWithoutJobStore(t *testing.T) {
+	s := api.New(config.Config{}, nil)
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/devices/x/jobs", nil)
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status %d", rr.Code)
+	}
+}
+
+func TestDeviceSensors(t *testing.T) {
+	store := telemetry.NewMemory()
+	ctx := context.Background()
+	ts := time.Now().UTC()
+	_ = store.WriteSensor(ctx, telemetry.SensorReading{
+		DeviceID: "n3", TS: ts, Sensor: "Inlet Temp", Value: 24.5, Unit: "Cel",
+	})
+	obs := observe.New(nil, jobstore.NewMemory(), store, nil)
+	s := api.New(config.Config{}, nil).WithObserve(obs)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/devices/n3/sensors", nil)
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status %d body=%s", rr.Code, rr.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	readings, ok := body["readings"].([]any)
+	if !ok || len(readings) != 1 {
+		t.Fatalf("readings: %+v", body["readings"])
+	}
+
+	rr = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/v1/devices/unknown/sensors", nil)
+	s.Handler().ServeHTTP(rr, req)
+	body = nil
+	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if body["readings"] == nil {
+		t.Fatal("readings must be [] not null")
+	}
+}
+
+func TestDeviceSensorsWithoutTelemetry(t *testing.T) {
+	obs := observe.New(nil, jobstore.NewMemory(), nil, nil)
+	s := api.New(config.Config{}, nil).WithObserve(obs)
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/devices/x/sensors", nil)
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status %d", rr.Code)
+	}
+}

--- a/internal/api/jobs.go
+++ b/internal/api/jobs.go
@@ -5,9 +5,12 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/mattcburns/shoal/internal/common/models"
+	"github.com/mattcburns/shoal/internal/common/telemetry"
 	"github.com/mattcburns/shoal/internal/deploy/jobstore"
 )
 
@@ -106,6 +109,47 @@ func (s *Server) handleGetJob(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, j)
+}
+
+func (s *Server) handleJobLog(w http.ResponseWriter, r *http.Request) {
+	if s.observe == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]any{
+			"error": "observe not configured",
+		})
+		return
+	}
+	id := r.PathValue("id")
+	if id == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "missing job id"})
+		return
+	}
+	limit := 50
+	if v := r.URL.Query().Get("limit"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			limit = n
+		}
+	}
+	if limit > maxListLimit {
+		limit = maxListLimit
+	}
+	var since time.Time
+	if v := r.URL.Query().Get("since"); v != "" {
+		if t, err := time.Parse(time.RFC3339, v); err == nil {
+			since = t
+		}
+	}
+	lines, err := s.observe.ListJobLog(r.Context(), id, since, limit)
+	if err != nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]any{"error": err.Error()})
+		return
+	}
+	if lines == nil {
+		lines = []telemetry.JobLogLine{}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"job_id": id,
+		"lines":  lines,
+	})
 }
 
 func (s *Server) handleCancelJob(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/jobs_test.go
+++ b/internal/api/jobs_test.go
@@ -12,7 +12,9 @@ import (
 	"github.com/mattcburns/shoal/internal/api"
 	"github.com/mattcburns/shoal/internal/common/config"
 	"github.com/mattcburns/shoal/internal/common/models"
+	"github.com/mattcburns/shoal/internal/common/telemetry"
 	"github.com/mattcburns/shoal/internal/deploy/jobstore"
+	"github.com/mattcburns/shoal/internal/observe"
 )
 
 func TestGetJob(t *testing.T) {
@@ -56,6 +58,55 @@ func TestGetJobNotFound(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/v1/jobs/missing", nil)
 	s.Handler().ServeHTTP(rr, req)
 	if rr.Code != http.StatusNotFound {
+		t.Fatalf("status %d", rr.Code)
+	}
+}
+
+func TestJobLog(t *testing.T) {
+	store := telemetry.NewMemory()
+	ctx := context.Background()
+	base := time.Date(2026, 7, 13, 12, 0, 0, 0, time.UTC)
+	_ = store.WriteJobLog(ctx, "job-1", base, "first")
+	_ = store.WriteJobLog(ctx, "job-1", base.Add(time.Minute), "second")
+	obs := observe.New(nil, jobstore.NewMemory(), store, nil)
+	s := api.New(config.Config{}, nil).WithObserve(obs)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/jobs/job-1/log", nil)
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status %d body=%s", rr.Code, rr.Body.String())
+	}
+	var body struct {
+		JobID string                 `json:"job_id"`
+		Lines []telemetry.JobLogLine `json:"lines"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if len(body.Lines) != 2 || body.Lines[0].Line != "first" || body.Lines[1].Line != "second" {
+		t.Fatalf("want oldest-first [first second], got %+v", body.Lines)
+	}
+
+	rr = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/v1/jobs/unknown-job/log", nil)
+	s.Handler().ServeHTTP(rr, req)
+	var empty map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &empty); err != nil {
+		t.Fatal(err)
+	}
+	if empty["lines"] == nil {
+		t.Fatal("lines must be [] not null")
+	}
+}
+
+func TestJobLogWithoutTelemetry(t *testing.T) {
+	obs := observe.New(nil, jobstore.NewMemory(), nil, nil)
+	s := api.New(config.Config{}, nil).WithObserve(obs)
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/jobs/x/log", nil)
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusServiceUnavailable {
 		t.Fatalf("status %d", rr.Code)
 	}
 }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -15,6 +15,10 @@ import (
 	"github.com/mattcburns/shoal/internal/observe"
 )
 
+// maxListLimit bounds the ?limit= query param on list endpoints (jobs-by-device,
+// sensors, job log) so a caller can't force an unbounded scan/response.
+const maxListLimit = 200
+
 // Server is the HTTP API surface (health + jobs + discover + observe).
 type Server struct {
 	cfg config.Config
@@ -55,11 +59,14 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("GET /metrics", s.handleMetrics)
 	s.mux.HandleFunc("POST /v1/jobs", s.handleStartJob)
 	s.mux.HandleFunc("GET /v1/jobs/{id}", s.handleGetJob)
+	s.mux.HandleFunc("GET /v1/jobs/{id}/log", s.handleJobLog)
 	s.mux.HandleFunc("POST /v1/jobs/{id}/cancel", s.handleCancelJob)
 	s.mux.HandleFunc("POST /v1/discover/ingest", s.handleDiscoverIngest)
 	s.mux.HandleFunc("POST /v1/discover/confirm", s.handleDiscoverConfirm)
 	s.mux.HandleFunc("GET /v1/devices/{id}/status", s.handleDeviceStatus)
 	s.mux.HandleFunc("GET /v1/devices/{id}/events", s.handleDeviceEvents)
+	s.mux.HandleFunc("GET /v1/devices/{id}/jobs", s.handleDeviceJobs)
+	s.mux.HandleFunc("GET /v1/devices/{id}/sensors", s.handleDeviceSensors)
 }
 
 func (s *Server) handleHealthz(w http.ResponseWriter, _ *http.Request) {

--- a/internal/common/telemetry/memory.go
+++ b/internal/common/telemetry/memory.go
@@ -149,6 +149,36 @@ func (m *Memory) ListSensors(_ context.Context, deviceID string, since time.Time
 	return out, nil
 }
 
+// ListJobLog returns job_log lines for jobID at or after since, oldest first,
+// capped at limit.
+func (m *Memory) ListJobLog(_ context.Context, jobID string, since time.Time, limit int) ([]JobLogLine, error) {
+	if jobID == "" {
+		return nil, fmt.Errorf("telemetry: job_id required")
+	}
+	if limit <= 0 {
+		limit = 100
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	var out []JobLogLine
+	for _, l := range m.jobLogs {
+		if l.JobID != jobID {
+			continue
+		}
+		if !since.IsZero() && l.TS.Before(since) {
+			continue
+		}
+		out = append(out, JobLogLine(l))
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].TS.Before(out[j].TS)
+	})
+	if len(out) > limit {
+		out = out[:limit]
+	}
+	return out, nil
+}
+
 // JobLogCount returns lines for a job (test helper).
 func (m *Memory) JobLogCount(jobID string) int {
 	m.mu.RLock()

--- a/internal/common/telemetry/postgres.go
+++ b/internal/common/telemetry/postgres.go
@@ -183,6 +183,45 @@ ORDER BY ts DESC LIMIT $3`, deviceID, since.UTC(), limit)
 	return out, rows.Err()
 }
 
+// ListJobLog returns oldest-first job_log lines for a job since the given time.
+func (p *Postgres) ListJobLog(ctx context.Context, jobID string, since time.Time, limit int) ([]JobLogLine, error) {
+	if jobID == "" {
+		return nil, fmt.Errorf("telemetry: job_id required")
+	}
+	if limit <= 0 {
+		limit = 100
+	}
+	var (
+		rows *sql.Rows
+		err  error
+	)
+	if since.IsZero() {
+		rows, err = p.db.QueryContext(ctx, `
+SELECT job_id, ts, line
+FROM job_log WHERE job_id = $1
+ORDER BY ts ASC LIMIT $2`, jobID, limit)
+	} else {
+		rows, err = p.db.QueryContext(ctx, `
+SELECT job_id, ts, line
+FROM job_log WHERE job_id = $1 AND ts >= $2
+ORDER BY ts ASC LIMIT $3`, jobID, since.UTC(), limit)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("telemetry: list job log: %w", err)
+	}
+	defer rows.Close()
+
+	var out []JobLogLine
+	for rows.Next() {
+		var l JobLogLine
+		if err := rows.Scan(&l.JobID, &l.TS, &l.Line); err != nil {
+			return nil, fmt.Errorf("telemetry: scan job log: %w", err)
+		}
+		out = append(out, l)
+	}
+	return out, rows.Err()
+}
+
 func nullStr(s string) any {
 	if s == "" {
 		return nil

--- a/internal/common/telemetry/postgres_integration_test.go
+++ b/internal/common/telemetry/postgres_integration_test.go
@@ -72,5 +72,13 @@ func TestLabPostgresStoreWriteList(t *testing.T) {
 	if len(sens) == 0 || sens[0].Value != 21.5 {
 		t.Fatalf("sensors: %+v", sens)
 	}
-	t.Logf("ok device=%s event_id=%s sensors=%d", device, evs[0].ID, len(sens))
+
+	lines, err := st.ListJobLog(ctx, "job-p4a-probe", time.Time{}, 10)
+	if err != nil {
+		t.Fatalf("list job log: %v", err)
+	}
+	if len(lines) == 0 || lines[0].Line != "phase4a probe line" {
+		t.Fatalf("job log: %+v", lines)
+	}
+	t.Logf("ok device=%s event_id=%s sensors=%d job_log=%d", device, evs[0].ID, len(sens), len(lines))
 }

--- a/internal/common/telemetry/schema.sql
+++ b/internal/common/telemetry/schema.sql
@@ -55,5 +55,6 @@ CREATE TABLE IF NOT EXISTS job_log (
 );
 
 CREATE INDEX IF NOT EXISTS jobs_state_idx ON jobs (state);
+CREATE INDEX IF NOT EXISTS jobs_device_idx ON jobs (device_id);
 CREATE INDEX IF NOT EXISTS events_device_ts_idx ON events (device_id, ts);
 CREATE INDEX IF NOT EXISTS job_log_job_ts_idx ON job_log (job_id, ts);

--- a/internal/common/telemetry/store.go
+++ b/internal/common/telemetry/store.go
@@ -10,11 +10,18 @@ import (
 
 // SensorReading is one numeric sensor sample for sensor_readings.
 type SensorReading struct {
-	DeviceID string
-	TS       time.Time
-	Sensor   string
-	Value    float64
-	Unit     string
+	DeviceID string    `json:"device_id"`
+	TS       time.Time `json:"ts"`
+	Sensor   string    `json:"sensor"`
+	Value    float64   `json:"value"`
+	Unit     string    `json:"unit,omitempty"`
+}
+
+// JobLogLine is one durable job_log row.
+type JobLogLine struct {
+	JobID string    `json:"job_id"`
+	TS    time.Time `json:"ts"`
+	Line  string    `json:"line"`
 }
 
 // Store is the durable telemetry surface (events, sensors, job log lines).
@@ -25,4 +32,7 @@ type Store interface {
 	WriteJobLog(ctx context.Context, jobID string, ts time.Time, line string) error
 	ListEvents(ctx context.Context, deviceID string, since time.Time, limit int) ([]models.NormalizedEvent, error)
 	ListSensors(ctx context.Context, deviceID string, since time.Time, limit int) ([]SensorReading, error)
+	// ListJobLog returns job_log lines oldest-first (a log reads chronologically,
+	// unlike events/sensors which are newest-first "recent activity" feeds).
+	ListJobLog(ctx context.Context, jobID string, since time.Time, limit int) ([]JobLogLine, error)
 }

--- a/internal/common/telemetry/store_test.go
+++ b/internal/common/telemetry/store_test.go
@@ -94,3 +94,52 @@ func TestMemorySensorsAndJobLog(t *testing.T) {
 		t.Fatal("job log")
 	}
 }
+
+func TestMemoryListJobLog(t *testing.T) {
+	st := telemetry.NewMemory()
+	ctx := context.Background()
+	base := time.Date(2026, 7, 13, 12, 0, 0, 0, time.UTC)
+	if err := st.WriteJobLog(ctx, "job-1", base, "first"); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.WriteJobLog(ctx, "job-1", base.Add(time.Minute), "second"); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.WriteJobLog(ctx, "other-job", base, "skip"); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := st.ListJobLog(ctx, "job-1", time.Time{}, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len=%d", len(got))
+	}
+	if got[0].Line != "first" || got[1].Line != "second" {
+		t.Fatalf("want oldest-first [first second], got %+v", got)
+	}
+
+	since, err := st.ListJobLog(ctx, "job-1", base.Add(30*time.Second), 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(since) != 1 || since[0].Line != "second" {
+		t.Fatalf("since filter: %+v", since)
+	}
+
+	capped, err := st.ListJobLog(ctx, "job-1", time.Time{}, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(capped) != 1 || capped[0].Line != "first" {
+		t.Fatalf("limit: %+v", capped)
+	}
+}
+
+func TestMemoryListJobLogRequiresJobID(t *testing.T) {
+	st := telemetry.NewMemory()
+	if _, err := st.ListJobLog(context.Background(), "", time.Time{}, 10); err == nil {
+		t.Fatal("expected error for empty job_id")
+	}
+}

--- a/internal/deploy/jobstore/lab_integration_test.go
+++ b/internal/deploy/jobstore/lab_integration_test.go
@@ -66,5 +66,29 @@ func TestLabPostgresJobStore(t *testing.T) {
 	if !found {
 		t.Fatal("job not in FAILED list")
 	}
+
+	byDevice, err := s.ListByDevice(ctx, "lab-node-1", "", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	found = false
+	for _, j := range byDevice {
+		if j.ID == id {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("job not in ListByDevice result")
+	}
+	byDeviceState, err := s.ListByDevice(ctx, "lab-node-1", models.StateFailed, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, j := range byDeviceState {
+		if j.ID == id && j.State != models.StateFailed {
+			t.Fatalf("state filter leaked non-matching job: %+v", j)
+		}
+	}
+
 	t.Logf("postgres jobstore OK for %s", id)
 }

--- a/internal/deploy/jobstore/memory.go
+++ b/internal/deploy/jobstore/memory.go
@@ -3,6 +3,7 @@ package jobstore
 import (
 	"context"
 	"fmt"
+	"sort"
 	"sync"
 	"time"
 
@@ -58,6 +59,40 @@ func (m *Memory) ListByState(_ context.Context, state models.LifecycleState) ([]
 		if j.State == state {
 			out = append(out, cloneJob(j))
 		}
+	}
+	return out, nil
+}
+
+// ListByDevice returns jobs for deviceID, newest-updated first, optionally
+// filtered by state, capped at limit.
+func (m *Memory) ListByDevice(_ context.Context, deviceID string, state models.LifecycleState, limit int) ([]models.ProvisioningJob, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	var out []models.ProvisioningJob
+	for _, j := range m.jobs {
+		if j.DeviceID != deviceID {
+			continue
+		}
+		if state != "" && j.State != state {
+			continue
+		}
+		out = append(out, cloneJob(j))
+	}
+	sort.Slice(out, func(i, k int) bool {
+		ti, tk := time.Time{}, time.Time{}
+		if out[i].UpdatedAt != nil {
+			ti = *out[i].UpdatedAt
+		}
+		if out[k].UpdatedAt != nil {
+			tk = *out[k].UpdatedAt
+		}
+		return ti.After(tk)
+	})
+	if len(out) > limit {
+		out = out[:limit]
 	}
 	return out, nil
 }

--- a/internal/deploy/jobstore/memory_test.go
+++ b/internal/deploy/jobstore/memory_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/mattcburns/shoal/internal/common/models"
 	"github.com/mattcburns/shoal/internal/deploy/jobstore"
@@ -45,6 +46,55 @@ func TestMemoryStoreLifecycle(t *testing.T) {
 	_, err = s.Get(ctx, "missing")
 	if !errors.Is(err, jobstore.ErrNotFound) {
 		t.Fatalf("want not found: %v", err)
+	}
+}
+
+func TestMemoryListByDevice(t *testing.T) {
+	ctx := context.Background()
+	s := jobstore.NewMemory()
+	older := time.Now().UTC().Add(-time.Hour)
+	newer := time.Now().UTC()
+	seed := []models.ProvisioningJob{
+		{ID: "d4-old", DeviceID: "d4", State: models.StateProvisioned, UpdatedAt: &older},
+		{ID: "d4-new", DeviceID: "d4", State: models.StateFailed, UpdatedAt: &newer},
+		{ID: "other", DeviceID: "d5", State: models.StateProvisioned, UpdatedAt: &newer},
+	}
+	for _, j := range seed {
+		if err := s.Insert(ctx, j); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	list, err := s.ListByDevice(ctx, "d4", "", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(list) != 2 || list[0].ID != "d4-new" || list[1].ID != "d4-old" {
+		t.Fatalf("want [d4-new d4-old] newest-first, got %+v", list)
+	}
+
+	filtered, err := s.ListByDevice(ctx, "d4", models.StateFailed, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(filtered) != 1 || filtered[0].ID != "d4-new" {
+		t.Fatalf("state filter: %+v", filtered)
+	}
+
+	capped, err := s.ListByDevice(ctx, "d4", "", 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(capped) != 1 {
+		t.Fatalf("limit: got %d", len(capped))
+	}
+
+	none, err := s.ListByDevice(ctx, "unknown-device", "", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(none) != 0 {
+		t.Fatalf("unknown device: %+v", none)
 	}
 }
 

--- a/internal/deploy/jobstore/postgres.go
+++ b/internal/deploy/jobstore/postgres.go
@@ -92,6 +92,41 @@ FROM jobs WHERE state = $1`, string(state))
 	return out, rows.Err()
 }
 
+// ListByDevice returns jobs for deviceID, newest-updated first, optionally
+// filtered by state, capped at limit.
+func (p *Postgres) ListByDevice(ctx context.Context, deviceID string, state models.LifecycleState, limit int) ([]models.ProvisioningJob, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+	query := `
+SELECT id, device_id, profile_ref, state, attempt, phase, percent, last_marker_seq,
+       started_at, updated_at, error, sol_session_id, iso_url, bmc_endpoint,
+       system_id, credential_ref, current_stage, install_strategy, stages_json
+FROM jobs WHERE device_id = $1`
+	args := []any{deviceID}
+	if state != "" {
+		query += fmt.Sprintf(" AND state = $%d", len(args)+1)
+		args = append(args, string(state))
+	}
+	query += fmt.Sprintf(" ORDER BY updated_at DESC NULLS LAST LIMIT $%d", len(args)+1)
+	args = append(args, limit)
+
+	rows, err := p.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("jobstore: list by device: %w", err)
+	}
+	defer rows.Close()
+	var out []models.ProvisioningJob
+	for rows.Next() {
+		j, err := scanJob(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, j)
+	}
+	return out, rows.Err()
+}
+
 // UpdateProgress updates progress fields only.
 func (p *Postgres) UpdateProgress(ctx context.Context, jobID string, phase string, percent *int, seq int, errSoft string) error {
 	now := time.Now().UTC()

--- a/internal/deploy/jobstore/store.go
+++ b/internal/deploy/jobstore/store.go
@@ -17,6 +17,9 @@ type Store interface {
 	Insert(ctx context.Context, job models.ProvisioningJob) error
 	Get(ctx context.Context, id string) (models.ProvisioningJob, error)
 	ListByState(ctx context.Context, state models.LifecycleState) ([]models.ProvisioningJob, error)
+	// ListByDevice returns jobs for deviceID, newest-updated first, capped at limit
+	// (<=0 uses the caller's default). state == "" means no state filter.
+	ListByDevice(ctx context.Context, deviceID string, state models.LifecycleState, limit int) ([]models.ProvisioningJob, error)
 	UpdateProgress(ctx context.Context, jobID string, phase string, percent *int, seq int, errSoft string) error
 	// UpdateRuntime persists BMC runtime coordinates for cancel/orphan cleanup.
 	UpdateRuntime(ctx context.Context, jobID string, systemID, solSessionID, credentialRef string) error

--- a/internal/observe/service.go
+++ b/internal/observe/service.go
@@ -108,6 +108,28 @@ func (s *Service) ListEvents(ctx context.Context, deviceID string, since time.Ti
 	return s.Telemetry.ListEvents(ctx, deviceID, since, limit)
 }
 
+// ListSensors returns recent sensor readings for a device.
+func (s *Service) ListSensors(ctx context.Context, deviceID string, since time.Time, limit int) ([]telemetry.SensorReading, error) {
+	if s.Telemetry == nil {
+		return nil, fmt.Errorf("observe: telemetry store not configured (set SHOAL_TELEMETRY_DATABASE_URL)")
+	}
+	if deviceID == "" {
+		return nil, fmt.Errorf("observe: device_id required")
+	}
+	return s.Telemetry.ListSensors(ctx, deviceID, since, limit)
+}
+
+// ListJobLog returns durable job_log lines for a job.
+func (s *Service) ListJobLog(ctx context.Context, jobID string, since time.Time, limit int) ([]telemetry.JobLogLine, error) {
+	if s.Telemetry == nil {
+		return nil, fmt.Errorf("observe: telemetry store not configured (set SHOAL_TELEMETRY_DATABASE_URL)")
+	}
+	if jobID == "" {
+		return nil, fmt.Errorf("observe: job_id required")
+	}
+	return s.Telemetry.ListJobLog(ctx, jobID, since, limit)
+}
+
 // Watching reports whether a SOL watch is active (for operators; not embedded in Phase).
 func (s *Service) Watching(deviceID string) bool {
 	return s.Watches != nil && s.Watches.HasWatch(deviceID)


### PR DESCRIPTION
## Summary

Implements the three "gaps to add" from `docs/netbox-telemetry-ui-design.md` §5.2 so a future NetBox plugin (or any UI) has the read APIs it needs. **Backend only** — the plugin itself is a separate Python/Django artifact (N4+, not linked into the Go binary), explicitly out of scope for this slice.

- **`GET /v1/devices/{id}/jobs?limit=&state=`** — new `jobstore.Store.ListByDevice` (Postgres + memory), new `jobs_device_idx`. Nothing existed below the API layer for this before.
- **`GET /v1/devices/{id}/sensors?since=&limit=`** — new `observe.Service.ListSensors` passthrough over the already-existing, already-tested `telemetry.Store.ListSensors` — mostly just a handler.
- **`GET /v1/jobs/{id}/log?since=&limit=`** — new `telemetry.Store.ListJobLog` (Postgres + memory, oldest-first) + `observe.Service` passthrough. No production code writes to `job_log` today (`WriteJobLog` is only ever called from tests), so this endpoint correctly, honestly returns `{"lines":[]}` until some future writer lands — matches the design doc's own N3 acceptance criterion.
- Shared 200-row `limit` cap on the three new endpoints (design doc calls for a bounded limit; no existing endpoint enforced one — left `status`/`events` unchanged, deliberate scope boundary).
- No composition-root changes — existing `WithObserve`/`WithJobStore` wiring already covers everything these handlers need.
- `docs/netbox-telemetry-ui-design.md` updated: N1-N3 marked done, N4+ (NetBox plugin) still not started.

## Test plan

- [x] `gofmt`, `go vet -tags=integration`, `staticcheck`, full `go test ./...` all clean
- [x] New unit tests: `ListByDevice` (memory), `ListJobLog` (memory), HTTP handler tests for all 3 routes (`devices_test.go`, `jobs_test.go`), auth-gate coverage for all 3 new routes (`auth_test.go`)
- [x] Live Postgres integration tests against the lab DB — `jobs_device_idx` + `ListByDevice` + `ListJobLog` all confirmed against real Postgres (`TestLabPostgresJobStore`, `TestLabPostgresStoreWriteList`)
- [x] Live end-to-end smoke: `go run ./cmd/shoal serve` against the lab DB + real BMC creds, `curl` against all three endpoints — `jobs` returned real filtered data; `sensors`/`log` correctly returned honest empty lists (sushy-tools reports zero sensors for nested lab nodes — pre-existing lab-fidelity gap, not a bug here; no `job_log` writer exists yet — expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)