### PR TITLE
feat(netbox): plugin MVP -- Shoal Status + Events device tabs (N4-N5)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,12 @@ them in the same change — they must stay consistent.
 **Stack:** the application is **Go only** (module
 `github.com/mattcburns/shoal`). There is no dual-stack app. Lab automation
 remains Ansible (and whatever Python the lab tools require). Do **not** add
-application Python packages.
+application Python packages. `extras/netbox-plugin-shoal/` is the one
+exercised instance of that lab-tooling carve-out: a NetBox plugin (Python/
+Django, NetBox plugin SDK) that runs inside the lab's NetBox container and is
+never linked into the Shoal binary — see
+[`docs/netbox-telemetry-ui-design.md`](./docs/netbox-telemetry-ui-design.md).
+Do not treat its presence as license to add Python elsewhere in the app.
 
 ---
 
@@ -116,6 +121,7 @@ shoal/                                    # module: github.com/mattcburns/shoal
     golden/                               # prompt regression fixtures
     redfish/                              # record/replay corpus
   infra/ansible/                          # lab automation (language-agnostic)
+  extras/netbox-plugin-shoal/             # NetBox plugin (Python/Django) -- lab-only, never linked into Go binary
   scripts/
     build-release.sh                      # multi-platform CGO-free release binaries
   .github/workflows/                      # ci.yml + release.yml (v* tags)

