### PR TITLE
feat(netbox): plugin Jobs + Sensors tabs (N6)

### DIFF
--- a/docs/netbox-telemetry-ui-design.md
+++ b/docs/netbox-telemetry-ui-design.md
@@ -1,7 +1,7 @@
 # NetBox integration: visual telemetry, events, and job context
 
 **Status:** Backend API slice (N1-N3) and plugin MVP (N4-N5: Status + Events tabs)
-implemented; Jobs/Sensors tabs (N6) and beyond not started  
+and plugin Jobs/Sensors tabs (N6) implemented; N7+ not started  
 **Date:** July 2026  
 **Audience:** Human architect + coding agents  
 **Related:** Design SoT `SHOAL_COMPREHENSIVE_DESIGN_AND_IMPLEMENTATION_PLAN.md` (v2.0.9+);
@@ -271,8 +271,8 @@ Plugin shows a button: “Open sensor dashboard” with `device_id` variable.
 |-----|---------|------|--------|
 | **Shoal Status** | Lifecycle, power, active job, phase | `GET …/status` | ✅ N5 |
 | **Shoal Events** | Table: ts, severity, type, component, message | `GET …/events` | ✅ N5 |
-| **Jobs** | Table of recent jobs; link to expand phase/error | `GET …/jobs` | N6, not started |
-| **Sensors** | Latest readings table; optional sparkline later | `GET …/sensors` | N6, not started |
+| **Jobs** | Table of recent jobs (id, state, phase, percent, profile, updated, error) | `GET …/jobs` | ✅ N6 |
+| **Sensors** | Flat readings table (sensor, value, unit, ts); no sparkline yet | `GET …/sensors` | ✅ N6 |
 
 Empty states: “No events yet — has Observe poll run?” with lab runbook link.
 
@@ -362,7 +362,7 @@ NetBox plugin ──GET jobs by device──► Shoal
 | **N3** | ✅ Shoal API: `GET /v1/jobs/{id}/log` | Done — honest empty state confirmed: `job_log` has no production writer yet (`WriteJobLog` is only called from tests), so this endpoint correctly returns `{"lines":[]}` until a writer lands; that writer work is a separate, not-yet-scoped slice |
 | **N4** | ✅ Config context for Shoal base URL (no new custom fields needed — see §4.2) | Done — `extras/netbox-plugin-shoal`, Ansible `plugins.py` wiring |
 | **N5** | ✅ NetBox plugin MVP: Status + Events tabs | Done — `extras/netbox-plugin-shoal/netbox_shoal/views.py`; verified live in the lab (both tabs render real job/event data and the designed empty states) |
-| **N6** | Plugin Jobs + Sensors tabs | Lab demo |
+| **N6** | ✅ Plugin Jobs + Sensors tabs | Done — `ShoalJobsView`/`ShoalSensorsView`; verified live in the lab |
 | **N7** | Optional Grafana dashboard + plugin link | Lab compose |
 | **N8** | Optional Orchestrator write of `shoal_last_job_id` pointer | NetBox shows last job link |
 

--- a/extras/netbox-plugin-shoal/netbox_shoal/client.py
+++ b/extras/netbox-plugin-shoal/netbox_shoal/client.py
@@ -49,3 +49,16 @@ def get_status(device_id):
 def get_events(device_id, limit=50):
     """GET /v1/devices/{id}/events?limit= -> ({"device_id","events":[...]}, error)."""
     return _get("/v1/devices/%s/events" % device_id, params={"limit": limit})
+
+
+def get_jobs(device_id, limit=50, state=None):
+    """GET /v1/devices/{id}/jobs?limit=&state= -> ({"device_id","jobs":[...]}, error)."""
+    params = {"limit": limit}
+    if state:
+        params["state"] = state
+    return _get("/v1/devices/%s/jobs" % device_id, params=params)
+
+
+def get_sensors(device_id, limit=50):
+    """GET /v1/devices/{id}/sensors?limit= -> ({"device_id","readings":[...]}, error)."""
+    return _get("/v1/devices/%s/sensors" % device_id, params={"limit": limit})