--- a/docs/lab-runbook.md
+++ b/docs/lab-runbook.md
@@ -784,6 +784,31 @@ ansible-playbook -i infra/ansible/inventory/lab-vm.yml infra/ansible/playbooks/s
 ansible-playbook -i infra/ansible/inventory/lab-vm.yml infra/ansible/playbooks/bootstrap_netbox.yml
 ```
 
+### Rebuild the NetBox Shoal plugin only
+The lab's NetBox image is built from `extras/netbox-plugin-shoal` (see that
+package's README) rather than pulled directly, so it always includes the
+`netbox_shoal` plugin (Shoal Status/Events tabs on the device page).
+`shoal_netbox_plugin: true` in `all/defaults.yml` controls this; set it to
+`false` to fall back to the plain upstream image.
+
+```bash
+# Re-stage the plugin source + rebuild/recreate the netbox container
+ansible-playbook -i infra/ansible/inventory/lab-vm.yml infra/ansible/playbooks/up.yml --tags shoal,compose
+
+# Verify: no plugin load errors in the NetBox log
+ssh -i ~/.ssh/shoal_lab_vm lab@192.168.122.100 "docker logs shoal-netbox --tail 200" | grep -i shoal
+
+# Verify in the browser: log into http://192.168.122.100:8000 (admin/admin),
+# open any shoal-node-* device, look for "Shoal Status" and "Shoal Events"
+# tabs. Empty/error states render a plain message (never a stack trace) when
+# Shoal is unreachable or a device has no data yet.
+```
+If tabs don't appear: check `PLUGINS_CONFIG` landed correctly
+(`docker exec shoal-netbox cat /etc/netbox/config/plugins.py`), and that
+`SHOAL_BASE_URL` (`http://host.docker.internal:8088` by default — see
+`shoal_netbox_plugin_base_url`) is actually reachable from inside the
+container (`docker exec shoal-netbox curl -sf http://host.docker.internal:8088/healthz`).
+
 ## 4) Direct host mode
 Run the lab stack directly on the L0 host (no nested VM):
 ```bash

--- a/docs/netbox-telemetry-ui-design.md
+++ b/docs/netbox-telemetry-ui-design.md
@@ -1,6 +1,7 @@
 # NetBox integration: visual telemetry, events, and job context
 
-**Status:** Backend API slice (N1-N3) implemented; NetBox plugin (N4+) not started  
+**Status:** Backend API slice (N1-N3) and plugin MVP (N4-N5: Status + Events tabs)
+implemented; Jobs/Sensors tabs (N6) and beyond not started  
 **Date:** July 2026  
 **Audience:** Human architect + coding agents  
 **Related:** Design SoT `SHOAL_COMPREHENSIVE_DESIGN_AND_IMPLEMENTATION_PLAN.md` (v2.0.9+);
@@ -117,26 +118,32 @@ Therefore:
 
 ### 4.2 Identity mapping
 
-| Concept | Source |
-|---------|--------|
-| NetBox device primary key / URL slug | NetBox |
-| `device_id` on jobs/events | Shoal — **must match** the id Discover writes / operators use |
-| BMC endpoint / credential_ref | NetBox custom fields / secrets pattern (existing design) |
+**Resolved (N4/N5, confirmed against `internal/common/netbox/client.go`):** Shoal's
+`device_id` **is the NetBox device's numeric primary key** (string form).
+`Client.UpsertDevice` looks up/creates devices by `serial`, but the NetBox device ID
+returned from that create/lookup is what Shoal writes onto every job/event/telemetry
+row from then on (`internal/discover/service.go`'s `finalize()`). **No dedicated
+`shoal_device_id` custom field is needed or created** — the plugin's views read
+`device.pk` directly off the `Device` object NetBox already resolved for the tab. This
+replaces the speculative "name or `shoal_device_id` CF" MVP rule below, which is kept
+struck through for history.
 
-**MVP rule:** Plugin uses NetBox device **name or a dedicated custom field**
-`shoal_device_id` if present; otherwise NetBox numeric id string only if that is already
-how the lab keys devices. Implementation PR must pin one canonical mapping and document
-lab bootstrap (Discover upsert should set a stable key both sides understand).
+~~**MVP rule:** Plugin uses NetBox device name or a dedicated custom field
+`shoal_device_id` if present; otherwise NetBox numeric id string only if that is
+already how the lab keys devices.~~
 
-Recommended custom fields (identity/pointers only, not history):
+**Custom fields actually bootstrapped** (`infra/ansible/roles/netbox_bootstrap`, all
+`dcim.device`-scoped, plain names — **not** `shoal_`-prefixed as an earlier draft of
+this table assumed):
 
 | Field | Purpose |
 |-------|---------|
-| `shoal_lifecycle_state` | Existing |
-| `shoal_credential_ref` | Existing pattern |
-| `shoal_device_id` | Explicit Shoal key when ≠ NetBox name/id |
-| `shoal_last_job_id` | Optional pointer (updated by Orchestrator on start/terminal) |
-| `shoal_ui_base` | Optional override of global plugin Shoal URL |
+| `lifecycle_state` | Current Shoal lifecycle state |
+| `credential_ref` | Secrets-backend key for BMC credentials (never a password) |
+| `bmc_ip` | Management BMC address |
+
+No `shoal_last_job_id` or `shoal_ui_base` fields exist; both remain optional future
+work (N8 and a per-device Shoal-URL override, respectively), not needed for N4/N5.
 
 ### 4.3 Components
 
@@ -260,23 +267,32 @@ Plugin shows a button: “Open sensor dashboard” with `device_id` variable.
 
 ### 6.1 Device tabs (MVP)
 
-| Tab | Content | Data |
-|-----|---------|------|
-| **Shoal status** | Lifecycle (from status API + NetBox CF), power, active job, phase bar | `GET …/status` |
-| **Events** | Table: ts, severity, type, component, message | `GET …/events` |
-| **Jobs** | Table of recent jobs; link to expand phase/error | `GET …/jobs` |
-| **Sensors** | Latest readings table; optional sparkline later | `GET …/sensors` |
+| Tab | Content | Data | Status |
+|-----|---------|------|--------|
+| **Shoal Status** | Lifecycle, power, active job, phase | `GET …/status` | ✅ N5 |
+| **Shoal Events** | Table: ts, severity, type, component, message | `GET …/events` | ✅ N5 |
+| **Jobs** | Table of recent jobs; link to expand phase/error | `GET …/jobs` | N6, not started |
+| **Sensors** | Latest readings table; optional sparkline later | `GET …/sensors` | N6, not started |
 
 Empty states: “No events yet — has Observe poll run?” with lab runbook link.
 
 ### 6.2 Global plugin configuration
 
-```text
-SHOAL_BASE_URL=http://192.168.122.100:8088   # or internal Docker DNS
-SHOAL_API_TOKEN=…                            # Bearer
-SHOAL_REQUEST_TIMEOUT=10s
-SHOAL_DEVICE_ID_FIELD=shoal_device_id        # or name / id strategy
+Implemented in `extras/netbox-plugin-shoal` (`netbox_shoal.PluginConfig.default_settings`),
+rendered into the lab's `plugins.py` by Ansible (`infra/ansible/roles/compose_stack`):
+
+```python
+PLUGINS_CONFIG = {
+    "netbox_shoal": {
+        "SHOAL_BASE_URL": "http://host.docker.internal:8088",  # empty = "not configured" in the UI
+        "SHOAL_API_TOKEN": "",                                  # optional Bearer; empty = no header sent
+        "SHOAL_REQUEST_TIMEOUT": 10,
+    }
+}
 ```
+
+`SHOAL_DEVICE_ID_FIELD` from the earlier speculative version of this block is dropped —
+see §4.2, no device-id field lookup is needed.
 
 ### 6.3 Optional v2 plugin features
 
@@ -344,8 +360,8 @@ NetBox plugin ──GET jobs by device──► Shoal
 | **N1** | ✅ Shoal API: `GET /v1/devices/{id}/jobs` (+ tests) | Done — `jobstore.Store.ListByDevice`, unit + lab-integration tests |
 | **N2** | ✅ Shoal API: sensors latest (and/or since) | Done — `GET /v1/devices/{id}/sensors`, unit + lab-integration tests |
 | **N3** | ✅ Shoal API: `GET /v1/jobs/{id}/log` | Done — honest empty state confirmed: `job_log` has no production writer yet (`WriteJobLog` is only called from tests), so this endpoint correctly returns `{"lines":[]}` until a writer lands; that writer work is a separate, not-yet-scoped slice |