--- a/extras/netbox-plugin-shoal/netbox_shoal/templates/netbox_shoal/jobs.html
+++ b/extras/netbox-plugin-shoal/netbox_shoal/templates/netbox_shoal/jobs.html
@@ -1,0 +1,49 @@
+{% extends 'generic/object.html' %}
+
+{% block content %}
+  <div class="row">
+    <div class="col col-md-12">
+      <div class="card">
+        <h5 class="card-header">Shoal Jobs</h5>
+        <div class="card-body">
+          {% if shoal_error %}
+            <div class="alert alert-warning" role="alert">
+              Shoal unavailable: {{ shoal_error }}
+            </div>
+          {% elif not shoal_jobs %}
+            <div class="alert alert-info" role="alert">
+              No jobs recorded for this device yet.
+            </div>
+          {% else %}
+            <table class="table table-hover">
+              <thead>
+                <tr>
+                  <th scope="col">ID</th>
+                  <th scope="col">State</th>
+                  <th scope="col">Phase</th>
+                  <th scope="col">Percent</th>
+                  <th scope="col">Profile</th>
+                  <th scope="col">Updated</th>
+                  <th scope="col">Error</th>
+                </tr>
+              </thead>
+              <tbody>
+                {% for job in shoal_jobs %}
+                  <tr>
+                    <td>{{ job.id|default:"—" }}</td>
+                    <td>{{ job.state|default:"—" }}</td>
+                    <td>{{ job.phase|default:"—" }}</td>
+                    <td>{{ job.percent|default:"—" }}</td>
+                    <td>{{ job.profile_ref|default:"—" }}</td>
+                    <td>{{ job.updated_at|default:"—" }}</td>
+                    <td>{{ job.error|default:"—" }}</td>
+                  </tr>
+                {% endfor %}
+              </tbody>
+            </table>
+          {% endif %}
+        </div>
+      </div>
+    </div>
+  </div>
+{% endblock %}

--- a/extras/netbox-plugin-shoal/netbox_shoal/templates/netbox_shoal/sensors.html
+++ b/extras/netbox-plugin-shoal/netbox_shoal/templates/netbox_shoal/sensors.html
@@ -1,0 +1,44 @@
+{% extends 'generic/object.html' %}
+
+{% block content %}
+  <div class="row">
+    <div class="col col-md-12">
+      <div class="card">
+        <h5 class="card-header">Shoal Sensors</h5>
+        <div class="card-body">
+          {% if shoal_error %}
+            <div class="alert alert-warning" role="alert">
+              Shoal unavailable: {{ shoal_error }}
+            </div>
+          {% elif not shoal_sensors %}
+            <div class="alert alert-info" role="alert">
+              No sensor readings yet — has Observe poll run? See the lab
+              runbook for how to enable SEL/sensor polling.
+            </div>
+          {% else %}
+            <table class="table table-hover">
+              <thead>
+                <tr>
+                  <th scope="col">Sensor</th>
+                  <th scope="col">Value</th>
+                  <th scope="col">Unit</th>
+                  <th scope="col">Time</th>
+                </tr>
+              </thead>
+              <tbody>
+                {% for reading in shoal_sensors %}
+                  <tr>
+                    <td>{{ reading.sensor|default:"—" }}</td>
+                    <td>{{ reading.value|default:"—" }}</td>
+                    <td>{{ reading.unit|default:"—" }}</td>
+                    <td>{{ reading.ts|default:"—" }}</td>
+                  </tr>
+                {% endfor %}
+              </tbody>
+            </table>
+          {% endif %}
+        </div>
+      </div>
+    </div>
+  </div>
+{% endblock %}

--- a/extras/netbox-plugin-shoal/netbox_shoal/views.py
+++ b/extras/netbox-plugin-shoal/netbox_shoal/views.py
@@ -1,4 +1,4 @@
-"""Device-page tabs: Shoal Status and Shoal Events.
+"""Device-page tabs: Shoal Status, Events, Jobs, and Sensors.
 
 Each view resolves the NetBox Device it's attached to and uses its numeric
 primary key (str(device.pk)) as the Shoal device_id -- this is the identity
@@ -45,5 +45,39 @@ class ShoalEventsView(generic.ObjectView):
         data, error = client.get_events(str(instance.pk), limit=50)
         return {
             "shoal_events": (data or {}).get("events", []),
+            "shoal_error": error,
+        }
+
+
+@register_model_view(Device, name="shoal_jobs")
+class ShoalJobsView(generic.ObjectView):
+    queryset = Device.objects.all()
+    template_name = "netbox_shoal/jobs.html"
+    tab = ViewTab(
+        label="Shoal Jobs",
+        permission="dcim.view_device",
+    )
+
+    def get_extra_context(self, request, instance):
+        data, error = client.get_jobs(str(instance.pk), limit=50)
+        return {
+            "shoal_jobs": (data or {}).get("jobs", []),
+            "shoal_error": error,
+        }
+
+
+@register_model_view(Device, name="shoal_sensors")
+class ShoalSensorsView(generic.ObjectView):
+    queryset = Device.objects.all()
+    template_name = "netbox_shoal/sensors.html"
+    tab = ViewTab(
+        label="Shoal Sensors",
+        permission="dcim.view_device",
+    )
+
+    def get_extra_context(self, request, instance):
+        data, error = client.get_sensors(str(instance.pk), limit=50)
+        return {
+            "shoal_sensors": (data or {}).get("readings", []),
             "shoal_error": error,
         }

--- a/extras/netbox-plugin-shoal/tests/test_client.py
+++ b/extras/netbox-plugin-shoal/tests/test_client.py
@@ -134,5 +134,82 @@ class GetEventsTests(unittest.TestCase):
         self.assertEqual(kwargs["params"], {"limit": 50})
 
 
+class GetJobsTests(unittest.TestCase):
+    def setUp(self):
+        settings.PLUGINS_CONFIG = {
+            "netbox_shoal": {
+                "SHOAL_BASE_URL": "http://shoal.example:8088",
+                "SHOAL_API_TOKEN": "",
+                "SHOAL_REQUEST_TIMEOUT": 10,
+            }
+        }
+
+    @mock.patch("netbox_shoal.client.requests.get")
+    def test_get_jobs_url_and_default_limit(self, mock_get):
+        mock_get.return_value = FakeResponse({"device_id": "1", "jobs": []})
+        client.get_jobs("1")
+        args, kwargs = mock_get.call_args
+        self.assertEqual(args[0], "http://shoal.example:8088/v1/devices/1/jobs")
+        self.assertEqual(kwargs["params"], {"limit": 50})
+
+    @mock.patch("netbox_shoal.client.requests.get")
+    def test_get_jobs_omits_state_when_not_given(self, mock_get):
+        mock_get.return_value = FakeResponse({"device_id": "1", "jobs": []})
+        client.get_jobs("1", limit=10)
+        _, kwargs = mock_get.call_args
+        self.assertNotIn("state", kwargs["params"])
+
+    @mock.patch("netbox_shoal.client.requests.get")
+    def test_get_jobs_passes_state_filter(self, mock_get):
+        mock_get.return_value = FakeResponse({"device_id": "1", "jobs": []})
+        client.get_jobs("1", limit=10, state="failed")
+        _, kwargs = mock_get.call_args
+        self.assertEqual(kwargs["params"], {"limit": 10, "state": "failed"})
+
+    @mock.patch("netbox_shoal.client.requests.get")
+    def test_get_jobs_returns_data_on_success(self, mock_get):
+        mock_get.return_value = FakeResponse(
+            {"device_id": "1", "jobs": [{"id": "j1", "state": "provisioning"}]}
+        )
+        data, err = client.get_jobs("1")
+        self.assertIsNone(err)
+        self.assertEqual(data["jobs"][0]["id"], "j1")
+
+
+class GetSensorsTests(unittest.TestCase):
+    def setUp(self):
+        settings.PLUGINS_CONFIG = {
+            "netbox_shoal": {
+                "SHOAL_BASE_URL": "http://shoal.example:8088",
+                "SHOAL_API_TOKEN": "",
+                "SHOAL_REQUEST_TIMEOUT": 10,
+            }
+        }
+
+    @mock.patch("netbox_shoal.client.requests.get")
+    def test_get_sensors_url_and_default_limit(self, mock_get):
+        mock_get.return_value = FakeResponse({"device_id": "1", "readings": []})
+        client.get_sensors("1")
+        args, kwargs = mock_get.call_args
+        self.assertEqual(args[0], "http://shoal.example:8088/v1/devices/1/sensors")
+        self.assertEqual(kwargs["params"], {"limit": 50})
+
+    @mock.patch("netbox_shoal.client.requests.get")
+    def test_get_sensors_passes_limit(self, mock_get):
+        mock_get.return_value = FakeResponse({"device_id": "1", "readings": []})
+        client.get_sensors("1", limit=5)
+        _, kwargs = mock_get.call_args
+        self.assertEqual(kwargs["params"], {"limit": 5})
+
+    @mock.patch("netbox_shoal.client.requests.get")
+    def test_get_sensors_returns_data_on_success(self, mock_get):
+        mock_get.return_value = FakeResponse(
+            {"device_id": "1", "readings": [{"sensor": "Inlet Temp", "value": 24.5, "unit": "Cel"}]}
+        )
+        data, err = client.get_sensors("1")
+        self.assertIsNone(err)
+        self.assertEqual(data["readings"][0]["sensor"], "Inlet Temp")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Extends `extras/netbox-plugin-shoal` with the two remaining read-only tabs from the design doc's MVP (N4-N6): **Shoal Jobs** (recent jobs for the device: id, state, phase, percent, profile, updated, error) and **Shoal Sensors** (flat since/limit readings: sensor, value, unit, ts).

Reuses the exact `client.py`/`views.py`/template pattern from the Status + Events tabs (#33) — no new packaging or URL-registration issues this time since those were already solved there (`uv` vs `pip`, `urls.py` needing to import `views.py` for `@register_model_view` to actually run).

This closes out the NetBox plugin's read-only MVP (N4-N6). N7 (optional Grafana link) and N8 (optional `shoal_last_job_id` pointer) remain unstarted, explicitly optional per the design doc.

## Test plan

- [x] `client.py` unit tests pass (14, up from 7)
- [x] Verified live in the lab: both tabs render the designed empty states ("No jobs recorded...", "No sensor readings yet — has Observe poll run?") and real inserted job/sensor data correctly
- [x] `smoke.yml` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)