-| **N4** | NetBox custom fields + config context for Shoal base URL / device id | Lab bootstrap — not started |
-| **N5** | NetBox plugin MVP: Status + Events tabs | Lab demo from device page |
+| **N4** | ✅ Config context for Shoal base URL (no new custom fields needed — see §4.2) | Done — `extras/netbox-plugin-shoal`, Ansible `plugins.py` wiring |
+| **N5** | ✅ NetBox plugin MVP: Status + Events tabs | Done — `extras/netbox-plugin-shoal/netbox_shoal/views.py`; verified live in the lab (both tabs render real job/event data and the designed empty states) |
 | **N6** | Plugin Jobs + Sensors tabs | Lab demo |
 | **N7** | Optional Grafana dashboard + plugin link | Lab compose |
 | **N8** | Optional Orchestrator write of `shoal_last_job_id` pointer | NetBox shows last job link |
@@ -368,12 +384,17 @@ Do **not** block N5 on Grafana or job start-from-NetBox.
 
 ## 12. Open questions
 
-1. **Canonical `device_id`:** NetBox name vs numeric id vs dedicated `shoal_device_id` CF —
-   pin in N4/N5 with Discover alignment.  
-2. **Plugin repo location:** monorepo `extras/netbox-plugin-shoal/` vs separate repo?  
-3. **Read-only API token** vs single token for MVP?  
-4. **job_log population:** which components write today; is N3 blocked until writers land?  
-5. **Historical sensor retention** and Grafana retention policy?  
+1. ✅ **Canonical `device_id`:** resolved — NetBox numeric device ID (`device.pk`), matching
+   `internal/common/netbox/client.go`'s existing `UpsertDevice` convention. No new custom
+   field. See §4.2.
+2. ✅ **Plugin repo location:** resolved — monorepo `extras/netbox-plugin-shoal/`.
+3. **Read-only API token** vs single token for MVP: still open, but moot for N4/N5 — the
+   plugin only calls `GET` routes (never starts/cancels jobs), so the existing single
+   `SHOAL_API_TOKEN` is sufficient until a write-capable feature is built.
+4. ✅ **job_log population:** resolved (see N3, PR #32) — no production writer exists yet;
+   `GET /v1/jobs/{id}/log` honestly returns `{"lines":[]}` until one lands. Not relevant to
+   N4/N5 (Status/Events tabs don't call this endpoint).
+5. **Historical sensor retention** and Grafana retention policy: still open, relevant to N6/N7.
 
 ---
 

--- a/extras/netbox-plugin-shoal/.gitignore
+++ b/extras/netbox-plugin-shoal/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.pyc
+*.egg-info/
+.venv/
+build/
+dist/

--- a/extras/netbox-plugin-shoal/Dockerfile
+++ b/extras/netbox-plugin-shoal/Dockerfile
@@ -1,0 +1,11 @@
+# Bakes the netbox-shoal plugin into the lab's NetBox image. Pinned to the
+# same NetBox version as infra/ansible/roles/compose_stack (see that role's
+# docker-compose.lab.yml.j2 for why: v4.6+ netbox-docker switched to v2 API
+# tokens and breaks the bootstrap playbook's fixed-key token creation).
+FROM docker.io/netboxcommunity/netbox:v4.5.10-4.0.2
+
+# This image ships no `pip` at all (deliberately stripped -- deps are managed
+# with `uv`, already on PATH). VIRTUAL_ENV is already set to the netbox venv,
+# so a bare `uv pip install` targets it without extra flags.
+COPY . /opt/netbox-shoal
+RUN uv pip install --no-cache /opt/netbox-shoal

--- a/extras/netbox-plugin-shoal/README.md
+++ b/extras/netbox-plugin-shoal/README.md
@@ -1,0 +1,66 @@
+# netbox-shoal
+
+A NetBox plugin that adds **Shoal Status** and **Shoal Events** tabs to the
+device detail page, reading [Shoal](https://github.com/mattcburns/shoal)'s
+HTTP API server-side. See
+[`docs/netbox-telemetry-ui-design.md`](../../docs/netbox-telemetry-ui-design.md)
+in the main repo for the full design; this package covers slices N4+N5
+(plugin skeleton + Status/Events tabs). Jobs/Sensors tabs (N6) are a
+follow-up.
+
+This is the first Python code in the Shoal repo. It runs entirely inside the
+lab's NetBox container — it is never linked into the Shoal Go binary and
+follows AGENTS.md's "lab automation... and whatever Python the lab tools
+require" carve-out from the project's Go-only application stack rule, not an
+exception to it.
+
+## Identity convention
+
+Shoal's `device_id` **is** the NetBox device's own numeric primary key
+(`str(device.pk)`) — established by `internal/common/netbox/client.go`'s
+`UpsertDevice`, which looks devices up by serial but keys everything
+downstream (jobs, events, telemetry) by the NetBox device ID it gets back.
+No separate `shoal_device_id` custom field is needed or used; each view here
+just reads `instance.pk` off the `Device` it's already rendering.
+
+## Configuration
+
+Set in NetBox's `configuration.py` (or, in the lab, the Ansible-rendered
+`plugins.py` mounted alongside it — see `infra/ansible/roles/compose_stack`):
+
+```python
+PLUGINS = ["netbox_shoal"]
+
+PLUGINS_CONFIG = {
+    "netbox_shoal": {
+        "SHOAL_BASE_URL": "http://192.168.122.100:8088",  # empty = "not configured" state in the UI
+        "SHOAL_API_TOKEN": "",                             # optional Bearer token; empty = no header sent
+        "SHOAL_REQUEST_TIMEOUT": 10,                        # seconds
+    }
+}
+```
+
+## Development
+
+```bash
+cd extras/netbox-plugin-shoal
+python -m unittest discover -s tests
+```
+
+The `client.py` module is deliberately Django-settings-only (no models, no
+migrations), so it's unit-testable with stdlib `unittest` + `unittest.mock`
+without a full NetBox test app/database. View-level (`ObjectView`) behavior
+is verified by manual lab smoke test (see `docs/lab-runbook.md`), not
+automated here yet — building full NetBox Django test-app scaffolding is a
+larger, separate piece of work.
+
+## Building into the lab image
+
+```bash
+docker build -t netbox-shoal:local extras/netbox-plugin-shoal
+```
+
+In the lab, this happens automatically via
+`infra/ansible/roles/compose_stack` (the `netbox` service builds from
+`extras/netbox-plugin-shoal/Dockerfile` instead of pulling the upstream
+image directly).

--- a/extras/netbox-plugin-shoal/netbox_shoal/__init__.py
+++ b/extras/netbox-plugin-shoal/netbox_shoal/__init__.py
@@ -1,0 +1,31 @@
+"""NetBox plugin: Shoal device telemetry tabs (status, events).
+
+Renders Shoal (github.com/mattcburns/shoal) device status/events on the
+NetBox device detail page, reading Shoal's HTTP API server-side. See
+docs/netbox-telemetry-ui-design.md in the main Shoal repo for the design.
+"""
+
+from netbox.plugins import PluginConfig
+
+
+class ShoalConfig(PluginConfig):
+    name = "netbox_shoal"
+    verbose_name = "Shoal Telemetry"
+    description = "Shoal device status/events tabs on the NetBox device page"
+    version = "0.1.0"
+    author = "Shoal contributors"
+    base_url = "shoal"
+
+    # Read from PLUGINS_CONFIG["netbox_shoal"] in configuration.py.
+    # SHOAL_BASE_URL empty means "not configured" -- views render a plain
+    # message rather than erroring. SHOAL_API_TOKEN empty means no
+    # Authorization header is sent, matching Shoal's own auth gate (which is
+    # a no-op when SHOAL_API_TOKEN is unset -- the lab default).
+    default_settings = {
+        "SHOAL_BASE_URL": "",
+        "SHOAL_API_TOKEN": "",
+        "SHOAL_REQUEST_TIMEOUT": 10,
+    }
+
+
+config = ShoalConfig

--- a/extras/netbox-plugin-shoal/netbox_shoal/client.py
+++ b/extras/netbox-plugin-shoal/netbox_shoal/client.py
@@ -1,0 +1,51 @@
+"""Thin HTTP client for the Shoal API, used by the plugin's views.
+
+Deliberately minimal: no retries, no caching, one request per call. Base URL
+and token come only from PLUGINS_CONFIG (admin-configured), never from
+request input -- the plugin never proxies an operator-supplied host, so
+there's no SSRF surface here by construction.
+
+Returns (data, error) tuples instead of raising so views can render a plain
+"Shoal unavailable" message rather than a 500 when Shoal is down, unreachable,
+or simply not configured yet.
+"""
+
+import requests
+from django.conf import settings
+
+PLUGIN_NAME = "netbox_shoal"
+
+
+def _cfg():
+    return settings.PLUGINS_CONFIG.get(PLUGIN_NAME, {})
+
+
+def _get(path, params=None):
+    cfg = _cfg()
+    base = (cfg.get("SHOAL_BASE_URL") or "").rstrip("/")
+    if not base:
+        return None, "Shoal base URL not configured (SHOAL_BASE_URL)"
+
+    headers = {}
+    token = cfg.get("SHOAL_API_TOKEN")
+    if token:
+        headers["Authorization"] = "Bearer " + token
+
+    timeout = cfg.get("SHOAL_REQUEST_TIMEOUT", 10)
+
+    try:
+        resp = requests.get(base + path, headers=headers, params=params, timeout=timeout)
+        resp.raise_for_status()
+        return resp.json(), None
+    except requests.RequestException as exc:
+        return None, str(exc)
+
+
+def get_status(device_id):
+    """GET /v1/devices/{id}/status -> (models.DeviceStatus dict, error)."""
+    return _get("/v1/devices/%s/status" % device_id)
+
+
+def get_events(device_id, limit=50):
+    """GET /v1/devices/{id}/events?limit= -> ({"device_id","events":[...]}, error)."""
+    return _get("/v1/devices/%s/events" % device_id, params={"limit": limit})

--- a/extras/netbox-plugin-shoal/netbox_shoal/templates/netbox_shoal/events.html
+++ b/extras/netbox-plugin-shoal/netbox_shoal/templates/netbox_shoal/events.html
@@ -1,0 +1,46 @@
+{% extends 'generic/object.html' %}
+
+{% block content %}
+  <div class="row">
+    <div class="col col-md-12">
+      <div class="card">
+        <h5 class="card-header">Shoal Events</h5>
+        <div class="card-body">
+          {% if shoal_error %}
+            <div class="alert alert-warning" role="alert">
+              Shoal unavailable: {{ shoal_error }}
+            </div>
+          {% elif not shoal_events %}
+            <div class="alert alert-info" role="alert">
+              No events yet — has Observe poll run? See the lab runbook for
+              how to enable SEL/sensor polling.
+            </div>
+          {% else %}
+            <table class="table table-hover">
+              <thead>
+                <tr>
+                  <th scope="col">Time</th>
+                  <th scope="col">Severity</th>
+                  <th scope="col">Type</th>
+                  <th scope="col">Component</th>
+                  <th scope="col">Message</th>
+                </tr>
+              </thead>
+              <tbody>
+                {% for event in shoal_events %}
+                  <tr>
+                    <td>{{ event.timestamp|default:"—" }}</td>
+                    <td>{{ event.severity|default:"—" }}</td>
+                    <td>{{ event.event_type|default:"—" }}</td>
+                    <td>{{ event.component|default:"—" }}</td>
+                    <td>{{ event.message|default:"—" }}</td>
+                  </tr>
+                {% endfor %}
+              </tbody>
+            </table>
+          {% endif %}
+        </div>
+      </div>
+    </div>
+  </div>
+{% endblock %}

--- a/extras/netbox-plugin-shoal/netbox_shoal/templates/netbox_shoal/status.html
+++ b/extras/netbox-plugin-shoal/netbox_shoal/templates/netbox_shoal/status.html
@@ -1,0 +1,32 @@
+{% extends 'generic/object.html' %}
+
+{% block content %}
+  <div class="row">
+    <div class="col col-md-12">
+      <div class="card">
+        <h5 class="card-header">Shoal Status</h5>
+        <div class="card-body">
+          {% if shoal_error %}
+            <div class="alert alert-warning" role="alert">
+              Shoal unavailable: {{ shoal_error }}
+            </div>
+          {% elif not shoal_status %}
+            <div class="alert alert-info" role="alert">
+              No Shoal status for this device yet.
+            </div>
+          {% else %}
+            <table class="table table-hover attr-table">
+              <tr><th scope="row">Lifecycle state</th><td>{{ shoal_status.lifecycle_state|default:"—" }}</td></tr>
+              <tr><th scope="row">Power state</th><td>{{ shoal_status.power_state|default:"—" }}</td></tr>
+              <tr><th scope="row">Active job</th><td>{{ shoal_status.active_job_id|default:"—" }}</td></tr>
+              <tr><th scope="row">Phase</th><td>{{ shoal_status.phase|default:"—" }}</td></tr>
+              <tr><th scope="row">Percent</th><td>{{ shoal_status.percent|default:"—" }}</td></tr>
+              <tr><th scope="row">Last event</th><td>{{ shoal_status.last_event|default:"—" }}</td></tr>
+              <tr><th scope="row">Updated</th><td>{{ shoal_status.updated_at|default:"—" }}</td></tr>
+            </table>
+          {% endif %}
+        </div>
+      </div>
+    </div>
+  </div>
+{% endblock %}

--- a/extras/netbox-plugin-shoal/netbox_shoal/urls.py
+++ b/extras/netbox-plugin-shoal/netbox_shoal/urls.py
@@ -1,0 +1,16 @@
+"""No plugin-specific URL patterns needed -- both views attach to the
+existing dcim.Device model via @register_model_view(Device, name=...) in
+views.py, and NetBox's own dcim/urls.py (get_model_urls('dcim', 'device'))
+discovers and routes to them automatically.
+
+The `from . import views` below is not unused despite nothing referencing
+it directly: it's what makes Django actually execute views.py (and thus run
+the @register_model_view decorators) at plugin load time. Confirmed the
+hard way -- without this import, nothing ever imports views.py, the
+decorators never run, and the tabs silently don't exist (no 500, no log
+line, just a 404 on every guessed URL).
+"""
+
+from . import views  # noqa: F401
+
+urlpatterns = []

--- a/extras/netbox-plugin-shoal/netbox_shoal/views.py
+++ b/extras/netbox-plugin-shoal/netbox_shoal/views.py
@@ -1,0 +1,49 @@
+"""Device-page tabs: Shoal Status and Shoal Events.
+
+Each view resolves the NetBox Device it's attached to and uses its numeric
+primary key (str(device.pk)) as the Shoal device_id -- this is the identity
+convention Shoal's own NetBox client (internal/common/netbox/client.go)
+already establishes: UpsertDevice keys by serial, but the NetBox device ID
+returned from that create/lookup becomes Shoal's device_id from then on. No
+separate "shoal_device_id" custom field is needed.
+"""
+
+from dcim.models import Device
+from netbox.views import generic
+from utilities.views import ViewTab, register_model_view
+
+from . import client
+
+
+@register_model_view(Device, name="shoal_status")
+class ShoalStatusView(generic.ObjectView):
+    queryset = Device.objects.all()
+    template_name = "netbox_shoal/status.html"
+    tab = ViewTab(
+        label="Shoal Status",
+        permission="dcim.view_device",
+    )
+
+    def get_extra_context(self, request, instance):
+        data, error = client.get_status(str(instance.pk))
+        return {
+            "shoal_status": data,
+            "shoal_error": error,
+        }
+
+
+@register_model_view(Device, name="shoal_events")
+class ShoalEventsView(generic.ObjectView):
+    queryset = Device.objects.all()
+    template_name = "netbox_shoal/events.html"
+    tab = ViewTab(
+        label="Shoal Events",
+        permission="dcim.view_device",
+    )
+
+    def get_extra_context(self, request, instance):
+        data, error = client.get_events(str(instance.pk), limit=50)
+        return {
+            "shoal_events": (data or {}).get("events", []),
+            "shoal_error": error,
+        }

--- a/extras/netbox-plugin-shoal/pyproject.toml
+++ b/extras/netbox-plugin-shoal/pyproject.toml
@@ -1,0 +1,20 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "netbox-shoal"
+version = "0.1.0"
+description = "NetBox plugin: Shoal device telemetry tabs (status, events)"
+readme = "README.md"
+requires-python = ">=3.10"
+license = { text = "AGPL-3.0-or-later" }
+# requests is already a core NetBox dependency -- this adds nothing new to
+# the image's dependency set.
+dependencies = ["requests"]
+
+[tool.setuptools.packages.find]
+include = ["netbox_shoal*"]
+
+[tool.setuptools.package-data]
+netbox_shoal = ["templates/netbox_shoal/*.html"]

--- a/extras/netbox-plugin-shoal/tests/test_client.py
+++ b/extras/netbox-plugin-shoal/tests/test_client.py
@@ -1,0 +1,138 @@
+"""Unit tests for netbox_shoal.client.
+
+Django-settings-only: no NetBox app registry, no models, no database needed.
+`django.conf.settings.configure()` is enough to exercise the plugin-config
+reading + requests-mocking logic in isolation.
+"""
+
+import sys
+import types
+import unittest
+from unittest import mock
+
+import django
+from django.conf import settings
+
+if not settings.configured:
+    settings.configure(
+        PLUGINS_CONFIG={
+            "netbox_shoal": {
+                "SHOAL_BASE_URL": "http://shoal.example:8088",
+                "SHOAL_API_TOKEN": "",
+                "SHOAL_REQUEST_TIMEOUT": 10,
+            }
+        }
+    )
+    django.setup()
+
+# netbox_shoal/__init__.py imports `netbox.plugins.PluginConfig` at package
+# import time -- that module only exists inside a running NetBox instance.
+# client.py itself has no NetBox dependency (only requests + django.conf),
+# so stub the minimum needed to import the package outside NetBox rather
+# than requiring a full NetBox install just to unit-test the HTTP client.
+if "netbox.plugins" not in sys.modules:
+    fake_netbox = types.ModuleType("netbox")
+    fake_netbox_plugins = types.ModuleType("netbox.plugins")
+    fake_netbox_plugins.PluginConfig = object
+    fake_netbox.plugins = fake_netbox_plugins
+    sys.modules["netbox"] = fake_netbox
+    sys.modules["netbox.plugins"] = fake_netbox_plugins
+
+from netbox_shoal import client  # noqa: E402  (import after settings.configure + stub)
+
+
+class FakeResponse:
+    def __init__(self, json_data, status_code=200):
+        self._json = json_data
+        self.status_code = status_code
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            import requests
+
+            raise requests.HTTPError("status %d" % self.status_code)
+
+    def json(self):
+        return self._json
+
+
+class GetStatusTests(unittest.TestCase):
+    def setUp(self):
+        # Reset PLUGINS_CONFIG to a known-good base before each test.
+        settings.PLUGINS_CONFIG = {
+            "netbox_shoal": {
+                "SHOAL_BASE_URL": "http://shoal.example:8088",
+                "SHOAL_API_TOKEN": "",
+                "SHOAL_REQUEST_TIMEOUT": 10,
+            }
+        }
+
+    @mock.patch("netbox_shoal.client.requests.get")
+    def test_get_status_success(self, mock_get):
+        mock_get.return_value = FakeResponse({"device_id": "1", "lifecycle_state": "provisioned"})
+        data, err = client.get_status("1")
+        self.assertIsNone(err)
+        self.assertEqual(data["lifecycle_state"], "provisioned")
+        mock_get.assert_called_once()
+        args, kwargs = mock_get.call_args
+        self.assertEqual(args[0], "http://shoal.example:8088/v1/devices/1/status")
+        self.assertNotIn("Authorization", kwargs["headers"])
+
+    @mock.patch("netbox_shoal.client.requests.get")
+    def test_get_status_sends_bearer_token_when_configured(self, mock_get):
+        settings.PLUGINS_CONFIG["netbox_shoal"]["SHOAL_API_TOKEN"] = "secret-token"
+        mock_get.return_value = FakeResponse({"device_id": "1"})
+        client.get_status("1")
+        _, kwargs = mock_get.call_args
+        self.assertEqual(kwargs["headers"]["Authorization"], "Bearer secret-token")
+
+    def test_get_status_without_base_url_returns_error_not_exception(self):
+        settings.PLUGINS_CONFIG["netbox_shoal"]["SHOAL_BASE_URL"] = ""
+        data, err = client.get_status("1")
+        self.assertIsNone(data)
+        self.assertIn("not configured", err)
+
+    @mock.patch("netbox_shoal.client.requests.get")
+    def test_get_status_network_error_returns_tuple_not_raises(self, mock_get):
+        import requests
+
+        mock_get.side_effect = requests.ConnectionError("connection refused")
+        data, err = client.get_status("1")
+        self.assertIsNone(data)
+        self.assertIn("connection refused", err)
+
+    @mock.patch("netbox_shoal.client.requests.get")
+    def test_get_status_http_error_returns_tuple_not_raises(self, mock_get):
+        mock_get.return_value = FakeResponse({"error": "internal error"}, status_code=500)
+        data, err = client.get_status("1")
+        self.assertIsNone(data)
+        self.assertIsNotNone(err)
+
+
+class GetEventsTests(unittest.TestCase):
+    def setUp(self):
+        settings.PLUGINS_CONFIG = {
+            "netbox_shoal": {
+                "SHOAL_BASE_URL": "http://shoal.example:8088",
+                "SHOAL_API_TOKEN": "",
+                "SHOAL_REQUEST_TIMEOUT": 10,
+            }
+        }
+
+    @mock.patch("netbox_shoal.client.requests.get")
+    def test_get_events_passes_limit_param(self, mock_get):
+        mock_get.return_value = FakeResponse({"device_id": "1", "events": []})
+        client.get_events("1", limit=25)
+        _, kwargs = mock_get.call_args
+        self.assertEqual(kwargs["params"], {"limit": 25})
+
+    @mock.patch("netbox_shoal.client.requests.get")
+    def test_get_events_default_limit(self, mock_get):
+        mock_get.return_value = FakeResponse({"device_id": "1", "events": []})
+        client.get_events("1")
+        _, kwargs = mock_get.call_args
+        self.assertEqual(kwargs["params"], {"limit": 50})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/infra/ansible/inventory/group_vars/all/defaults.yml
+++ b/infra/ansible/inventory/group_vars/all/defaults.yml
@@ -50,6 +50,17 @@ shoal_compose_app: true
 # Optional Bearer token for /v1/* (empty = open lab API). Prefer vault.
 shoal_api_token: ""
 
+# Build the netbox_shoal plugin into the lab's NetBox image (adds Shoal
+# Status/Events tabs to the device page). See extras/netbox-plugin-shoal.
+shoal_netbox_plugin: true
+# The Shoal app runs network_mode: host, so it's not reachable from
+# bridge-networked containers (like netbox) via 127.0.0.1 -- that resolves to
+# the container itself, not the host. host.docker.internal (wired via
+# extra_hosts: host-gateway in the netbox service) works the same way in both
+# VM-hosted and direct-host lab modes, so this one value covers both instead
+# of needing a per-mode override.
+shoal_netbox_plugin_base_url: "http://host.docker.internal:{{ shoal_app_http_port }}"
+
 # --- AI provider (see design doc §6 / v2.0.4 dual-model contract) ---
 # Provider is "ollama" (local, served by the shoal-ollama container) or "cloud".
 # The Ollama base URL is mode-specific (see vm_mode.yml / direct_mode.yml).

--- a/infra/ansible/roles/compose_stack/tasks/main.yml
+++ b/infra/ansible/roles/compose_stack/tasks/main.yml
@@ -59,6 +59,15 @@
   when: shoal_compose_app | default(true) | bool
   tags: [config, shoal]
 
+- name: Stage netbox_shoal plugin build context on lab host
+  ansible.builtin.copy:
+    src: "{{ playbook_dir }}/../../../extras/netbox-plugin-shoal/"
+    dest: "{{ shoal_compose_dir }}/netbox-shoal-build/"
+    mode: '0644'
+    directory_mode: '0755'
+  when: shoal_netbox_plugin | default(true) | bool
+  tags: [config, shoal]
+
 - name: Copy Docker Compose file
   template:
     src: docker-compose.lab.yml.j2
@@ -141,6 +150,14 @@
   when: generated_secret.stdout | default('') | length > 0
   no_log: true
   tags: [config]
+
+- name: Write NetBox plugins.py (netbox_shoal)
+  template:
+    src: netbox-plugins.py.j2
+    dest: "{{ shoal_compose_dir }}/netbox-config/plugins.py"
+    mode: '0644'
+  when: shoal_netbox_plugin | default(true) | bool
+  tags: [config, shoal]
 
 - name: Generate NetBox API token pepper if missing
   shell:

--- a/infra/ansible/roles/compose_stack/templates/docker-compose.lab.yml.j2
+++ b/infra/ansible/roles/compose_stack/templates/docker-compose.lab.yml.j2
@@ -4,8 +4,20 @@ services:
     # API tokens that require API_TOKEN_PEPPERS and a key+token pair, breaking
     # the bootstrap playbook's fixed-key token creation. Verify the tag before
     # upgrading.
+{% if shoal_netbox_plugin | default(true) | bool %}
+    # Built from extras/netbox-plugin-shoal (bakes in the netbox_shoal
+    # plugin) instead of pulling the upstream image directly.
+    build:
+      context: {{ shoal_compose_dir }}/netbox-shoal-build
+    image: netbox-shoal:lab
+{% else %}
     image: docker.io/netboxcommunity/netbox:v4.5.10-4.0.2
+{% endif %}
     container_name: shoal-netbox
+    extra_hosts:
+      # Lets this bridge-networked container reach the host-networked shoal
+      # service (see shoal_netbox_plugin_base_url in all/defaults.yml).
+      - "host.docker.internal:host-gateway"
     environment:
       - SUPERUSER_NAME=admin
       - SUPERUSER_EMAIL=admin@example.com
@@ -41,6 +53,9 @@ services:
       - netbox-scripts:/opt/netbox/netbox/scripts
       - {{ shoal_compose_dir }}/netbox-config/secret_key.py:/etc/netbox/config/secret_key.py:ro
       - {{ shoal_compose_dir }}/netbox-config/api_token_pepper_1:/run/secrets/api_token_pepper_1:ro
+{% if shoal_netbox_plugin | default(true) | bool %}
+      - {{ shoal_compose_dir }}/netbox-config/plugins.py:/etc/netbox/config/plugins.py:ro
+{% endif %}
     restart: unless-stopped
     networks:
       - shoal-lab

--- a/infra/ansible/roles/compose_stack/templates/netbox-plugins.py.j2
+++ b/infra/ansible/roles/compose_stack/templates/netbox-plugins.py.j2
@@ -1,0 +1,16 @@
+# Rendered by Ansible (compose_stack role) and mounted at
+# /etc/netbox/config/plugins.py, alongside secret_key.py -- netbox-docker
+# execs every /etc/netbox/config/*.py file into configuration.py's namespace,
+# so this is additive and needs no upstream image changes.
+#
+# See extras/netbox-plugin-shoal/README.md for the plugin itself.
+
+PLUGINS = ["netbox_shoal"]
+
+PLUGINS_CONFIG = {
+    "netbox_shoal": {
+        "SHOAL_BASE_URL": "{{ shoal_netbox_plugin_base_url }}",
+        "SHOAL_API_TOKEN": "{{ shoal_api_token | default('') }}",
+        "SHOAL_REQUEST_TIMEOUT": 10,
+    }
+}


### PR DESCRIPTION
## Summary

Adds `extras/netbox-plugin-shoal`, a NetBox plugin (Python/Django) that renders Shoal device telemetry on the NetBox device detail page, reading the N1-N3 backend APIs (PR #32) server-side. **This is the first Python code in the repo** — it runs entirely inside the lab's NetBox container, never linked into the Shoal Go binary, per AGENTS.md's existing "lab automation... and whatever Python the lab tools require" carve-out from the Go-only application stack rule.

**Resolves both open questions the design doc flagged for the plugin:**
- **Canonical `device_id`:** confirmed from `internal/common/netbox/client.go` that Shoal's `device_id` already *is* the NetBox device's numeric primary key (`UpsertDevice` keys by serial, but the returned NetBox device ID is what's written onto every job/event/telemetry row from then on). No new custom field needed — views just read `device.pk`.
- **Plugin repo location:** monorepo `extras/netbox-plugin-shoal/`, alongside `infra/ansible` and `infra/scripts`.

**Scope:** Status + Events tabs only (N4+N5). Jobs/Sensors tabs (N6) are a smaller follow-up now that the plugin skeleton/packaging exists.

**Lab packaging:** `infra/ansible/roles/compose_stack` now builds NetBox from `extras/netbox-plugin-shoal/Dockerfile` instead of pulling the upstream image directly, and renders a `plugins.py` mounted the same way `secret_key.py` already is (`shoal_netbox_plugin: true` toggles this, default on).

**Two real bugs found only by actually deploying this to the lab:**
- The pinned netbox-docker image ships **no `pip`** at all (deps managed via `uv`) — Dockerfile now uses `uv pip install`.
- `@register_model_view` decorators never execute unless something imports the module they're in; the plugin's `urls.py` didn't import `views.py`, so the tabs silently 404'd with no error anywhere. Fixed and documented inline so the next person doesn't hit the same silent failure.

## Test plan

- [x] `client.py` unit tests (stdlib `unittest` + `mock`, no NetBox/Django harness needed) pass
- [x] Verified live against the lab from **both** an incremental rebuild and a **full clean `down.yml`/`up.yml` cycle**: both tabs render real job/event data and the designed empty states ("No events yet — has Observe poll run?") correctly, never a stack trace
- [x] `smoke.yml` passes clean
- [ ] Jobs/Sensors tabs (N6) — out of scope for this PR, tracked as a follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)