### PR TITLE
feat(netbox): demo polish — power, credentials, firmware, real BMC poll

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -288,15 +288,24 @@ go run ./cmd/shoal deploy run \
 | `SHOAL_PROFILE_DIR` | JSON provisioning profiles + approval records (Phase 5b). Lab Ansible default: `/var/lib/shoal/profiles` via `shoal_profile_dir` + `env.j2`. Empty disables non-spike profile load |
 | `SHOAL_API_TOKEN` | Phase 6d: if non-empty, require `Authorization: Bearer …` for `/v1/*`. Empty = open (lab default). Never log. |
 | `SHOAL_SERIAL_TRANSPORT` | `libvirt` (default, unchanged lab behavior) \| `redfish_sol`. Orchestrator-wide default; `StartJobRequest.serial_transport` overrides per job. Real-hardware only; see `docs/real-hardware-sol-runbook.md`. |
+| `SHOAL_POLL_IDLE_INTERVAL` | Background SEL/sensor poll when no SOL watch. Go duration (default `5m`). |
+| `SHOAL_POLL_WATCH_INTERVAL` | Elevated poll while a SOL watch is active. Go duration (default `30s`). |
 
 
 Full table and Ansible extension points: design doc §8.1.
 
-**Phase 4 Observe:** `shoal observe status|poll`, `GET /v1/devices/{id}/status` and
-`…/events`. Poll uses Redfish `ListSEL`/`ListSensors` → durable `telemetry.Store`
-only (no silent memory fallback). Empty SEL/sensors with exit 0 is valid when the
-BMC has no logs; write failures and Redfish errors fail the poll. Observe never
-imports Deploy (job reads via `jobport.JobQuery`).
+**Phase 4 Observe:** `shoal observe status|poll|power`, `GET /v1/devices/{id}/status` and
+`…/events`, `POST /v1/devices/{id}/power` (On / ForceOff / ForceRestart; not a job),
+`POST /v1/devices/{id}/poll` (on-demand SEL + sensors + firmware inventory +
+power state), `GET /v1/devices/{id}/firmware`. Background poller is
+`SHOAL_POLL_IDLE_INTERVAL` (default 5m) / `SHOAL_POLL_WATCH_INTERVAL` (default
+30s while a SOL watch is active), and only auto-seeds devices that have a
+job; on-demand poll also `SetTarget`s the device. Poll uses Redfish
+`ListSEL`/`ListSensors`/`ListFirmware`/`GetSystem` → durable `telemetry.Store`
+only (no silent memory fallback). Empty SEL/sensors/firmware with exit 0 is
+valid when the BMC has no logs;
+write failures and Redfish errors fail the poll. Observe never imports Deploy
+(job reads via `jobport.JobQuery`).
 
 **Phase 5–6a Deploy:** Orchestrator best-effort syncs NetBox `lifecycle_state`.
 Profiles under `SHOAL_PROFILE_DIR`; destruct needs approve or `-approve-destruct`.

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ gofmt -w . && go vet ./... && staticcheck ./... && go test ./...
 ### NetBox plugin
 [`extras/netbox-plugin-shoal/`](extras/netbox-plugin-shoal/README.md) is a
 NetBox plugin (Python/Django — the one place in this repo Go isn't used;
-see the "Stack" note in `AGENTS.md`) that adds read-only **Shoal Status**,
-**Events**, **Jobs**, and **Sensors** tabs to the NetBox device page, reading
+see the "Stack" note in `AGENTS.md`) that adds **Shoal Status**,
+**Events**, **Jobs**, **Sensors**, and **Firmware** tabs to the NetBox device page, reading
 the API above server-side. It's baked into the lab's NetBox image by default
 (`shoal_netbox_plugin: true`); see
 [`docs/netbox-telemetry-ui-design.md`](docs/netbox-telemetry-ui-design.md)

--- a/SHOAL_COMPREHENSIVE_DESIGN_AND_IMPLEMENTATION_PLAN.md
+++ b/SHOAL_COMPREHENSIVE_DESIGN_AND_IMPLEMENTATION_PLAN.md
@@ -1348,6 +1348,8 @@ Default VM-hosted endpoints: NetBox `:8000`, sushy `:8001`, ISO HTTP `:8080`, Ol
 | `SHOAL_FEWSHOT_DIR` | no | Append-only learned few-shot JSONL (Phase 3b confirm). Lab default via Ansible `shoal_fewshot_dir` → `/var/lib/shoal/fewshot` in `env.j2` + mkdir. Empty disables confirm |
 | `SHOAL_PROFILE_DIR` | no | JSON provisioning profiles + approval records (Phase 5b). Lab default via Ansible `shoal_profile_dir` → `/var/lib/shoal/profiles` in `env.j2` + mkdir. Empty disables non-spike profile load; `spike` profile ref always allowed without a store |
 | `SHOAL_API_TOKEN` | no | Phase 6d: Bearer token for `/v1/*` when set; empty = open API (lab default). Never log. Lab Ansible: `shoal_api_token` (vault optional) |
+| `SHOAL_POLL_IDLE_INTERVAL` | no | Background SEL/sensor poll when no SOL watch. Go `time.ParseDuration` (default `5m`) |
+| `SHOAL_POLL_WATCH_INTERVAL` | no | Elevated poll while a SOL watch is active. Go duration (default `30s`) |
 | `shoal_compose_app` (Ansible) | — | Phase 6d: when true (lab default), stage binary + Dockerfile and run Compose service `shoal` (`network_mode: host`, port `shoal_app_http_port` / 8088) |
 
 **Ansible extensions (when packaging app service):**

--- a/SHOAL_COMPREHENSIVE_DESIGN_AND_IMPLEMENTATION_PLAN.md
+++ b/SHOAL_COMPREHENSIVE_DESIGN_AND_IMPLEMENTATION_PLAN.md
@@ -1026,6 +1026,8 @@ type DeviceIdentity struct {
     ID             string         `json:"id,omitempty"`
     Name           string         `json:"name,omitempty"`
     Serial         string         `json:"serial"`
+    Vendor         string         `json:"vendor,omitempty"` // Redfish Manufacturer; empty → lab virtual defaults
+    Model          string         `json:"model,omitempty"`  // Redfish Model → NetBox device type
     LifecycleState LifecycleState `json:"lifecycle_state"`
     CredentialRef  string         `json:"credential_ref"`
     BMCIP          string         `json:"bmc_ip"`

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -1,7 +1,9 @@
 # Minimal runtime image: copy a pre-built CGO-free shoal binary.
 # Build context is staged by Ansible (binary + this Dockerfile).
+# libvirt-client: lab Compose mounts the host libvirt socket so SOL
+# (virsh ttyconsole) works for jobs started via NetBox / API.
 FROM alpine:3.20
-RUN apk add --no-cache ca-certificates
+RUN apk add --no-cache ca-certificates libvirt-client
 COPY shoal /usr/local/bin/shoal
 RUN chmod +x /usr/local/bin/shoal
 EXPOSE 8088

--- a/docs/lab-runbook.md
+++ b/docs/lab-runbook.md
@@ -262,7 +262,9 @@ them on an existing lab, re-run bootstrap (or create CFs once) and re-ingest
 devices so values land in custom fields instead of comments.
 
 NetBox down does **not** block BMC actions (warn log only). Device key is the
-job `device_id` (serial preferred after Discover ingest).
+job `device_id`. With NetBox configured, Start **remaps** name/serial (e.g.
+`shoal-node-1`) to the NetBox numeric primary key so plugin tabs see the job.
+Bootstrap sets each lab node **serial = name** for that resolve path.
 
 **Cross-process cancel/cleanup:** jobs persist `system_id` + `credential_ref`.
 Use a **shared** secrets dir so the cancel process can resolve BMC credentials:
@@ -809,6 +811,82 @@ If tabs don't appear: check `PLUGINS_CONFIG` landed correctly
 `SHOAL_BASE_URL` (`http://host.docker.internal:8088` by default — see
 `shoal_netbox_plugin_base_url`) is actually reachable from inside the
 container (`docker exec shoal-netbox curl -sf http://host.docker.internal:8088/healthz`).
+
+### NetBox demo (VM-hosted lab)
+
+End-to-end path for a polished read-only demo: Status/Jobs progress bars, stage
+list, job log lines from SOL markers, and NetBox `lifecycle_state` CF updates.
+
+**Prereqs:** lab up + smoke green; marker ISO published; Shoal app listening on
+`:8088` (Compose app or `go run ./cmd/shoal serve`); NetBox plugin tabs present.
+
+1. **Identity (bootstrap once / after re-bootstrap)** — lab nodes get
+   `serial = name` (`shoal-node-1`, …) and `bmc_ip`:
+
+   ```bash
+   ansible-playbook -i infra/ansible/inventory/lab-vm.yml \
+     infra/ansible/playbooks/bootstrap_netbox.yml
+   ```
+
+2. **Env on the operator (L0) against the VM lab** (token from vault /
+   bootstrap):
+
+   ```bash
+   export SHOAL_NETBOX_URL=http://192.168.122.100:8000
+   export SHOAL_NETBOX_TOKEN=…   # shoal_netbox_api_token
+   export SHOAL_TELEMETRY_DATABASE_URL='postgres://shoal:…@192.168.122.100:5433/shoal_telemetry?sslmode=disable'
+   export SHOAL_BMC_USERNAME=admin SHOAL_BMC_PASSWORD=…   # vault
+   export SHOAL_SERIAL_SSH_HOST=192.168.122.100
+   export SHOAL_SERIAL_SSH_KEY=$HOME/.ssh/shoal_lab_vm
+   # Optional if not using Compose app:
+   # go run ./cmd/shoal serve -addr :8088
+   ```
+
+3. **Start a short simulate job** (hostname is fine — Start remaps to NetBox pk
+   when NetBox env is set):
+
+   ```bash
+   go run ./cmd/shoal deploy run \
+     -device-id shoal-node-1 \
+     -bmc-url http://192.168.122.100:8001 \
+     -serial-target shoal-node-1 \
+     -iso-url http://192.168.124.1:8080/shoal-marker.iso \
+     -wait
+   ```
+
+   Prefer starting via the **Compose `shoal` service** (same env) if that is how
+   the lab runs, so the plugin’s `SHOAL_BASE_URL` hits the same process that
+   owns the job + job_log writer.
+
+4. **Open NetBox** → Devices → **shoal-node-1**:
+
+   | Tab / field | What you should see |
+   |-------------|---------------------|
+   | Device custom field `lifecycle_state` | `provisioning` → `provisioned` (or `failed`) |
+   | **Shoal Status** | Lifecycle badge, phase, animated progress while running; stages panel; job log (`SHOAL\|…` lines) |
+   | **Shoal Status → Provision** | **Start provision** (demo write path): prefills lab BMC URL + marker ISO; uses Shoal `SHOAL_BMC_*` when user/pass left blank. Requires `dcim.change_device` (NetBox admin). **Cancel** when a job is provisioning. |
+   | **Shoal Jobs** | Job row with state badge + progress + stages; log for active/latest job; cancel active |
+   | **Shoal Events / Sensors** | Often empty on nested sushy (valid); not the demo focus |
+
+   Status/Jobs **auto-refresh every 5s** while a job is `provisioning`.
+
+   Prefer starting from NetBox when Compose `shoal-app` has libvirt SOL (privileged +
+   `/var/run/libvirt` mount from current compose template). CLI `deploy run` from L0
+   with `SHOAL_SERIAL_SSH_*` remains the fallback.
+
+5. **If Jobs/Status are empty** while deploy succeeded:
+
+   - Confirm resolve: job JSON `device_id` should be a **number string** (NetBox
+     pk), not `shoal-node-1`. If it stayed a hostname, NetBox env was missing
+     on the process that started the job, or serial was never set (re-run
+     bootstrap).
+   - From NetBox container:
+     `curl -sf http://host.docker.internal:8088/v1/devices/<pk>/jobs`
+   - Rebuild plugin image if templates are stale (`up.yml --tags shoal,compose`).
+
+**Fidelity notes for demos:** simulate/marker jobs prove the NetBox UX loop.
+Full OS image-write (Phase 7a) and multi-stage prep demos take longer but use
+the same tabs. Events/Sensors need real BMC SEL/sensors or seeded telemetry.
 
 ## 4) Direct host mode
 Run the lab stack directly on the L0 host (no nested VM):

--- a/docs/lab-runbook.md
+++ b/docs/lab-runbook.md
@@ -221,10 +221,16 @@ export SHOAL_BMC_USERNAME=… SHOAL_BMC_PASSWORD=…
 go run ./cmd/shoal observe status -device-id shoal-node-1
 go run ./cmd/shoal observe status -device-id shoal-node-1 -events 10
 
-# One-shot Redfish SEL + sensor poll → durable telemetry only
+# One-shot Redfish SEL + sensors + firmware + power → durable telemetry only
 go run ./cmd/shoal observe poll \
   -device-id shoal-node-1 \
   -bmc-url http://192.168.122.100:8001
+
+# Serve also exposes:
+#   POST /v1/devices/{id}/poll
+#   GET  /v1/devices/{id}/firmware
+#   POST /v1/devices/{id}/power
+#   GET/PUT /v1/devices/{id}/credentials
 
 # Multi-system sushy: pass -system-id when using -bmc-url for power state
 go run ./cmd/shoal observe status -device-id shoal-node-1 \
@@ -232,7 +238,8 @@ go run ./cmd/shoal observe status -device-id shoal-node-1 \
 
 # With serve: GET /v1/devices/{id}/status and /v1/devices/{id}/events
 # Background poller runs only when DSN is healthy; seeds jobs with bmc_endpoint;
-# interval elevates while a SOL watch is active (15s vs 60s idle).
+# interval elevates while a SOL watch is active (SHOAL_POLL_WATCH_INTERVAL,
+# default 30s vs SHOAL_POLL_IDLE_INTERVAL default 5m).
 ```
 
 **What “pass” means on lab:**
@@ -243,7 +250,13 @@ go run ./cmd/shoal observe status -device-id shoal-node-1 \
 - `ActiveJobID` is only set for `provisioning` jobs (failed jobs expose lifecycle
   + error, not an “active” id).
 
-**Lab fidelity:** rich SEL/sensors need real BMC hardware.
+**Lab fidelity:** rich SEL/sensors/firmware need real BMC hardware. Nested
+sushy often returns empty SEL/sensors and no UpdateService (empty is valid).
+On-demand `POST /v1/devices/{id}/poll` (NetBox Sensors/Firmware **Poll BMC**)
+also registers the device on the background poller. Idle default is **5m**
+(`SHOAL_POLL_IDLE_INTERVAL`); **30s** while SOL is watched
+(`SHOAL_POLL_WATCH_INTERVAL`). The poller auto-seeds only devices that already
+have a job.
 
 ### Phase 5a: NetBox lifecycle on deploy
 
@@ -789,8 +802,8 @@ ansible-playbook -i infra/ansible/inventory/lab-vm.yml infra/ansible/playbooks/b
 ### Rebuild the NetBox Shoal plugin only
 The lab's NetBox image is built from `extras/netbox-plugin-shoal` (see that
 package's README) rather than pulled directly, so it always includes the
-`netbox_shoal` plugin (Status, Events, Jobs, and Sensors tabs on the device
-page). `shoal_netbox_plugin: true` in `all/defaults.yml` controls this; set it
+`netbox_shoal` plugin (Status, Events, Jobs, Sensors, and Firmware tabs on the
+device page). `shoal_netbox_plugin: true` in `all/defaults.yml` controls this; set it
 to `false` to fall back to the plain upstream image.
 
 ```bash
@@ -802,9 +815,9 @@ ssh -i ~/.ssh/shoal_lab_vm lab@192.168.122.100 "docker logs shoal-netbox --tail 
 
 # Verify in the browser: log into http://192.168.122.100:8000 (admin/admin),
 # open any shoal-node-* device, look for "Shoal Status", "Shoal Events",
-# "Shoal Jobs", and "Shoal Sensors" tabs. Empty/error states render a plain
-# message (never a stack trace) when Shoal is unreachable or a device has no
-# data yet.
+# "Shoal Jobs", "Shoal Sensors", and "Shoal Firmware" tabs. Empty/error states
+# render a plain message (never a stack trace) when Shoal is unreachable or a
+# device has no data yet.
 ```
 If tabs don't appear: check `PLUGINS_CONFIG` landed correctly
 (`docker exec shoal-netbox cat /etc/netbox/config/plugins.py`), and that
@@ -863,10 +876,10 @@ list, job log lines from SOL markers, and NetBox `lifecycle_state` CF updates.
    | Tab / field | What you should see |
    |-------------|---------------------|
    | Device custom field `lifecycle_state` | `provisioning` → `provisioned` (or `failed`) |
-   | **Shoal Status** | Lifecycle badge, phase, animated progress while running; stages panel; job log (`SHOAL\|…` lines) |
-   | **Shoal Status → Provision** | **Start provision** (demo write path): prefills lab BMC URL + marker ISO; uses Shoal `SHOAL_BMC_*` when user/pass left blank. Requires `dcim.change_device` (NetBox admin). **Cancel** when a job is provisioning. |
+   | **Shoal Status** | Lifecycle badge, last polled power, phase, animated progress while running; stages panel; job log (`SHOAL\|…` lines); **BMC credentials** (saved in Shoal secrets); **Host power** |
+   | **Shoal Status → Provision** | **Start provision** (demo write path): prefills lab BMC URL + marker ISO (real servers use `https://<bmc_ip>`). Empty user/pass uses `SHOAL_BMC_*` (not the stored per-device secret). Requires `dcim.change_device`. **Cancel** when a job is provisioning. Lab sushy + libvirt SOL is the path that completes; real BMC SOL + ISO reachability is still a gap. |
    | **Shoal Jobs** | Job row with state badge + progress + stages; log for active/latest job; cancel active |
-   | **Shoal Events / Sensors** | Often empty on nested sushy (valid); not the demo focus |
+   | **Shoal Events / Sensors / Firmware** | Often empty on nested sushy (valid). Real BMC: **Poll BMC** fills SEL, sensors (null readings keep a note), firmware inventory, and power. |
 
    Status/Jobs **auto-refresh every 5s** while a job is `provisioning`.
 

--- a/docs/netbox-telemetry-ui-design.md
+++ b/docs/netbox-telemetry-ui-design.md
@@ -1,12 +1,17 @@
 # NetBox integration: visual telemetry, events, and job context
 
 **Status:** Read-only MVP complete — backend APIs **N1–N3** and plugin tabs
-**N4–N6** (Status, Events, Jobs, Sensors) implemented and lab-verified. Demo
+**N4–N6** (Status, Events, Jobs, Sensors) plus **Firmware** (gather-only). Demo
 polish: job_log production writer (SOL markers), device_id name/serial → NetBox
 pk remap on Start, plugin progress/stages/log + auto-refresh, bootstrap
 serial=name. Demo write path: NetBox Status **Start provision / Cancel** (plugin
-v0.3) → `POST /v1/jobs` / cancel; lab defaults + Shoal `SHOAL_BMC_*` so passwords
-stay off NetBox. **N7** Grafana and richer wizard still open.
+v0.4) → `POST /v1/jobs` / cancel; **Host power**, **BMC credentials** (password
+in Shoal secrets only), **Poll BMC** (SEL + sensors + firmware + power).
+Physical servers prefill `https://<bmc_ip>`; lab virtual BMC nodes keep the
+shared sushy URL. Status credentials GET passes `credential_ref` so Shoal does
+not call NetBox while a device page is rendering. Power/poll resolve stored
+secrets then `SHOAL_BMC_*`; Start provision still uses env defaults when the
+form leaves user/pass blank. **N7** Grafana and richer wizard still open.
 **Date:** July 2026 (status updated August 2026)  
 **Audience:** Human architect + coding agents  
 **Related:** Design SoT `SHOAL_COMPREHENSIVE_DESIGN_AND_IMPLEMENTATION_PLAN.md` (v2.0.9+);
@@ -34,8 +39,8 @@ inventory inside Shoal.
 | Layer | Role today |
 |-------|------------|
 | **NetBox** | Device identity + current `lifecycle_state` (+ credential ref / BMC metadata as designed) |
-| **Shoal telemetry DB** | `jobs`, `events`, `sensor_readings`, `job_log` |
-| **Shoal API** | Device status/events; job start/status/cancel; metrics |
+| **Shoal telemetry DB** | `jobs`, `events`, `sensor_readings`, `job_log`, `device_power`, `firmware_inventory` |
+| **Shoal API** | Device status/events/sensors/firmware; poll; power; credentials; job start/status/cancel; metrics |
 | **Operator UX** | API + CLI only (no first-party browser UI in MVP) |
 
 ### 2.2 What operators want
@@ -44,6 +49,7 @@ From **NetBox** (where they already look at devices):
 
 - See recent **SEL / normalized events**
 - See **sensor** context (latest and/or simple history)
+- See **firmware inventory** (gather-only) and last **power state**
 - See **active / recent provisioning jobs** and phase/progress
 - Optionally tail **job log** lines related to that device
 - Navigate without juggling raw URLs and tokens
@@ -192,7 +198,11 @@ MVP may use the existing single token with plugin only calling GET routes.
 
 | Method | Path | Use in UI |
 |--------|------|-----------|
-| `GET` | `/v1/devices/{id}/status` | Status tab: lifecycle, power, active job, phase/percent |
+| `GET` | `/v1/devices/{id}/status` | Status tab: lifecycle, power (from last poll), active job, phase/percent |
+| `GET` | `/v1/devices/{id}/firmware` | Firmware tab: gather-only Redfish FirmwareInventory snapshot |
+| `POST` | `/v1/devices/{id}/poll` | On-demand Redfish SEL + sensors + firmware + power into telemetry (also registers the device on the background poller: `SHOAL_POLL_IDLE_INTERVAL` / `SHOAL_POLL_WATCH_INTERVAL`) |
+| `POST` | `/v1/devices/{id}/power` | Host power: `{reset_type,bmc_endpoint,…}` — On / ForceOff / ForceRestart (not a provision job). Empty `bmc_endpoint` fills `https://<bmc_ip>` from NetBox. |
+| `GET`/`PUT` | `/v1/devices/{id}/credentials` | BMC username + has_password + credential_ref (password never returned; stored in secrets backend). `GET ?credential_ref=` skips NetBox lookup. |
 | `GET` | `/v1/devices/{id}/events?since=&limit=` | Events/SEL tab |
 | `GET` | `/v1/jobs/{id}` | Job detail panel |
 | `GET` | `/metrics` | Ops only; not NetBox-facing |
@@ -274,10 +284,11 @@ Plugin shows a button: “Open sensor dashboard” with `device_id` variable.
 
 | Tab | Content | Data | Status |
 |-----|---------|------|--------|
-| **Shoal Status** | Lifecycle badge, progress bar, phase, stages panel, job log, 5s auto-refresh while provisioning | `GET …/status` + jobs + log | ✅ N5 + demo polish |
+| **Shoal Status** | Lifecycle badge, last polled power, progress/stages/log, BMC credentials form, host power, Start/Cancel; 5s auto-refresh while provisioning | `GET …/status` + jobs + log + credentials | ✅ N5 + demo polish |
 | **Shoal Events** | Table: ts, severity badge, type, component, message | `GET …/events` | ✅ N5 |
 | **Jobs** | Table with badges/progress/stages + active/latest job log; auto-refresh | `GET …/jobs` + log | ✅ N6 + demo polish |
 | **Sensors** | Flat readings table (sensor, value, unit, ts); no sparkline yet | `GET …/sensors` | ✅ N6 |
+| **Firmware** | Gather-only inventory (name, version, health); Poll BMC | `GET …/firmware` | gather-only |
 
 Empty states: “No events yet — has Observe poll run?” with lab runbook link.
 

--- a/docs/netbox-telemetry-ui-design.md
+++ b/docs/netbox-telemetry-ui-design.md
@@ -1,8 +1,12 @@
 # NetBox integration: visual telemetry, events, and job context
 
 **Status:** Read-only MVP complete — backend APIs **N1–N3** and plugin tabs
-**N4–N6** (Status, Events, Jobs, Sensors) implemented and lab-verified; **N7+**
-(Grafana link, last-job pointer, write actions) not started.  
+**N4–N6** (Status, Events, Jobs, Sensors) implemented and lab-verified. Demo
+polish: job_log production writer (SOL markers), device_id name/serial → NetBox
+pk remap on Start, plugin progress/stages/log + auto-refresh, bootstrap
+serial=name. Demo write path: NetBox Status **Start provision / Cancel** (plugin
+v0.3) → `POST /v1/jobs` / cancel; lab defaults + Shoal `SHOAL_BMC_*` so passwords
+stay off NetBox. **N7** Grafana and richer wizard still open.
 **Date:** July 2026 (status updated August 2026)  
 **Audience:** Human architect + coding agents  
 **Related:** Design SoT `SHOAL_COMPREHENSIVE_DESIGN_AND_IMPLEMENTATION_PLAN.md` (v2.0.9+);
@@ -270,9 +274,9 @@ Plugin shows a button: “Open sensor dashboard” with `device_id` variable.
 
 | Tab | Content | Data | Status |
 |-----|---------|------|--------|
-| **Shoal Status** | Lifecycle, power, active job, phase | `GET …/status` | ✅ N5 |
-| **Shoal Events** | Table: ts, severity, type, component, message | `GET …/events` | ✅ N5 |
-| **Jobs** | Table of recent jobs (id, state, phase, percent, profile, updated, error) | `GET …/jobs` | ✅ N6 |
+| **Shoal Status** | Lifecycle badge, progress bar, phase, stages panel, job log, 5s auto-refresh while provisioning | `GET …/status` + jobs + log | ✅ N5 + demo polish |
+| **Shoal Events** | Table: ts, severity badge, type, component, message | `GET …/events` | ✅ N5 |
+| **Jobs** | Table with badges/progress/stages + active/latest job log; auto-refresh | `GET …/jobs` + log | ✅ N6 + demo polish |
 | **Sensors** | Flat readings table (sensor, value, unit, ts); no sparkline yet | `GET …/sensors` | ✅ N6 |
 
 Empty states: “No events yet — has Observe poll run?” with lab runbook link.
@@ -360,7 +364,7 @@ NetBox plugin ──GET jobs by device──► Shoal
 | **N0** | This design merged | Docs only |
 | **N1** | ✅ Shoal API: `GET /v1/devices/{id}/jobs` (+ tests) | Done — `jobstore.Store.ListByDevice`, unit + lab-integration tests |
 | **N2** | ✅ Shoal API: sensors latest (and/or since) | Done — `GET /v1/devices/{id}/sensors`, unit + lab-integration tests |
-| **N3** | ✅ Shoal API: `GET /v1/jobs/{id}/log` | Done — honest empty state confirmed: `job_log` has no production writer yet (`WriteJobLog` is only called from tests), so this endpoint correctly returns `{"lines":[]}` until a writer lands; that writer work is a separate, not-yet-scoped slice |
+| **N3** | ✅ Shoal API: `GET /v1/jobs/{id}/log` + production writer | Done — Deploy `progressAdapter` best-effort `WriteJobLog` on SOL markers (and stall/transport); empty list only when no markers yet or telemetry DSN unset |
 | **N4** | ✅ Config context for Shoal base URL (no new custom fields needed — see §4.2) | Done — `extras/netbox-plugin-shoal`, Ansible `plugins.py` wiring |
 | **N5** | ✅ NetBox plugin MVP: Status + Events tabs | Done — `extras/netbox-plugin-shoal/netbox_shoal/views.py`; verified live in the lab (both tabs render real job/event data and the designed empty states) |
 | **N6** | ✅ Plugin Jobs + Sensors tabs | Done — `ShoalJobsView`/`ShoalSensorsView`; verified live in the lab |
@@ -392,10 +396,8 @@ Do **not** block N5 on Grafana or job start-from-NetBox.
 3. **Read-only API token** vs single token for MVP: still open, but moot for N4/N5 — the
    plugin only calls `GET` routes (never starts/cancels jobs), so the existing single
    `SHOAL_API_TOKEN` is sufficient until a write-capable feature is built.
-4. ✅ **job_log population:** resolved (see N3, PR #32) — no production writer exists yet;
-   `GET /v1/jobs/{id}/log` honestly returns `{"lines":[]}` until one lands. Not relevant to
-   N4/N5 (Status/Events tabs don't call this endpoint).
-5. **Historical sensor retention** and Grafana retention policy: still open, relevant to N6/N7.
+4. ✅ **job_log population:** Deploy writes SHOAL\| lines on marker apply (and stall/transport).
+5. **Historical sensor retention** and Grafana retention policy: still open, relevant to N7.
 
 ---
 
@@ -416,8 +418,11 @@ An operator can:
 
 ### 14.1 Start / cancel jobs from NetBox
 
-NetBox as a control surface for Deploy. Requires careful secrets UX, profile picker, and
-permission mapping. **After** read-only MVP (N5–N6).
+**Demo MVP (plugin v0.3):** Status tab **Start provision** / **Cancel** posts to
+Shoal `POST /v1/jobs` and `…/cancel`. Prefills BMC URL + ISO from plugin config;
+optional BMC user/pass fields (empty → Shoal `SHOAL_BMC_*`). Permission:
+`dcim.change_device`. Not a full profile wizard — that remains future work
+(profile picker UI, read-only token, multi-tenant permission mapping).
 
 ### 14.2 Live SOL / log stream in the browser
 

--- a/extras/netbox-plugin-shoal/README.md
+++ b/extras/netbox-plugin-shoal/README.md
@@ -1,13 +1,14 @@
 # netbox-shoal
 
-A NetBox plugin that adds **Shoal Status**, **Shoal Events**, **Shoal Jobs**,
-and **Shoal Sensors** tabs to the device detail page, reading
+A NetBox plugin that adds **Shoal Status**, **Events**, **Jobs**, **Sensors**,
+and **Firmware** tabs to the device detail page, reading
 [Shoal](https://github.com/mattcburns/shoal)'s HTTP API server-side. See
 [`docs/netbox-telemetry-ui-design.md`](../../docs/netbox-telemetry-ui-design.md)
 in the main repo for the full design. This package covers slices **N4–N6**
-plus demo polish: progress bars, stage list, job log panel, auto-refresh while
-provisioning, and a **Start provision / Cancel** control on the Status tab
-(v0.3). Grafana and a full profile wizard remain optional follow-ons.
+plus demo polish (v0.4): progress/stages/job log, auto-refresh while
+provisioning, **Start provision / Cancel**, **host power**, **BMC credentials**
+(password stored in Shoal, never NetBox), and **Poll BMC** (SEL + sensors +
+firmware + power). Grafana and a full profile wizard remain optional follow-ons.
 
 This is the first Python code in the Shoal repo. It runs entirely inside the
 lab's NetBox container — it is never linked into the Shoal Go binary and
@@ -43,15 +44,20 @@ PLUGINS_CONFIG = {
         "SHOAL_API_TOKEN": "",                             # optional Bearer token; empty = no header sent
         "SHOAL_REQUEST_TIMEOUT": 30,                        # seconds (Start can be slow)
         "SHOAL_ENABLE_ACTIONS": True,                       # Status Start/Cancel forms
-        "SHOAL_DEFAULT_BMC_ENDPOINT": "http://127.0.0.1:8001",
+        "SHOAL_DEFAULT_BMC_ENDPOINT": "http://127.0.0.1:8001",  # lab virtual BMC nodes only; real servers use https://<bmc_ip>
         "SHOAL_DEFAULT_ISO_URL": "http://192.168.124.1:8080/shoal-marker.iso",
         "SHOAL_DEFAULT_PROFILE_REF": "spike",
     }
 }
 ```
 
-Start/cancel requires NetBox `dcim.change_device`. BMC passwords are **not**
-stored in NetBox: leave user/pass blank so Shoal uses `SHOAL_BMC_*` env defaults.
+Start/cancel/power/credentials/poll require NetBox `dcim.change_device`. BMC
+passwords are **not** stored in NetBox: the credentials card PUTs to Shoal’s
+secrets backend (`credential_ref` only). Empty user/pass on **power/poll** uses
+stored secrets, then `SHOAL_BMC_*`. **Start provision** still fills empty
+user/pass from `SHOAL_BMC_*` only. Real servers (role ≠ `virtual-bmc-node`)
+prefill `https://<bmc_ip>`; lab virtual BMC nodes keep
+`SHOAL_DEFAULT_BMC_ENDPOINT` (shared sushy).
 
 ## Development
 

--- a/extras/netbox-plugin-shoal/README.md
+++ b/extras/netbox-plugin-shoal/README.md
@@ -5,9 +5,9 @@ and **Shoal Sensors** tabs to the device detail page, reading
 [Shoal](https://github.com/mattcburns/shoal)'s HTTP API server-side. See
 [`docs/netbox-telemetry-ui-design.md`](../../docs/netbox-telemetry-ui-design.md)
 in the main repo for the full design. This package covers slices **N4–N6**
-(plugin skeleton + all four read-only device tabs). Optional follow-ons
-(Grafana link, job-log viewer, start/cancel from NetBox) are **N7+** and not
-in this package yet.
+plus demo polish: progress bars, stage list, job log panel, auto-refresh while
+provisioning, and a **Start provision / Cancel** control on the Status tab
+(v0.3). Grafana and a full profile wizard remain optional follow-ons.
 
 This is the first Python code in the Shoal repo. It runs entirely inside the
 lab's NetBox container — it is never linked into the Shoal Go binary and
@@ -24,6 +24,11 @@ downstream (jobs, events, telemetry) by the NetBox device ID it gets back.
 No separate `shoal_device_id` custom field is needed or used; each view here
 just reads `instance.pk` off the `Device` it's already rendering.
 
+**Lab demo:** bootstrap sets each `shoal-node-*` **serial equal to its name**.
+With `SHOAL_NETBOX_URL` + token set, Deploy remaps
+`-device-id shoal-node-1` → that device's pk so these tabs light up without
+operators looking up numeric ids. See `docs/lab-runbook.md` § NetBox demo.
+
 ## Configuration
 
 Set in NetBox's `configuration.py` (or, in the lab, the Ansible-rendered
@@ -36,10 +41,17 @@ PLUGINS_CONFIG = {
     "netbox_shoal": {
         "SHOAL_BASE_URL": "http://192.168.122.100:8088",  # empty = "not configured" state in the UI
         "SHOAL_API_TOKEN": "",                             # optional Bearer token; empty = no header sent
-        "SHOAL_REQUEST_TIMEOUT": 10,                        # seconds
+        "SHOAL_REQUEST_TIMEOUT": 30,                        # seconds (Start can be slow)
+        "SHOAL_ENABLE_ACTIONS": True,                       # Status Start/Cancel forms
+        "SHOAL_DEFAULT_BMC_ENDPOINT": "http://127.0.0.1:8001",
+        "SHOAL_DEFAULT_ISO_URL": "http://192.168.124.1:8080/shoal-marker.iso",
+        "SHOAL_DEFAULT_PROFILE_REF": "spike",
     }
 }
 ```
+
+Start/cancel requires NetBox `dcim.change_device`. BMC passwords are **not**
+stored in NetBox: leave user/pass blank so Shoal uses `SHOAL_BMC_*` env defaults.
 
 ## Development
 

--- a/extras/netbox-plugin-shoal/netbox_shoal/__init__.py
+++ b/extras/netbox-plugin-shoal/netbox_shoal/__init__.py
@@ -12,7 +12,7 @@ class ShoalConfig(PluginConfig):
     name = "netbox_shoal"
     verbose_name = "Shoal Telemetry"
     description = "Shoal device status/events tabs on the NetBox device page"
-    version = "0.1.0"
+    version = "0.3.0"
     author = "Shoal contributors"
     base_url = "shoal"
 
@@ -21,10 +21,16 @@ class ShoalConfig(PluginConfig):
     # message rather than erroring. SHOAL_API_TOKEN empty means no
     # Authorization header is sent, matching Shoal's own auth gate (which is
     # a no-op when SHOAL_API_TOKEN is unset -- the lab default).
+    # Lab demo write path: SHOAL_DEFAULT_* prefill Start form; BMC passwords
+    # stay on Shoal (SHOAL_BMC_*) unless the operator types them into the form.
     default_settings = {
         "SHOAL_BASE_URL": "",
         "SHOAL_API_TOKEN": "",
-        "SHOAL_REQUEST_TIMEOUT": 10,
+        "SHOAL_REQUEST_TIMEOUT": 30,  # Start can take longer (media + SOL register)
+        "SHOAL_ENABLE_ACTIONS": True,
+        "SHOAL_DEFAULT_BMC_ENDPOINT": "",
+        "SHOAL_DEFAULT_ISO_URL": "",
+        "SHOAL_DEFAULT_PROFILE_REF": "spike",
     }
 
 

--- a/extras/netbox-plugin-shoal/netbox_shoal/__init__.py
+++ b/extras/netbox-plugin-shoal/netbox_shoal/__init__.py
@@ -12,7 +12,7 @@ class ShoalConfig(PluginConfig):
     name = "netbox_shoal"
     verbose_name = "Shoal Telemetry"
     description = "Shoal device status/events tabs on the NetBox device page"
-    version = "0.3.0"
+    version = "0.4.0"
     author = "Shoal contributors"
     base_url = "shoal"
 

--- a/extras/netbox-plugin-shoal/netbox_shoal/client.py
+++ b/extras/netbox-plugin-shoal/netbox_shoal/client.py
@@ -20,22 +20,63 @@ def _cfg():
     return settings.PLUGINS_CONFIG.get(PLUGIN_NAME, {})
 
 
+def _headers():
+    headers = {"Content-Type": "application/json", "Accept": "application/json"}
+    token = _cfg().get("SHOAL_API_TOKEN")
+    if token:
+        headers["Authorization"] = "Bearer " + token
+    return headers
+
+
+def _base():
+    return (_cfg().get("SHOAL_BASE_URL") or "").rstrip("/")
+
+
+def _timeout():
+    return _cfg().get("SHOAL_REQUEST_TIMEOUT", 10)
+
+
 def _get(path, params=None):
-    cfg = _cfg()
-    base = (cfg.get("SHOAL_BASE_URL") or "").rstrip("/")
+    base = _base()
     if not base:
         return None, "Shoal base URL not configured (SHOAL_BASE_URL)"
 
-    headers = {}
-    token = cfg.get("SHOAL_API_TOKEN")
-    if token:
-        headers["Authorization"] = "Bearer " + token
+    try:
+        resp = requests.get(
+            base + path, headers=_headers(), params=params, timeout=_timeout()
+        )
+        resp.raise_for_status()
+        return resp.json(), None
+    except requests.RequestException as exc:
+        return None, str(exc)
 
-    timeout = cfg.get("SHOAL_REQUEST_TIMEOUT", 10)
+
+def _post(path, body=None):
+    base = _base()
+    if not base:
+        return None, "Shoal base URL not configured (SHOAL_BASE_URL)"
 
     try:
-        resp = requests.get(base + path, headers=headers, params=params, timeout=timeout)
-        resp.raise_for_status()
+        resp = requests.post(
+            base + path,
+            headers=_headers(),
+            json=body or {},
+            timeout=_timeout(),
+        )
+        # Start may return 409 with a partial job body on late BMC/SOL failure.
+        if resp.status_code >= 400:
+            try:
+                data = resp.json()
+            except ValueError:
+                data = None
+            msg = None
+            if isinstance(data, dict):
+                msg = data.get("error") or data.get("detail")
+            if not msg:
+                msg = "HTTP %s: %s" % (resp.status_code, (resp.text or "")[:200])
+            return data, msg
+        if resp.status_code == 204 or not resp.content:
+            return {}, None
         return resp.json(), None
     except requests.RequestException as exc:
         return None, str(exc)
@@ -62,3 +103,18 @@ def get_jobs(device_id, limit=50, state=None):
 def get_sensors(device_id, limit=50):
     """GET /v1/devices/{id}/sensors?limit= -> ({"device_id","readings":[...]}, error)."""
     return _get("/v1/devices/%s/sensors" % device_id, params={"limit": limit})
+
+
+def get_job_log(job_id, limit=100):
+    """GET /v1/jobs/{id}/log?limit= -> ({"job_id","lines":[...]}, error)."""
+    return _get("/v1/jobs/%s/log" % job_id, params={"limit": limit})
+
+
+def start_job(body):
+    """POST /v1/jobs with a StartJobRequest body -> (job dict or error body, error)."""
+    return _post("/v1/jobs", body=body)
+
+
+def cancel_job(job_id):
+    """POST /v1/jobs/{id}/cancel -> (body, error)."""
+    return _post("/v1/jobs/%s/cancel" % job_id, body={})

--- a/extras/netbox-plugin-shoal/netbox_shoal/client.py
+++ b/extras/netbox-plugin-shoal/netbox_shoal/client.py
@@ -51,17 +51,48 @@ def _get(path, params=None):
         return None, str(exc)
 
 
-def _post(path, body=None):
+def _put(path, body=None):
     base = _base()
     if not base:
         return None, "Shoal base URL not configured (SHOAL_BASE_URL)"
+    try:
+        resp = requests.put(
+            base + path,
+            headers=_headers(),
+            json=body or {},
+            timeout=_timeout(),
+        )
+        if resp.status_code >= 400:
+            try:
+                data = resp.json()
+            except ValueError:
+                data = None
+            msg = None
+            if isinstance(data, dict):
+                msg = data.get("error") or data.get("detail")
+            if not msg:
+                msg = "HTTP %s: %s" % (resp.status_code, (resp.text or "")[:200])
+            return data, msg
+        if resp.status_code == 204 or not resp.content:
+            return {}, None
+        return resp.json(), None
+    except requests.RequestException as exc:
+        return None, str(exc)
+
+
+def _post(path, body=None, timeout=None):
+    base = _base()
+    if not base:
+        return None, "Shoal base URL not configured (SHOAL_BASE_URL)"
+    if timeout is None:
+        timeout = _timeout()
 
     try:
         resp = requests.post(
             base + path,
             headers=_headers(),
             json=body or {},
-            timeout=_timeout(),
+            timeout=timeout,
         )
         # Start may return 409 with a partial job body on late BMC/SOL failure.
         if resp.status_code >= 400:
@@ -100,9 +131,14 @@ def get_jobs(device_id, limit=50, state=None):
     return _get("/v1/devices/%s/jobs" % device_id, params=params)
 
 
-def get_sensors(device_id, limit=50):
+def get_sensors(device_id, limit=200):
     """GET /v1/devices/{id}/sensors?limit= -> ({"device_id","readings":[...]}, error)."""
     return _get("/v1/devices/%s/sensors" % device_id, params={"limit": limit})
+
+
+def get_firmware(device_id, limit=200):
+    """GET /v1/devices/{id}/firmware?limit= -> ({"device_id","components":[...]}, error)."""
+    return _get("/v1/devices/%s/firmware" % device_id, params={"limit": limit})
 
 
 def get_job_log(job_id, limit=100):
@@ -118,3 +154,34 @@ def start_job(body):
 def cancel_job(job_id):
     """POST /v1/jobs/{id}/cancel -> (body, error)."""
     return _post("/v1/jobs/%s/cancel" % job_id, body={})
+
+
+def power_device(device_id, body):
+    """POST /v1/devices/{id}/power -> (result dict, error)."""
+    return _post("/v1/devices/%s/power" % device_id, body=body)
+
+
+def get_credentials(device_id, credential_ref=None):
+    """GET /v1/devices/{id}/credentials -> view without password.
+
+    credential_ref from NetBox CF avoids Shoal calling NetBox back during a
+    device-page render (that nested round-trip can stall the Status tab).
+    """
+    params = None
+    if credential_ref:
+        params = {"credential_ref": credential_ref}
+    return _get("/v1/devices/%s/credentials" % device_id, params=params)
+
+
+def put_credentials(device_id, body):
+    """PUT /v1/devices/{id}/credentials -> view without password."""
+    return _put("/v1/devices/%s/credentials" % device_id, body=body)
+
+
+def poll_device(device_id, body):
+    """POST /v1/devices/{id}/poll -> on-demand SEL + sensor refresh."""
+    # iDRAC ListSEL/ListSensors can exceed the default 30s plugin timeout.
+    timeout = _timeout()
+    if timeout < 120:
+        timeout = 120
+    return _post("/v1/devices/%s/poll" % device_id, body=body, timeout=timeout)

--- a/extras/netbox-plugin-shoal/netbox_shoal/defaults.py
+++ b/extras/netbox-plugin-shoal/netbox_shoal/defaults.py
@@ -1,0 +1,34 @@
+"""Form defaults for Shoal power/provision actions.
+
+No Django imports so this is unit-testable outside NetBox.
+"""
+
+# Lab sushy nodes share one emulator; their NetBox bmc_ip is the libvirt
+# address, not the Redfish URL. Real servers use https://bmc_ip instead.
+LAB_VIRTUAL_ROLE = "virtual-bmc-node"
+
+
+def endpoint_from_bmc_ip(bmc_ip):
+    """Turn a bmc_ip custom field into a Redfish base URL."""
+    ip = (bmc_ip or "").strip()
+    if not ip:
+        return ""
+    if ip.startswith("http://") or ip.startswith("https://"):
+        return ip
+    return "https://%s" % ip
+
+
+def bmc_endpoint(bmc_ip="", role_slug="", default_endpoint=""):
+    """Choose the BMC URL to prefill in NetBox forms.
+
+    Per-device bmc_ip wins for anything that is not a lab Virtual BMC Node.
+    Lab virtual nodes keep SHOAL_DEFAULT_BMC_ENDPOINT (shared sushy).
+    """
+    bmc_ip = (bmc_ip or "").strip()
+    role_slug = (role_slug or "").strip()
+    default_endpoint = (default_endpoint or "").strip()
+    if bmc_ip and role_slug != LAB_VIRTUAL_ROLE:
+        return endpoint_from_bmc_ip(bmc_ip)
+    if default_endpoint:
+        return default_endpoint
+    return endpoint_from_bmc_ip(bmc_ip)

--- a/extras/netbox-plugin-shoal/netbox_shoal/templates/netbox_shoal/events.html
+++ b/extras/netbox-plugin-shoal/netbox_shoal/templates/netbox_shoal/events.html
@@ -1,10 +1,17 @@
 {% extends 'generic/object.html' %}
 
+{% block title %}{{ object }} — Shoal Events{% endblock %}
+
 {% block content %}
+  <div class="row mb-3">
+    <div class="col col-md-12 d-flex justify-content-end">
+      <a class="btn btn-sm btn-outline-primary" href="{{ request.path }}">Refresh</a>
+    </div>
+  </div>
   <div class="row">
     <div class="col col-md-12">
       <div class="card">
-        <h5 class="card-header">Shoal Events</h5>
+        <h5 class="card-header">Shoal Events (SEL / normalized)</h5>
         <div class="card-body">
           {% if shoal_error %}
             <div class="alert alert-warning" role="alert">
@@ -12,32 +19,49 @@
             </div>
           {% elif not shoal_events %}
             <div class="alert alert-info" role="alert">
-              No events yet — has Observe poll run? See the lab runbook for
-              how to enable SEL/sensor polling.
+              No events yet — has Observe poll run with this device’s NetBox id?
+              On nested sushy, empty SEL is normal (fidelity gap); rich events need
+              a real BMC or seeded telemetry. See the lab runbook NetBox demo section.
             </div>
           {% else %}
-            <table class="table table-hover">
-              <thead>
-                <tr>
-                  <th scope="col">Time</th>
-                  <th scope="col">Severity</th>
-                  <th scope="col">Type</th>
-                  <th scope="col">Component</th>
-                  <th scope="col">Message</th>
-                </tr>
-              </thead>
-              <tbody>
-                {% for event in shoal_events %}
+            <div class="table-responsive">
+              <table class="table table-hover">
+                <thead>
                   <tr>
-                    <td>{{ event.timestamp|default:"—" }}</td>
-                    <td>{{ event.severity|default:"—" }}</td>
-                    <td>{{ event.event_type|default:"—" }}</td>
-                    <td>{{ event.component|default:"—" }}</td>
-                    <td>{{ event.message|default:"—" }}</td>
+                    <th scope="col">Time</th>
+                    <th scope="col">Severity</th>
+                    <th scope="col">Type</th>
+                    <th scope="col">Component</th>
+                    <th scope="col">Message</th>
                   </tr>
-                {% endfor %}
-              </tbody>
-            </table>
+                </thead>
+                <tbody>
+                  {% for event in shoal_events %}
+                    <tr>
+                      <td>{{ event.timestamp|default:"—" }}</td>
+                      <td>
+                        {% with sev=event.severity|default:""|lower %}
+                          {% if sev == "critical" or sev == "error" %}
+                            <span class="badge bg-danger">{{ event.severity }}</span>
+                          {% elif sev == "warning" or sev == "warn" %}
+                            <span class="badge bg-warning text-dark">{{ event.severity }}</span>
+                          {% elif sev == "ok" or sev == "info" or sev == "normal" %}
+                            <span class="badge bg-success">{{ event.severity }}</span>
+                          {% elif event.severity %}
+                            <span class="badge bg-secondary">{{ event.severity }}</span>
+                          {% else %}
+                            —
+                          {% endif %}
+                        {% endwith %}
+                      </td>
+                      <td>{{ event.event_type|default:"—" }}</td>
+                      <td>{{ event.component|default:"—" }}</td>
+                      <td>{{ event.message|default:"—" }}</td>
+                    </tr>
+                  {% endfor %}
+                </tbody>
+              </table>
+            </div>
           {% endif %}
         </div>
       </div>

--- a/extras/netbox-plugin-shoal/netbox_shoal/templates/netbox_shoal/firmware.html
+++ b/extras/netbox-plugin-shoal/netbox_shoal/templates/netbox_shoal/firmware.html
@@ -1,6 +1,6 @@
 {% extends 'generic/object.html' %}
 
-{% block title %}{{ object }} — Shoal Sensors{% endblock %}
+{% block title %}{{ object }} — Shoal Firmware{% endblock %}
 
 {% block content %}
   <div class="row mb-3">
@@ -26,18 +26,18 @@
               <input type="hidden" name="action" value="poll">
               <input type="hidden" name="system_id" value="{{ shoal_power_system_id }}">
               <div class="col-md-5">
-                <label class="form-label small mb-0" for="id_poll_bmc_endpoint">BMC endpoint</label>
-                <input class="form-control form-control-sm" id="id_poll_bmc_endpoint" name="bmc_endpoint"
+                <label class="form-label small mb-0" for="id_fw_bmc_endpoint">BMC endpoint</label>
+                <input class="form-control form-control-sm" id="id_fw_bmc_endpoint" name="bmc_endpoint"
                        value="{{ d.bmc_endpoint }}" required>
               </div>
               <div class="col-md-3">
-                <label class="form-label small mb-0" for="id_poll_bmc_username">BMC user (optional)</label>
-                <input class="form-control form-control-sm" id="id_poll_bmc_username" name="bmc_username"
+                <label class="form-label small mb-0" for="id_fw_bmc_username">BMC user (optional)</label>
+                <input class="form-control form-control-sm" id="id_fw_bmc_username" name="bmc_username"
                        autocomplete="off" placeholder="stored credentials, then env">
               </div>
               <div class="col-md-3">
-                <label class="form-label small mb-0" for="id_poll_bmc_password">BMC password (optional)</label>
-                <input class="form-control form-control-sm" type="password" id="id_poll_bmc_password"
+                <label class="form-label small mb-0" for="id_fw_bmc_password">BMC password (optional)</label>
+                <input class="form-control form-control-sm" type="password" id="id_fw_bmc_password"
                        name="bmc_password" autocomplete="new-password"
                        placeholder="stored credentials, then env">
               </div>
@@ -46,10 +46,8 @@
               </div>
             </form>
             <p class="text-muted small mt-2 mb-0">
-              Runs <code>POST /v1/devices/{{ d.device_id }}/poll</code> (Redfish SEL + sensors).
-              Background poll uses <code>SHOAL_POLL_IDLE_INTERVAL</code> (default 5m)
-              for devices with a job, or <code>SHOAL_POLL_WATCH_INTERVAL</code>
-              (default 30s) while SOL is watched. On-demand poll also adds this device to that loop.
+              Gather-only: Redfish FirmwareInventory plus power and sensors in the same poll.
+              Does not flash firmware.
             </p>
             {% endwith %}
           {% endif %}
@@ -61,43 +59,43 @@
   <div class="row">
     <div class="col col-md-12">
       <div class="card">
-        <h5 class="card-header">Shoal Sensors</h5>
+        <h5 class="card-header">Firmware inventory
+          {% if shoal_firmware_ts %}
+            <span class="text-muted small fw-normal">as of {{ shoal_firmware_ts }}</span>
+          {% endif %}
+        </h5>
         <div class="card-body">
           {% if shoal_error %}
             <div class="alert alert-warning" role="alert">
               Shoal unavailable: {{ shoal_error }}
             </div>
-          {% elif not shoal_sensors %}
+          {% elif not shoal_firmware %}
             <div class="alert alert-info" role="alert">
-              No sensor readings yet — has Observe poll run? Nested sushy often
-              returns no sensors (empty is valid). Real BMC hardware fills this tab.
+              No firmware inventory yet — Poll BMC (this tab or Sensors). Nested sushy
+              often has no UpdateService (empty is valid). Real BMCs fill this tab.
             </div>
           {% else %}
             <div class="table-responsive">
               <table class="table table-hover">
                 <thead>
                   <tr>
-                    <th scope="col">Sensor</th>
-                    <th scope="col">Value</th>
-                    <th scope="col">Unit</th>
-                    <th scope="col">Note</th>
-                    <th scope="col">Time</th>
+                    <th scope="col">Name</th>
+                    <th scope="col">Version</th>
+                    <th scope="col">Manufacturer</th>
+                    <th scope="col">Health</th>
+                    <th scope="col">Updateable</th>
+                    <th scope="col">Id</th>
                   </tr>
                 </thead>
                 <tbody>
-                  {% for reading in shoal_sensors %}
+                  {% for c in shoal_firmware %}
                     <tr>
-                      <td>{{ reading.sensor|default:"—" }}</td>
-                      <td>
-                        {% if reading.value == None %}
-                          <span class="text-muted">—</span>
-                        {% else %}
-                          <strong>{{ reading.value }}</strong>
-                        {% endif %}
-                      </td>
-                      <td>{{ reading.unit|default:"—" }}</td>
-                      <td class="text-muted">{{ reading.note|default:"" }}</td>
-                      <td>{{ reading.ts|default:"—" }}</td>
+                      <td>{{ c.name|default:c.id }}</td>
+                      <td><code>{{ c.version|default:"—" }}</code></td>
+                      <td>{{ c.manufacturer|default:"—" }}</td>
+                      <td>{{ c.health|default:"—" }}</td>
+                      <td>{% if c.updateable %}yes{% else %}no{% endif %}</td>
+                      <td class="text-muted"><code>{{ c.id }}</code></td>
                     </tr>
                   {% endfor %}
                 </tbody>

--- a/extras/netbox-plugin-shoal/netbox_shoal/templates/netbox_shoal/jobs.html
+++ b/extras/netbox-plugin-shoal/netbox_shoal/templates/netbox_shoal/jobs.html
@@ -1,6 +1,49 @@
 {% extends 'generic/object.html' %}
 
+{% block title %}{{ object }} — Shoal Jobs{% endblock %}
+
+{% block head %}
+  {{ block.super }}
+  {% if shoal_auto_refresh %}
+    <meta http-equiv="refresh" content="5">
+  {% endif %}
+  <style>
+    .shoal-badge { font-size: 0.85em; text-transform: lowercase; }
+    .shoal-progress { min-width: 100px; max-width: 140px; height: 1.1rem; }
+    .shoal-log {
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+      font-size: 0.78rem; max-height: 18rem; overflow: auto;
+      background: var(--nb-bg-secondary, #f8f9fa); padding: 0.75rem; border-radius: 0.25rem;
+      white-space: pre-wrap; word-break: break-all;
+    }
+    .shoal-stages small { display: block; }
+  </style>
+{% endblock %}
+
 {% block content %}
+  <div class="row mb-3">
+    <div class="col col-md-12 d-flex justify-content-between align-items-center">
+      <div>
+        {% if shoal_auto_refresh %}
+          <span class="badge bg-info text-dark">Auto-refresh 5s while a job is provisioning</span>
+        {% endif %}
+      </div>
+      <div class="d-flex gap-2">
+        {% if shoal_actions_enabled and shoal_can_control and shoal_active_job.id and shoal_active_job.state == "provisioning" %}
+          <form method="post" class="d-inline">
+            {% csrf_token %}
+            <input type="hidden" name="next" value="{{ request.path }}">
+            <input type="hidden" name="job_id" value="{{ shoal_active_job.id }}">
+            <button type="submit" name="action" value="cancel" class="btn btn-sm btn-outline-danger">
+              Cancel active job
+            </button>
+          </form>
+        {% endif %}
+        <a class="btn btn-sm btn-outline-primary" href="{{ request.path }}">Refresh</a>
+      </div>
+    </div>
+  </div>
+
   <div class="row">
     <div class="col col-md-12">
       <div class="card">
@@ -12,35 +55,102 @@
             </div>
           {% elif not shoal_jobs %}
             <div class="alert alert-info" role="alert">
-              No jobs recorded for this device yet.
+              No jobs recorded for this device yet. Run a deploy with
+              <code>-device-id {{ object.name }}</code> (or this device’s NetBox id)
+              while Shoal has <code>SHOAL_NETBOX_*</code> set so the id remaps to
+              this page’s primary key.
             </div>
           {% else %}
-            <table class="table table-hover">
-              <thead>
-                <tr>
-                  <th scope="col">ID</th>
-                  <th scope="col">State</th>
-                  <th scope="col">Phase</th>
-                  <th scope="col">Percent</th>
-                  <th scope="col">Profile</th>
-                  <th scope="col">Updated</th>
-                  <th scope="col">Error</th>
-                </tr>
-              </thead>
-              <tbody>
-                {% for job in shoal_jobs %}
+            <div class="table-responsive">
+              <table class="table table-hover">
+                <thead>
                   <tr>
-                    <td>{{ job.id|default:"—" }}</td>
-                    <td>{{ job.state|default:"—" }}</td>
-                    <td>{{ job.phase|default:"—" }}</td>
-                    <td>{{ job.percent|default:"—" }}</td>
-                    <td>{{ job.profile_ref|default:"—" }}</td>
-                    <td>{{ job.updated_at|default:"—" }}</td>
-                    <td>{{ job.error|default:"—" }}</td>
+                    <th scope="col">ID</th>
+                    <th scope="col">State</th>
+                    <th scope="col">Phase</th>
+                    <th scope="col">Progress</th>
+                    <th scope="col">Stages</th>
+                    <th scope="col">Profile</th>
+                    <th scope="col">Updated</th>
+                    <th scope="col">Error</th>
                   </tr>
-                {% endfor %}
-              </tbody>
-            </table>
+                </thead>
+                <tbody>
+                  {% for job in shoal_jobs %}
+                    <tr{% if job.state == "provisioning" %} class="table-primary"{% endif %}>
+                      <td><code title="{{ job.id }}">{{ job.id|truncatechars:12 }}</code></td>
+                      <td>
+                        {% if job.state == "provisioning" %}
+                          <span class="badge bg-primary shoal-badge">{{ job.state }}</span>
+                        {% elif job.state == "provisioned" %}
+                          <span class="badge bg-success shoal-badge">{{ job.state }}</span>
+                        {% elif job.state == "failed" %}
+                          <span class="badge bg-danger shoal-badge">{{ job.state }}</span>
+                        {% else %}
+                          <span class="badge bg-secondary shoal-badge">{{ job.state|default:"—" }}</span>
+                        {% endif %}
+                      </td>
+                      <td><code>{{ job.phase|default:"—" }}</code></td>
+                      <td>
+                        {% if job.percent != None %}
+                          <div class="progress shoal-progress" role="progressbar"
+                               aria-valuenow="{{ job.percent }}" aria-valuemin="0" aria-valuemax="100">
+                            <div class="progress-bar{% if job.state == "provisioning" %} progress-bar-striped progress-bar-animated{% endif %}"
+                                 style="width: {{ job.percent }}%">{{ job.percent }}%</div>
+                          </div>
+                        {% else %}
+                          —
+                        {% endif %}
+                      </td>
+                      <td class="shoal-stages">
+                        {% if job.stages %}
+                          {% for stage in job.stages %}
+                            <small>
+                              {% if stage.state == "done" %}✓{% elif stage.state == "running" %}●{% elif stage.state == "failed" %}✗{% else %}○{% endif %}
+                              {{ stage.kind|default:stage.id }}
+                              {% if stage.phase %} <code>{{ stage.phase }}</code>{% endif %}
+                            </small>
+                          {% endfor %}
+                        {% elif job.current_stage %}
+                          <code>{{ job.current_stage }}</code>
+                        {% else %}
+                          —
+                        {% endif %}
+                      </td>
+                      <td>{{ job.profile_ref|default:"—" }}</td>
+                      <td>{{ job.updated_at|default:"—" }}</td>
+                      <td class="text-danger small">{{ job.error|default:""|truncatechars:40 }}</td>
+                    </tr>
+                  {% endfor %}
+                </tbody>
+              </table>
+            </div>
+          {% endif %}
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="row mt-3">
+    <div class="col col-md-12">
+      <div class="card">
+        <h5 class="card-header">Job log
+          {% if shoal_active_job.id %}
+            <span class="text-muted small fw-normal">— latest / active {{ shoal_active_job.id|truncatechars:20 }}</span>
+          {% endif %}
+        </h5>
+        <div class="card-body">
+          {% if shoal_job_log_error %}
+            <div class="alert alert-warning" role="alert">Log unavailable: {{ shoal_job_log_error }}</div>
+          {% elif not shoal_active_job %}
+            <div class="alert alert-info" role="alert">No job selected for log view.</div>
+          {% elif not shoal_job_log %}
+            <div class="alert alert-info" role="alert">
+              No log lines yet for this job. SOL markers are written as the job progresses.
+            </div>
+          {% else %}
+            <div class="shoal-log">{% for line in shoal_job_log %}{{ line.ts|default:"" }}  {{ line.line }}
+{% endfor %}</div>
           {% endif %}
         </div>
       </div>

--- a/extras/netbox-plugin-shoal/netbox_shoal/templates/netbox_shoal/sensors.html
+++ b/extras/netbox-plugin-shoal/netbox_shoal/templates/netbox_shoal/sensors.html
@@ -1,6 +1,13 @@
 {% extends 'generic/object.html' %}
 
+{% block title %}{{ object }} — Shoal Sensors{% endblock %}
+
 {% block content %}
+  <div class="row mb-3">
+    <div class="col col-md-12 d-flex justify-content-end">
+      <a class="btn btn-sm btn-outline-primary" href="{{ request.path }}">Refresh</a>
+    </div>
+  </div>
   <div class="row">
     <div class="col col-md-12">
       <div class="card">
@@ -12,30 +19,32 @@
             </div>
           {% elif not shoal_sensors %}
             <div class="alert alert-info" role="alert">
-              No sensor readings yet — has Observe poll run? See the lab
-              runbook for how to enable SEL/sensor polling.
+              No sensor readings yet — has Observe poll run? Nested sushy often
+              returns no sensors (empty is valid). Real BMC hardware fills this tab.
             </div>
           {% else %}
-            <table class="table table-hover">
-              <thead>
-                <tr>
-                  <th scope="col">Sensor</th>
-                  <th scope="col">Value</th>
-                  <th scope="col">Unit</th>
-                  <th scope="col">Time</th>
-                </tr>
-              </thead>
-              <tbody>
-                {% for reading in shoal_sensors %}
+            <div class="table-responsive">
+              <table class="table table-hover">
+                <thead>
                   <tr>
-                    <td>{{ reading.sensor|default:"—" }}</td>
-                    <td>{{ reading.value|default:"—" }}</td>
-                    <td>{{ reading.unit|default:"—" }}</td>
-                    <td>{{ reading.ts|default:"—" }}</td>
+                    <th scope="col">Sensor</th>
+                    <th scope="col">Value</th>
+                    <th scope="col">Unit</th>
+                    <th scope="col">Time</th>
                   </tr>
-                {% endfor %}
-              </tbody>
-            </table>
+                </thead>
+                <tbody>
+                  {% for reading in shoal_sensors %}
+                    <tr>
+                      <td>{{ reading.sensor|default:"—" }}</td>
+                      <td><strong>{{ reading.value|default:"—" }}</strong></td>
+                      <td>{{ reading.unit|default:"—" }}</td>
+                      <td>{{ reading.ts|default:"—" }}</td>
+                    </tr>
+                  {% endfor %}
+                </tbody>
+              </table>
+            </div>
           {% endif %}
         </div>
       </div>

--- a/extras/netbox-plugin-shoal/netbox_shoal/templates/netbox_shoal/status.html
+++ b/extras/netbox-plugin-shoal/netbox_shoal/templates/netbox_shoal/status.html
@@ -56,7 +56,7 @@
                 <label class="form-label small mb-0" for="id_bmc_endpoint">BMC endpoint</label>
                 <input class="form-control form-control-sm" id="id_bmc_endpoint" name="bmc_endpoint"
                        value="{{ d.bmc_endpoint }}" required
-                       placeholder="http://…:8001">
+                       placeholder="https://bmc-ip or lab sushy URL">
               </div>
               <div class="col-md-4">
                 <label class="form-label small mb-0" for="id_iso_url">ISO URL</label>
@@ -108,7 +108,125 @@
             <p class="text-muted small mt-2 mb-0">
               Starts <code>POST /v1/jobs</code> on Shoal with device id
               <code>{{ d.device_id }}</code>. Passwords are not stored in NetBox;
-              empty user/pass uses Shoal’s <code>SHOAL_BMC_*</code> defaults.
+              empty user/pass uses Shoal <code>SHOAL_BMC_*</code> (not the
+              stored per-device secret). Lab spike needs libvirt SOL; real BMC
+              SOL/ISO reachability is a separate gap.
+            </p>
+            {% endwith %}
+          {% endif %}
+        </div>
+      </div>
+    </div>
+  </div>
+  {% endif %}
+
+  {% if shoal_actions_enabled %}
+  <div class="row mb-3">
+    <div class="col col-md-12">
+      <div class="card">
+        <h5 class="card-header">BMC credentials</h5>
+        <div class="card-body">
+          {% if shoal_credentials_error %}
+            <div class="alert alert-warning" role="alert">
+              Could not load credentials: {{ shoal_credentials_error }}
+            </div>
+          {% endif %}
+          {% if not shoal_can_control %}
+            <p class="mb-0">
+              User <code>{{ shoal_credentials.username|default:"—" }}</code>
+              {% if shoal_credentials.has_password %}
+                <span class="badge bg-success">password set</span>
+              {% else %}
+                <span class="badge bg-secondary">no password</span>
+              {% endif %}
+              <span class="text-muted">ref {{ shoal_credentials.credential_ref|default:"—" }}</span>
+            </p>
+          {% else %}
+            {% with c=shoal_credentials %}
+            <form method="post" class="row g-2 align-items-end">
+              {% csrf_token %}
+              <input type="hidden" name="next" value="{{ request.path }}">
+              <input type="hidden" name="action" value="credentials">
+              <div class="col-md-3">
+                <label class="form-label small mb-0" for="id_cred_username">BMC username</label>
+                <input class="form-control form-control-sm" id="id_cred_username" name="bmc_username"
+                       value="{{ c.username|default:"" }}" required autocomplete="off">
+              </div>
+              <div class="col-md-3">
+                <label class="form-label small mb-0" for="id_cred_password">BMC password</label>
+                <input class="form-control form-control-sm" type="password" id="id_cred_password"
+                       name="bmc_password" autocomplete="new-password"
+                       placeholder="{% if c.has_password %}leave blank to keep{% else %}required{% endif %}">
+              </div>
+              <div class="col-md-2">
+                <button type="submit" class="btn btn-primary btn-sm">Save</button>
+              </div>
+            </form>
+            <p class="text-muted small mt-2 mb-0">
+              Stored in Shoal’s secrets backend
+              (<code>{{ c.credential_ref|default:"bmc-&lt;serial&gt;" }}</code>),
+              never in NetBox.
+              {% if c.has_password %}<span class="badge bg-success">password set</span>{% endif %}
+              Power and provision use these when the forms leave user/pass empty.
+            </p>
+            {% endwith %}
+          {% endif %}
+        </div>
+      </div>
+    </div>
+  </div>
+  {% endif %}
+
+  {% if shoal_actions_enabled %}
+  <div class="row mb-3">
+    <div class="col col-md-12">
+      <div class="card">
+        <h5 class="card-header">Host power</h5>
+        <div class="card-body">
+          {% if not shoal_can_control %}
+            <div class="alert alert-secondary mb-0" role="alert">
+              View-only: <code>dcim.change_device</code> is required to power the host.
+            </div>
+          {% else %}
+            {% with d=shoal_start_defaults %}
+            <form method="post" class="row g-2 align-items-end">
+              {% csrf_token %}
+              <input type="hidden" name="next" value="{{ request.path }}">
+              <input type="hidden" name="action" value="power">
+              <input type="hidden" name="system_id" value="{{ shoal_power_system_id }}">
+              <div class="col-md-4">
+                <label class="form-label small mb-0" for="id_power_bmc_endpoint">BMC endpoint</label>
+                <input class="form-control form-control-sm" id="id_power_bmc_endpoint" name="bmc_endpoint"
+                       value="{{ d.bmc_endpoint }}" required>
+              </div>
+              <div class="col-md-3">
+                <label class="form-label small mb-0" for="id_power_bmc_username">BMC user (optional)</label>
+                <input class="form-control form-control-sm" id="id_power_bmc_username" name="bmc_username"
+                       autocomplete="off" placeholder="stored credentials, then env">
+              </div>
+              <div class="col-md-3">
+                <label class="form-label small mb-0" for="id_power_bmc_password">BMC password (optional)</label>
+                <input class="form-control form-control-sm" type="password" id="id_power_bmc_password"
+                       name="bmc_password" autocomplete="new-password"
+                       placeholder="stored credentials, then env">
+              </div>
+              <div class="col-md-12 d-flex gap-2 mt-2">
+                <button type="submit" name="reset_type" value="On" class="btn btn-success btn-sm">
+                  Power on
+                </button>
+                <button type="submit" name="reset_type" value="ForceOff" class="btn btn-outline-danger btn-sm"
+                        onclick="return confirm('Force power off this host?');">
+                  Force off
+                </button>
+                <button type="submit" name="reset_type" value="ForceRestart" class="btn btn-outline-warning btn-sm"
+                        onclick="return confirm('Force restart this host?');">
+                  Reset
+                </button>
+              </div>
+            </form>
+            <p class="text-muted small mt-2 mb-0">
+              Sends <code>POST /v1/devices/{{ d.device_id }}/power</code> (Redfish reset).
+              Empty user/pass uses stored BMC credentials, then Shoal <code>SHOAL_BMC_*</code>.
             </p>
             {% endwith %}
           {% endif %}

--- a/extras/netbox-plugin-shoal/netbox_shoal/templates/netbox_shoal/status.html
+++ b/extras/netbox-plugin-shoal/netbox_shoal/templates/netbox_shoal/status.html
@@ -1,8 +1,125 @@
 {% extends 'generic/object.html' %}
 
+{% block title %}{{ object }} — Shoal Status{% endblock %}
+
+{% block head %}
+  {{ block.super }}
+  {% if shoal_auto_refresh %}
+    <meta http-equiv="refresh" content="5">
+  {% endif %}
+  <style>
+    .shoal-badge { font-size: 0.85em; text-transform: lowercase; }
+    .shoal-progress { max-width: 280px; height: 1.25rem; }
+    .shoal-log {
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+      font-size: 0.78rem; max-height: 16rem; overflow: auto;
+      background: var(--nb-bg-secondary, #f8f9fa); padding: 0.75rem; border-radius: 0.25rem;
+      white-space: pre-wrap; word-break: break-all;
+    }
+    .shoal-stage-list { list-style: none; padding-left: 0; margin-bottom: 0; }
+    .shoal-stage-list li {
+      display: flex; align-items: center; gap: 0.5rem;
+      padding: 0.35rem 0; border-bottom: 1px solid var(--nb-border-color, #dee2e6);
+    }
+    .shoal-stage-list li:last-child { border-bottom: none; }
+  </style>
+{% endblock %}
+
 {% block content %}
-  <div class="row">
+  <div class="row mb-3">
+    <div class="col col-md-12 d-flex justify-content-between align-items-center">
+      <div>
+        {% if shoal_auto_refresh %}
+          <span class="badge bg-info text-dark">Auto-refresh 5s while provisioning</span>
+        {% endif %}
+      </div>
+      <a class="btn btn-sm btn-outline-primary" href="{{ request.path }}">Refresh</a>
+    </div>
+  </div>
+
+  {% if shoal_actions_enabled %}
+  <div class="row mb-3">
     <div class="col col-md-12">
+      <div class="card border-primary">
+        <h5 class="card-header">Provision</h5>
+        <div class="card-body">
+          {% if not shoal_can_control %}
+            <div class="alert alert-secondary mb-0" role="alert">
+              View-only: <code>dcim.change_device</code> is required to start or cancel jobs.
+            </div>
+          {% else %}
+            {% with d=shoal_start_defaults %}
+            <form method="post" class="row g-2 align-items-end">
+              {% csrf_token %}
+              <input type="hidden" name="next" value="{{ request.path }}">
+              <div class="col-md-4">
+                <label class="form-label small mb-0" for="id_bmc_endpoint">BMC endpoint</label>
+                <input class="form-control form-control-sm" id="id_bmc_endpoint" name="bmc_endpoint"
+                       value="{{ d.bmc_endpoint }}" required
+                       placeholder="http://…:8001">
+              </div>
+              <div class="col-md-4">
+                <label class="form-label small mb-0" for="id_iso_url">ISO URL</label>
+                <input class="form-control form-control-sm" id="id_iso_url" name="iso_url"
+                       value="{{ d.iso_url }}" required
+                       placeholder="http://…/shoal-marker.iso">
+              </div>
+              <div class="col-md-2">
+                <label class="form-label small mb-0" for="id_profile_ref">Profile</label>
+                <input class="form-control form-control-sm" id="id_profile_ref" name="profile_ref"
+                       value="{{ d.profile_ref }}">
+              </div>
+              <div class="col-md-2">
+                <label class="form-label small mb-0" for="id_serial_target">Serial / system</label>
+                <input class="form-control form-control-sm" id="id_serial_target" name="serial_target"
+                       value="{{ d.serial_target }}">
+                <input type="hidden" name="system_id" value="{{ d.system_id }}">
+              </div>
+              <div class="col-md-3">
+                <label class="form-label small mb-0" for="id_bmc_username">BMC user (optional)</label>
+                <input class="form-control form-control-sm" id="id_bmc_username" name="bmc_username"
+                       autocomplete="off" placeholder="uses Shoal env if empty">
+              </div>
+              <div class="col-md-3">
+                <label class="form-label small mb-0" for="id_bmc_password">BMC password (optional)</label>
+                <input class="form-control form-control-sm" type="password" id="id_bmc_password"
+                       name="bmc_password" autocomplete="new-password"
+                       placeholder="uses Shoal env if empty">
+              </div>
+              <div class="col-md-3 form-check mt-4 ms-2">
+                <input class="form-check-input" type="checkbox" name="approve_destruct" id="id_approve_destruct">
+                <label class="form-check-label small" for="id_approve_destruct">Approve destruct steps</label>
+              </div>
+              <div class="col-md-3 d-flex gap-2 mt-3">
+                <button type="submit" name="action" value="start" class="btn btn-primary btn-sm"
+                        {% if shoal_status.active_job_id or shoal_status.lifecycle_state == "provisioning" %}disabled title="A job is already provisioning"{% endif %}>
+                  Start provision
+                </button>
+                {% if shoal_active_job.id and shoal_active_job.state == "provisioning" %}
+                  <button type="submit" name="action" value="cancel" class="btn btn-outline-danger btn-sm"
+                          formaction="{{ request.path }}"
+                          onclick="this.form.job_id.value='{{ shoal_active_job.id }}';">
+                    Cancel job
+                  </button>
+                  <input type="hidden" name="job_id" value="{{ shoal_active_job.id }}">
+                {% endif %}
+              </div>
+            </form>
+            <p class="text-muted small mt-2 mb-0">
+              Starts <code>POST /v1/jobs</code> on Shoal with device id
+              <code>{{ d.device_id }}</code>. Passwords are not stored in NetBox;
+              empty user/pass uses Shoal’s <code>SHOAL_BMC_*</code> defaults.
+            </p>
+            {% endwith %}
+          {% endif %}
+        </div>
+      </div>
+    </div>
+  </div>
+  {% endif %}
+
+  <div class="row">
+    <div class="col col-md-6">
       <div class="card">
         <h5 class="card-header">Shoal Status</h5>
         <div class="card-body">
@@ -12,18 +129,127 @@
             </div>
           {% elif not shoal_status %}
             <div class="alert alert-info" role="alert">
-              No Shoal status for this device yet.
+              No Shoal status for this device yet. Start a job with
+              <code>-device-id</code> matching this NetBox device (name/serial
+              or numeric id) while Shoal has NetBox configured.
             </div>
           {% else %}
+            {% with st=shoal_status.lifecycle_state|default:"" %}
             <table class="table table-hover attr-table">
-              <tr><th scope="row">Lifecycle state</th><td>{{ shoal_status.lifecycle_state|default:"—" }}</td></tr>
-              <tr><th scope="row">Power state</th><td>{{ shoal_status.power_state|default:"—" }}</td></tr>
-              <tr><th scope="row">Active job</th><td>{{ shoal_status.active_job_id|default:"—" }}</td></tr>
-              <tr><th scope="row">Phase</th><td>{{ shoal_status.phase|default:"—" }}</td></tr>
-              <tr><th scope="row">Percent</th><td>{{ shoal_status.percent|default:"—" }}</td></tr>
+              <tr>
+                <th scope="row">Lifecycle</th>
+                <td>
+                  {% if st == "provisioning" %}
+                    <span class="badge bg-primary shoal-badge">{{ st }}</span>
+                  {% elif st == "provisioned" %}
+                    <span class="badge bg-success shoal-badge">{{ st }}</span>
+                  {% elif st == "failed" %}
+                    <span class="badge bg-danger shoal-badge">{{ st }}</span>
+                  {% elif st %}
+                    <span class="badge bg-secondary shoal-badge">{{ st }}</span>
+                  {% else %}
+                    —
+                  {% endif %}
+                </td>
+              </tr>
+              <tr><th scope="row">Power</th><td>{{ shoal_status.power_state|default:"—" }}</td></tr>
+              <tr>
+                <th scope="row">Active job</th>
+                <td>
+                  {% if shoal_status.active_job_id %}
+                    <code>{{ shoal_status.active_job_id|truncatechars:16 }}</code>
+                  {% else %}
+                    —
+                  {% endif %}
+                </td>
+              </tr>
+              <tr><th scope="row">Phase</th><td><code>{{ shoal_status.phase|default:"—" }}</code></td></tr>
+              <tr>
+                <th scope="row">Progress</th>
+                <td>
+                  {% if shoal_status.percent != None %}
+                    <div class="progress shoal-progress" role="progressbar"
+                         aria-valuenow="{{ shoal_status.percent }}" aria-valuemin="0" aria-valuemax="100">
+                      <div class="progress-bar{% if st == "provisioning" %} progress-bar-striped progress-bar-animated{% endif %}"
+                           style="width: {{ shoal_status.percent }}%">
+                        {{ shoal_status.percent }}%
+                      </div>
+                    </div>
+                  {% else %}
+                    —
+                  {% endif %}
+                </td>
+              </tr>
               <tr><th scope="row">Last event</th><td>{{ shoal_status.last_event|default:"—" }}</td></tr>
               <tr><th scope="row">Updated</th><td>{{ shoal_status.updated_at|default:"—" }}</td></tr>
             </table>
+            {% endwith %}
+          {% endif %}
+        </div>
+      </div>
+    </div>
+
+    <div class="col col-md-6">
+      <div class="card">
+        <h5 class="card-header">Stages
+          {% if shoal_active_job.install_strategy %}
+            <span class="badge bg-secondary shoal-badge ms-1">{{ shoal_active_job.install_strategy }}</span>
+          {% endif %}
+        </h5>
+        <div class="card-body">
+          {% if shoal_active_job.stages %}
+            <ul class="shoal-stage-list">
+              {% for stage in shoal_active_job.stages %}
+                <li>
+                  {% if stage.state == "done" %}
+                    <span class="badge bg-success shoal-badge">done</span>
+                  {% elif stage.state == "running" %}
+                    <span class="badge bg-primary shoal-badge">running</span>
+                  {% elif stage.state == "failed" %}
+                    <span class="badge bg-danger shoal-badge">failed</span>
+                  {% else %}
+                    <span class="badge bg-secondary shoal-badge">{{ stage.state|default:"pending" }}</span>
+                  {% endif %}
+                  <strong>{{ stage.kind|default:stage.id|default:"stage" }}</strong>
+                  {% if stage.phase %}<code class="ms-1">{{ stage.phase }}</code>{% endif %}
+                  {% if stage.strategy %}<span class="text-muted small ms-1">{{ stage.strategy }}</span>{% endif %}
+                </li>
+              {% endfor %}
+            </ul>
+            {% if shoal_active_job.current_stage %}
+              <p class="text-muted small mt-2 mb-0">Current stage: <code>{{ shoal_active_job.current_stage }}</code></p>
+            {% endif %}
+          {% elif shoal_active_job %}
+            <p class="text-muted mb-0">Single-stage job (no expanded stage list).</p>
+          {% else %}
+            <p class="text-muted mb-0">No recent jobs for this device.</p>
+          {% endif %}
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="row mt-3">
+    <div class="col col-md-12">
+      <div class="card">
+        <h5 class="card-header">Job log
+          {% if shoal_active_job.id %}
+            <span class="text-muted small fw-normal">— {{ shoal_active_job.id|truncatechars:20 }}</span>
+          {% endif %}
+        </h5>
+        <div class="card-body">
+          {% if shoal_job_log_error %}
+            <div class="alert alert-warning" role="alert">Log unavailable: {{ shoal_job_log_error }}</div>
+          {% elif not shoal_active_job %}
+            <div class="alert alert-info" role="alert">No job to show a log for yet.</div>
+          {% elif not shoal_job_log %}
+            <div class="alert alert-info" role="alert">
+              No log lines yet. Markers appear here as SOL progress is recorded
+              (simulate / image-write jobs). Heartbeats and stage advances are included.
+            </div>
+          {% else %}
+            <div class="shoal-log">{% for line in shoal_job_log %}{{ line.ts|default:"" }}  {{ line.line }}
+{% endfor %}</div>
           {% endif %}
         </div>
       </div>

--- a/extras/netbox-plugin-shoal/netbox_shoal/views.py
+++ b/extras/netbox-plugin-shoal/netbox_shoal/views.py
@@ -6,13 +6,175 @@ convention Shoal's own NetBox client (internal/common/netbox/client.go)
 already establishes: UpsertDevice keys by serial, but the NetBox device ID
 returned from that create/lookup becomes Shoal's device_id from then on. No
 separate "shoal_device_id" custom field is needed.
+
+Deploy also remaps lab hostnames (shoal-node-1) to this pk when NetBox is
+configured, so jobs started with -device-id shoal-node-1 still appear here.
+
+Write actions (start / cancel) POST back to this view and call Shoal's
+POST /v1/jobs and /v1/jobs/{id}/cancel. BMC passwords are not collected in
+NetBox when Shoal has SHOAL_BMC_* defaults; lab plugin config only supplies
+non-secret defaults (BMC URL, ISO URL).
 """
+
+from django.conf import settings
+from django.contrib import messages
+from django.shortcuts import redirect
+from django.utils.http import url_has_allowed_host_and_scheme
 
 from dcim.models import Device
 from netbox.views import generic
 from utilities.views import ViewTab, register_model_view
 
 from . import client
+
+PLUGIN_NAME = "netbox_shoal"
+
+
+def _cfg():
+    return settings.PLUGINS_CONFIG.get(PLUGIN_NAME, {})
+
+
+def _active_or_latest_job(jobs):
+    """Prefer a provisioning job; else first row (API returns newest-first)."""
+    if not jobs:
+        return None
+    for j in jobs:
+        if (j or {}).get("state") == "provisioning":
+            return j
+    return jobs[0]
+
+
+def _can_control(request):
+    """Start/cancel require change_device (stronger than view-only tabs)."""
+    return request.user.has_perm("dcim.change_device")
+
+
+def _redirect_back(request, fallback_path):
+    nxt = request.POST.get("next") or request.GET.get("next") or fallback_path
+    if nxt and url_has_allowed_host_and_scheme(
+        nxt, allowed_hosts={request.get_host()}, require_https=request.is_secure()
+    ):
+        return redirect(nxt)
+    return redirect(fallback_path)
+
+
+def _start_defaults(instance):
+    """Build form defaults from plugin config + device identity."""
+    cfg = _cfg()
+    name = instance.name or ""
+    cf = getattr(instance, "custom_field_data", None) or {}
+    if not isinstance(cf, dict):
+        cf = {}
+    bmc_ip = cf.get("bmc_ip") or ""
+    bmc_endpoint = (cfg.get("SHOAL_DEFAULT_BMC_ENDPOINT") or "").strip()
+    if not bmc_endpoint and bmc_ip:
+        # Real BMC path: https://bmc_ip — lab multi-system sushy usually sets the full URL in config.
+        bmc_endpoint = "https://%s" % bmc_ip
+    iso_url = (cfg.get("SHOAL_DEFAULT_ISO_URL") or "").strip()
+    return {
+        "device_id": str(instance.pk),
+        "serial_target": name,
+        "system_id": name,  # sushy System.Name matches domain name
+        "bmc_endpoint": bmc_endpoint,
+        "iso_url": iso_url,
+        "profile_ref": (cfg.get("SHOAL_DEFAULT_PROFILE_REF") or "spike").strip() or "spike",
+    }
+
+
+def _handle_control_post(request, instance):
+    """Process start/cancel POST. Returns (messages_added: bool)."""
+    if not _can_control(request):
+        messages.error(request, "Permission denied: dcim.change_device required to start or cancel jobs.")
+        return True
+
+    action = (request.POST.get("action") or "").strip()
+    if action == "start":
+        defaults = _start_defaults(instance)
+        body = {
+            "device_id": defaults["device_id"],
+            "serial_target": (request.POST.get("serial_target") or defaults["serial_target"]).strip(),
+            "system_id": (request.POST.get("system_id") or defaults["system_id"]).strip(),
+            "bmc_endpoint": (request.POST.get("bmc_endpoint") or defaults["bmc_endpoint"]).strip(),
+            "iso_url": (request.POST.get("iso_url") or defaults["iso_url"]).strip(),
+            "profile_ref": (request.POST.get("profile_ref") or defaults["profile_ref"]).strip(),
+        }
+        # Optional credential override (never stored in NetBox). Empty => Shoal env defaults.
+        user = (request.POST.get("bmc_username") or "").strip()
+        password = request.POST.get("bmc_password") or ""
+        if user:
+            body["bmc_username"] = user
+        if password:
+            body["bmc_password"] = password
+        if request.POST.get("approve_destruct") == "on":
+            body["approve_destruct"] = True
+
+        if not body["bmc_endpoint"]:
+            messages.error(request, "BMC endpoint is required (set SHOAL_DEFAULT_BMC_ENDPOINT in plugin config or the form).")
+            return True
+        if not body["iso_url"] and body["profile_ref"] in ("", "spike"):
+            messages.error(request, "ISO URL is required for spike jobs (set SHOAL_DEFAULT_ISO_URL or the form).")
+            return True
+
+        data, err = client.start_job(body)
+        if err:
+            job_id = ""
+            if isinstance(data, dict) and isinstance(data.get("job"), dict):
+                job_id = data["job"].get("id") or ""
+            if job_id:
+                messages.warning(request, "Job %s started but reported an error: %s" % (job_id[:12], err))
+            else:
+                messages.error(request, "Start failed: %s" % err)
+            return True
+        job_id = (data or {}).get("id") or "?"
+        messages.success(
+            request,
+            "Provisioning job %s started (state=%s). Status auto-refreshes while provisioning."
+            % (job_id[:16], (data or {}).get("state", "?")),
+        )
+        return True
+
+    if action == "cancel":
+        job_id = (request.POST.get("job_id") or "").strip()
+        if not job_id:
+            messages.error(request, "Missing job id to cancel.")
+            return True
+        _, err = client.cancel_job(job_id)
+        if err:
+            messages.error(request, "Cancel failed: %s" % err)
+        else:
+            messages.success(request, "Cancel requested for job %s." % job_id[:16])
+        return True
+
+    messages.error(request, "Unknown action.")
+    return True
+
+
+def _status_context(instance, request=None):
+    device_id = str(instance.pk)
+    data, error = client.get_status(device_id)
+    jobs_data, jobs_err = client.get_jobs(device_id, limit=5)
+    jobs = (jobs_data or {}).get("jobs", []) if not jobs_err else []
+    active = _active_or_latest_job(jobs)
+    log_lines = []
+    log_error = None
+    if active and active.get("id"):
+        log_data, log_error = client.get_job_log(active["id"], limit=40)
+        log_lines = (log_data or {}).get("lines", [])
+    provisioning = bool(
+        data and (data.get("lifecycle_state") == "provisioning" or data.get("active_job_id"))
+    ) or any((j or {}).get("state") == "provisioning" for j in jobs)
+    return {
+        "shoal_status": data,
+        "shoal_error": error,
+        "shoal_jobs": jobs,
+        "shoal_active_job": active,
+        "shoal_job_log": log_lines,
+        "shoal_job_log_error": log_error,
+        "shoal_auto_refresh": provisioning,
+        "shoal_can_control": bool(request and _can_control(request)),
+        "shoal_start_defaults": _start_defaults(instance),
+        "shoal_actions_enabled": bool(_cfg().get("SHOAL_ENABLE_ACTIONS", True)),
+    }
 
 
 @register_model_view(Device, name="shoal_status")
@@ -25,11 +187,15 @@ class ShoalStatusView(generic.ObjectView):
     )
 
     def get_extra_context(self, request, instance):
-        data, error = client.get_status(str(instance.pk))
-        return {
-            "shoal_status": data,
-            "shoal_error": error,
-        }
+        return _status_context(instance, request)
+
+    def post(self, request, **kwargs):
+        instance = self.get_object(**kwargs)
+        if _cfg().get("SHOAL_ENABLE_ACTIONS", True):
+            _handle_control_post(request, instance)
+        else:
+            messages.error(request, "Shoal write actions are disabled in plugin config.")
+        return _redirect_back(request, request.path)
 
 
 @register_model_view(Device, name="shoal_events")
@@ -59,11 +225,33 @@ class ShoalJobsView(generic.ObjectView):
     )
 
     def get_extra_context(self, request, instance):
-        data, error = client.get_jobs(str(instance.pk), limit=50)
+        device_id = str(instance.pk)
+        data, error = client.get_jobs(device_id, limit=50)
+        jobs = (data or {}).get("jobs", [])
+        active = _active_or_latest_job(jobs)
+        log_lines = []
+        log_error = None
+        if active and active.get("id"):
+            log_data, log_error = client.get_job_log(active["id"], limit=80)
+            log_lines = (log_data or {}).get("lines", [])
         return {
-            "shoal_jobs": (data or {}).get("jobs", []),
+            "shoal_jobs": jobs,
             "shoal_error": error,
+            "shoal_active_job": active,
+            "shoal_job_log": log_lines,
+            "shoal_job_log_error": log_error,
+            "shoal_auto_refresh": any((j or {}).get("state") == "provisioning" for j in jobs),
+            "shoal_can_control": bool(request and _can_control(request)),
+            "shoal_actions_enabled": bool(_cfg().get("SHOAL_ENABLE_ACTIONS", True)),
         }
+
+    def post(self, request, **kwargs):
+        instance = self.get_object(**kwargs)
+        if _cfg().get("SHOAL_ENABLE_ACTIONS", True):
+            _handle_control_post(request, instance)
+        else:
+            messages.error(request, "Shoal write actions are disabled in plugin config.")
+        return _redirect_back(request, request.path)
 
 
 @register_model_view(Device, name="shoal_sensors")

--- a/extras/netbox-plugin-shoal/netbox_shoal/views.py
+++ b/extras/netbox-plugin-shoal/netbox_shoal/views.py
@@ -10,10 +10,11 @@ separate "shoal_device_id" custom field is needed.
 Deploy also remaps lab hostnames (shoal-node-1) to this pk when NetBox is
 configured, so jobs started with -device-id shoal-node-1 still appear here.
 
-Write actions (start / cancel) POST back to this view and call Shoal's
-POST /v1/jobs and /v1/jobs/{id}/cancel. BMC passwords are not collected in
-NetBox when Shoal has SHOAL_BMC_* defaults; lab plugin config only supplies
-non-secret defaults (BMC URL, ISO URL).
+Write actions (start / cancel / power / credentials) POST back to this view
+and call Shoal's /v1/jobs, power, and credentials APIs. BMC passwords are
+never stored in NetBox: the credentials form PUTs to Shoal's secrets backend
+(credential_ref only). Lab plugin config supplies non-secret defaults (BMC
+URL, ISO URL).
 """
 
 from django.conf import settings
@@ -26,6 +27,7 @@ from netbox.views import generic
 from utilities.views import ViewTab, register_model_view
 
 from . import client
+from .defaults import bmc_endpoint as resolve_bmc_endpoint
 
 PLUGIN_NAME = "netbox_shoal"
 
@@ -58,18 +60,37 @@ def _redirect_back(request, fallback_path):
     return redirect(fallback_path)
 
 
+def _device_bmc_ip(instance):
+    cf = getattr(instance, "custom_field_data", None) or {}
+    if not isinstance(cf, dict):
+        cf = {}
+    ip = (cf.get("bmc_ip") or "").strip()
+    if ip:
+        return ip
+    extra = getattr(instance, "cf", None)
+    if extra is None:
+        return ""
+    try:
+        return (extra.get("bmc_ip") or "").strip()
+    except (AttributeError, TypeError):
+        return ""
+
+
+def _role_slug(instance):
+    role = getattr(instance, "role", None)
+    return (getattr(role, "slug", None) or "").strip()
+
+
 def _start_defaults(instance):
     """Build form defaults from plugin config + device identity."""
     cfg = _cfg()
     name = instance.name or ""
-    cf = getattr(instance, "custom_field_data", None) or {}
-    if not isinstance(cf, dict):
-        cf = {}
-    bmc_ip = cf.get("bmc_ip") or ""
-    bmc_endpoint = (cfg.get("SHOAL_DEFAULT_BMC_ENDPOINT") or "").strip()
-    if not bmc_endpoint and bmc_ip:
-        # Real BMC path: https://bmc_ip — lab multi-system sushy usually sets the full URL in config.
-        bmc_endpoint = "https://%s" % bmc_ip
+    bmc_ip = _device_bmc_ip(instance)
+    bmc_endpoint = resolve_bmc_endpoint(
+        bmc_ip=bmc_ip,
+        role_slug=_role_slug(instance),
+        default_endpoint=(cfg.get("SHOAL_DEFAULT_BMC_ENDPOINT") or "").strip(),
+    )
     iso_url = (cfg.get("SHOAL_DEFAULT_ISO_URL") or "").strip()
     return {
         "device_id": str(instance.pk),
@@ -133,6 +154,86 @@ def _handle_control_post(request, instance):
         )
         return True
 
+    if action == "credentials":
+        body = {
+            "username": (request.POST.get("bmc_username") or "").strip(),
+        }
+        password = request.POST.get("bmc_password") or ""
+        if password:
+            body["password"] = password
+        ip = (request.POST.get("bmc_ip") or "").strip()
+        if ip:
+            body["bmc_ip"] = ip
+        data, err = client.put_credentials(str(instance.pk), body)
+        if err:
+            messages.error(request, "Save BMC credentials failed: %s" % err)
+            return True
+        messages.success(
+            request,
+            "BMC credentials saved in Shoal (ref=%s). Password is not stored in NetBox."
+            % ((data or {}).get("credential_ref") or "?"),
+        )
+        return True
+
+    if action == "power":
+        defaults = _start_defaults(instance)
+        reset_type = (request.POST.get("reset_type") or "").strip()
+        body = {
+            "reset_type": reset_type,
+            "bmc_endpoint": (request.POST.get("bmc_endpoint") or defaults["bmc_endpoint"]).strip(),
+            "system_id": (request.POST.get("system_id") or "").strip(),
+        }
+        user = (request.POST.get("bmc_username") or "").strip()
+        password = request.POST.get("bmc_password") or ""
+        if user:
+            body["bmc_username"] = user
+        if password:
+            body["bmc_password"] = password
+        if not body["bmc_endpoint"]:
+            messages.error(request, "BMC endpoint is required for power control.")
+            return True
+        data, err = client.power_device(str(instance.pk), body)
+        if err:
+            messages.error(request, "Power %s failed: %s" % (reset_type or "action", err))
+            return True
+        state = (data or {}).get("power_state") or "?"
+        messages.success(
+            request,
+            "Power %s sent. BMC reports power_state=%s." % (reset_type, state),
+        )
+        return True
+
+    if action == "poll":
+        defaults = _start_defaults(instance)
+        body = {
+            "bmc_endpoint": (request.POST.get("bmc_endpoint") or defaults["bmc_endpoint"]).strip(),
+            "system_id": (request.POST.get("system_id") or "").strip(),
+        }
+        user = (request.POST.get("bmc_username") or "").strip()
+        password = request.POST.get("bmc_password") or ""
+        if user:
+            body["bmc_username"] = user
+        if password:
+            body["bmc_password"] = password
+        if not body["bmc_endpoint"]:
+            messages.error(request, "BMC endpoint is required to poll sensors.")
+            return True
+        data, err = client.poll_device(str(instance.pk), body)
+        if err:
+            messages.error(request, "Poll BMC failed: %s" % err)
+            return True
+        messages.success(
+            request,
+            "Polled BMC: %s sensor(s), %s firmware, power=%s, %s new SEL."
+            % (
+                (data or {}).get("sensors_written", 0),
+                (data or {}).get("firmware_written", 0),
+                (data or {}).get("power_state") or "—",
+                (data or {}).get("sel_new", 0),
+            ),
+        )
+        return True
+
     if action == "cancel":
         job_id = (request.POST.get("job_id") or "").strip()
         if not job_id:
@@ -163,6 +264,23 @@ def _status_context(instance, request=None):
     provisioning = bool(
         data and (data.get("lifecycle_state") == "provisioning" or data.get("active_job_id"))
     ) or any((j or {}).get("state") == "provisioning" for j in jobs)
+    defaults = _start_defaults(instance)
+    power_system_id = ""
+    if str(defaults.get("serial_target") or "").startswith("shoal-node"):
+        power_system_id = defaults.get("system_id") or ""
+    cf = getattr(instance, "custom_field_data", None) or {}
+    if not isinstance(cf, dict):
+        cf = {}
+    creds, creds_err = client.get_credentials(
+        device_id, credential_ref=(cf.get("credential_ref") or "")
+    )
+    if isinstance(creds, dict):
+        if not creds.get("bmc_ip") and cf.get("bmc_ip"):
+            creds = dict(creds)
+            creds["bmc_ip"] = cf.get("bmc_ip")
+        if not creds.get("credential_ref") and cf.get("credential_ref"):
+            creds = dict(creds)
+            creds["credential_ref"] = cf.get("credential_ref")
     return {
         "shoal_status": data,
         "shoal_error": error,
@@ -172,7 +290,10 @@ def _status_context(instance, request=None):
         "shoal_job_log_error": log_error,
         "shoal_auto_refresh": provisioning,
         "shoal_can_control": bool(request and _can_control(request)),
-        "shoal_start_defaults": _start_defaults(instance),
+        "shoal_start_defaults": defaults,
+        "shoal_power_system_id": power_system_id,
+        "shoal_credentials": creds or {},
+        "shoal_credentials_error": creds_err,
         "shoal_actions_enabled": bool(_cfg().get("SHOAL_ENABLE_ACTIONS", True)),
     }
 
@@ -264,8 +385,58 @@ class ShoalSensorsView(generic.ObjectView):
     )
 
     def get_extra_context(self, request, instance):
-        data, error = client.get_sensors(str(instance.pk), limit=50)
+        data, error = client.get_sensors(str(instance.pk), limit=200)
+        defaults = _start_defaults(instance)
+        power_system_id = ""
+        if str(defaults.get("serial_target") or "").startswith("shoal-node"):
+            power_system_id = defaults.get("system_id") or ""
         return {
             "shoal_sensors": (data or {}).get("readings", []),
             "shoal_error": error,
+            "shoal_can_control": bool(request and _can_control(request)),
+            "shoal_actions_enabled": bool(_cfg().get("SHOAL_ENABLE_ACTIONS", True)),
+            "shoal_start_defaults": defaults,
+            "shoal_power_system_id": power_system_id,
         }
+
+    def post(self, request, **kwargs):
+        instance = self.get_object(**kwargs)
+        if _cfg().get("SHOAL_ENABLE_ACTIONS", True):
+            _handle_control_post(request, instance)
+        else:
+            messages.error(request, "Shoal write actions are disabled in plugin config.")
+        return _redirect_back(request, request.path)
+
+
+@register_model_view(Device, name="shoal_firmware")
+class ShoalFirmwareView(generic.ObjectView):
+    queryset = Device.objects.all()
+    template_name = "netbox_shoal/firmware.html"
+    tab = ViewTab(
+        label="Shoal Firmware",
+        permission="dcim.view_device",
+    )
+
+    def get_extra_context(self, request, instance):
+        data, error = client.get_firmware(str(instance.pk), limit=200)
+        defaults = _start_defaults(instance)
+        power_system_id = ""
+        if str(defaults.get("serial_target") or "").startswith("shoal-node"):
+            power_system_id = defaults.get("system_id") or ""
+        return {
+            "shoal_firmware": (data or {}).get("components", []),
+            "shoal_firmware_ts": (data or {}).get("ts"),
+            "shoal_error": error,
+            "shoal_can_control": bool(request and _can_control(request)),
+            "shoal_actions_enabled": bool(_cfg().get("SHOAL_ENABLE_ACTIONS", True)),
+            "shoal_start_defaults": defaults,
+            "shoal_power_system_id": power_system_id,
+        }
+
+    def post(self, request, **kwargs):
+        instance = self.get_object(**kwargs)
+        if _cfg().get("SHOAL_ENABLE_ACTIONS", True):
+            _handle_control_post(request, instance)
+        else:
+            messages.error(request, "Shoal write actions are disabled in plugin config.")
+        return _redirect_back(request, request.path)

--- a/extras/netbox-plugin-shoal/pyproject.toml
+++ b/extras/netbox-plugin-shoal/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "netbox-shoal"
-version = "0.1.0"
+version = "0.3.0"
 description = "NetBox plugin: Shoal device telemetry tabs (status, events)"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/extras/netbox-plugin-shoal/tests/test_client.py
+++ b/extras/netbox-plugin-shoal/tests/test_client.py
@@ -211,5 +211,67 @@ class GetSensorsTests(unittest.TestCase):
         self.assertEqual(data["readings"][0]["sensor"], "Inlet Temp")
 
 
+class GetJobLogTests(unittest.TestCase):
+    def setUp(self):
+        settings.PLUGINS_CONFIG = {
+            "netbox_shoal": {
+                "SHOAL_BASE_URL": "http://shoal.example:8088",
+                "SHOAL_API_TOKEN": "",
+                "SHOAL_REQUEST_TIMEOUT": 10,
+            }
+        }
+
+    @mock.patch("netbox_shoal.client.requests.get")
+    def test_get_job_log_url_and_limit(self, mock_get):
+        mock_get.return_value = FakeResponse({"job_id": "abc", "lines": []})
+        data, err = client.get_job_log("abc", limit=40)
+        self.assertIsNone(err)
+        self.assertEqual(data["job_id"], "abc")
+        args, kwargs = mock_get.call_args
+        self.assertEqual(args[0], "http://shoal.example:8088/v1/jobs/abc/log")
+        self.assertEqual(kwargs["params"], {"limit": 40})
+
+
+class WriteJobTests(unittest.TestCase):
+    def setUp(self):
+        settings.PLUGINS_CONFIG = {
+            "netbox_shoal": {
+                "SHOAL_BASE_URL": "http://shoal.example:8088",
+                "SHOAL_API_TOKEN": "tok",
+                "SHOAL_REQUEST_TIMEOUT": 10,
+            }
+        }
+
+    @mock.patch("netbox_shoal.client.requests.post")
+    def test_start_job_posts_json(self, mock_post):
+        mock_post.return_value = FakeResponse({"id": "j1", "state": "provisioning"}, status_code=201)
+        body = {"device_id": "1", "bmc_endpoint": "http://bmc", "iso_url": "http://iso/x.iso", "serial_target": "n1"}
+        data, err = client.start_job(body)
+        self.assertIsNone(err)
+        self.assertEqual(data["id"], "j1")
+        args, kwargs = mock_post.call_args
+        self.assertEqual(args[0], "http://shoal.example:8088/v1/jobs")
+        self.assertEqual(kwargs["json"], body)
+        self.assertEqual(kwargs["headers"]["Authorization"], "Bearer tok")
+
+    @mock.patch("netbox_shoal.client.requests.post")
+    def test_start_job_conflict_returns_error_and_body(self, mock_post):
+        mock_post.return_value = FakeResponse(
+            {"error": "register watch failed", "job": {"id": "j2"}}, status_code=409
+        )
+        data, err = client.start_job({"device_id": "1"})
+        self.assertIsNotNone(err)
+        self.assertIn("register watch", err)
+        self.assertEqual(data["job"]["id"], "j2")
+
+    @mock.patch("netbox_shoal.client.requests.post")
+    def test_cancel_job(self, mock_post):
+        mock_post.return_value = FakeResponse({"ok": True}, status_code=200)
+        data, err = client.cancel_job("abc")
+        self.assertIsNone(err)
+        args, _ = mock_post.call_args
+        self.assertEqual(args[0], "http://shoal.example:8088/v1/jobs/abc/cancel")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/extras/netbox-plugin-shoal/tests/test_client.py
+++ b/extras/netbox-plugin-shoal/tests/test_client.py
@@ -45,6 +45,7 @@ class FakeResponse:
     def __init__(self, json_data, status_code=200):
         self._json = json_data
         self.status_code = status_code
+        self.content = b"x" if json_data is not None else b""
 
     def raise_for_status(self):
         if self.status_code >= 400:
@@ -192,7 +193,7 @@ class GetSensorsTests(unittest.TestCase):
         client.get_sensors("1")
         args, kwargs = mock_get.call_args
         self.assertEqual(args[0], "http://shoal.example:8088/v1/devices/1/sensors")
-        self.assertEqual(kwargs["params"], {"limit": 50})
+        self.assertEqual(kwargs["params"], {"limit": 200})
 
     @mock.patch("netbox_shoal.client.requests.get")
     def test_get_sensors_passes_limit(self, mock_get):
@@ -271,6 +272,69 @@ class WriteJobTests(unittest.TestCase):
         self.assertIsNone(err)
         args, _ = mock_post.call_args
         self.assertEqual(args[0], "http://shoal.example:8088/v1/jobs/abc/cancel")
+
+    @mock.patch("netbox_shoal.client.requests.post")
+    def test_power_device_posts_json(self, mock_post):
+        mock_post.return_value = FakeResponse(
+            {"device_id": "6", "reset_type": "On", "power_state": "On"}
+        )
+        body = {"reset_type": "On", "bmc_endpoint": "https://bmc"}
+        data, err = client.power_device("6", body)
+        self.assertIsNone(err)
+        self.assertEqual(data["power_state"], "On")
+        args, kwargs = mock_post.call_args
+        self.assertEqual(args[0], "http://shoal.example:8088/v1/devices/6/power")
+        self.assertEqual(kwargs["json"], body)
+
+    @mock.patch("netbox_shoal.client.requests.get")
+    def test_get_credentials(self, mock_get):
+        mock_get.return_value = FakeResponse(
+            {"device_id": "6", "username": "root", "has_password": True, "credential_ref": "bmc-C784MH3"}
+        )
+        data, err = client.get_credentials("6", credential_ref="bmc-C784MH3")
+        self.assertIsNone(err)
+        self.assertEqual(data["username"], "root")
+        self.assertNotIn("password", data)
+        args, kwargs = mock_get.call_args
+        self.assertEqual(args[0], "http://shoal.example:8088/v1/devices/6/credentials")
+        self.assertEqual(kwargs.get("params"), {"credential_ref": "bmc-C784MH3"})
+
+    @mock.patch("netbox_shoal.client.requests.get")
+    def test_get_firmware(self, mock_get):
+        mock_get.return_value = FakeResponse(
+            {"device_id": "6", "components": [{"id": "BIOS", "version": "1.8.0"}]}
+        )
+        data, err = client.get_firmware("6")
+        self.assertIsNone(err)
+        self.assertEqual(data["components"][0]["version"], "1.8.0")
+        args, _ = mock_get.call_args
+        self.assertEqual(args[0], "http://shoal.example:8088/v1/devices/6/firmware")
+
+    @mock.patch("netbox_shoal.client.requests.post")
+    def test_poll_device(self, mock_post):
+        mock_post.return_value = FakeResponse(
+            {"device_id": "6", "sel_new": 0, "sensors_written": 26}
+        )
+        body = {"bmc_endpoint": "https://172.16.21.202"}
+        data, err = client.poll_device("6", body)
+        self.assertIsNone(err)
+        self.assertEqual(data["sensors_written"], 26)
+        args, kwargs = mock_post.call_args
+        self.assertEqual(args[0], "http://shoal.example:8088/v1/devices/6/poll")
+        self.assertEqual(kwargs["json"], body)
+        self.assertGreaterEqual(kwargs["timeout"], 120)
+
+    @mock.patch("netbox_shoal.client.requests.put")
+    def test_put_credentials(self, mock_put):
+        mock_put.return_value = FakeResponse(
+            {"device_id": "6", "username": "root", "has_password": True, "credential_ref": "bmc-C784MH3"}
+        )
+        data, err = client.put_credentials("6", {"username": "root", "password": "x"})
+        self.assertIsNone(err)
+        self.assertTrue(data["has_password"])
+        self.assertNotIn("password", data)
+        args, kwargs = mock_put.call_args
+        self.assertEqual(args[0], "http://shoal.example:8088/v1/devices/6/credentials")
 
 
 if __name__ == "__main__":

--- a/extras/netbox-plugin-shoal/tests/test_defaults.py
+++ b/extras/netbox-plugin-shoal/tests/test_defaults.py
@@ -1,0 +1,53 @@
+"""Unit tests for BMC endpoint prefill (no NetBox/Django required)."""
+
+import sys
+import types
+import unittest
+
+# netbox_shoal/__init__.py imports PluginConfig at package import time.
+if "netbox.plugins" not in sys.modules:
+    fake_netbox = types.ModuleType("netbox")
+    fake_netbox_plugins = types.ModuleType("netbox.plugins")
+    fake_netbox_plugins.PluginConfig = object
+    fake_netbox.plugins = fake_netbox_plugins
+    sys.modules["netbox"] = fake_netbox
+    sys.modules["netbox.plugins"] = fake_netbox_plugins
+
+from netbox_shoal.defaults import bmc_endpoint  # noqa: E402
+
+
+class BMCEndpointTests(unittest.TestCase):
+    def test_physical_server_uses_device_bmc_ip_not_lab_default(self):
+        got = bmc_endpoint(
+            bmc_ip="172.16.21.202",
+            role_slug="server",
+            default_endpoint="http://127.0.0.1:8001",
+        )
+        self.assertEqual(got, "https://172.16.21.202")
+
+    def test_lab_virtual_node_keeps_shared_sushy_url(self):
+        got = bmc_endpoint(
+            bmc_ip="192.168.124.10",
+            role_slug="virtual-bmc-node",
+            default_endpoint="http://127.0.0.1:8001",
+        )
+        self.assertEqual(got, "http://127.0.0.1:8001")
+
+    def test_lab_virtual_falls_back_to_bmc_ip_when_no_default(self):
+        got = bmc_endpoint(bmc_ip="192.168.124.10", role_slug="virtual-bmc-node")
+        self.assertEqual(got, "https://192.168.124.10")
+
+    def test_existing_scheme_kept(self):
+        got = bmc_endpoint(
+            bmc_ip="http://172.16.21.202:8000",
+            role_slug="server",
+            default_endpoint="http://127.0.0.1:8001",
+        )
+        self.assertEqual(got, "http://172.16.21.202:8000")
+
+    def test_empty(self):
+        self.assertEqual(bmc_endpoint(), "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/infra/ansible/inventory/group_vars/all/defaults.yml
+++ b/infra/ansible/inventory/group_vars/all/defaults.yml
@@ -47,6 +47,13 @@ shoal_app_http_port: 8088
 
 # Phase 6d: run Shoal app as a Compose service (binary image staged by Ansible).
 shoal_compose_app: true
+# Lab sushy is HTTP (TLS unused). insecure lets the same Shoal process talk to
+# real BMCs with self-signed HTTPS certs (iDRAC) from NetBox power/poll.
+shoal_redfish_auth_mode: basic
+shoal_redfish_tls_mode: insecure
+# Observe SEL/sensor poll cadence (Go duration). Keep idle high vs real BMCs.
+shoal_poll_idle_interval: 5m
+shoal_poll_watch_interval: 30s
 # Optional Bearer token for /v1/* (empty = open lab API). Prefer vault.
 shoal_api_token: ""
 

--- a/infra/ansible/inventory/group_vars/all/defaults.yml
+++ b/infra/ansible/inventory/group_vars/all/defaults.yml
@@ -87,6 +87,8 @@ shoal_iso_server_dir: /srv/iso
 # Append-only learned few-shot JSONL (Phase 3b confirm). Outside git; durable on
 # the lab service host. Empty string disables SHOAL_FEWSHOT_DIR in env.j2.
 shoal_fewshot_dir: /var/lib/shoal/fewshot
+# Durable job BMC credential_ref store (Compose mount; orphan cleanup after restart).
+shoal_secrets_dir: /var/lib/shoal/secrets
 # Provisioning profiles + approval records (Phase 5b). Outside git; durable on
 # the lab service host. Empty string disables SHOAL_PROFILE_DIR in env.j2.
 shoal_profile_dir: /var/lib/shoal/profiles

--- a/infra/ansible/roles/compose_stack/tasks/main.yml
+++ b/infra/ansible/roles/compose_stack/tasks/main.yml
@@ -94,6 +94,7 @@
       (
         ([shoal_fewshot_dir | dirname] if (shoal_fewshot_dir | default('') | length) > 0 else [])
         + ([shoal_profile_dir | dirname] if (shoal_profile_dir | default('') | length) > 0 else [])
+        + ([shoal_secrets_dir | dirname] if (shoal_secrets_dir | default('') | length) > 0 else [])
       ) | unique | list
     }}
   tags: [config]
@@ -116,6 +117,16 @@
     owner: "{{ ansible_user | default(shoal_lab_vm_user) }}"
     group: "{{ ansible_user | default(shoal_lab_vm_user) }}"
   when: (shoal_profile_dir | default('') | length) > 0
+  tags: [config]
+
+- name: Ensure durable secrets directory exists
+  file:
+    path: "{{ shoal_secrets_dir }}"
+    state: directory
+    mode: '0700'
+    owner: "{{ ansible_user | default(shoal_lab_vm_user) }}"
+    group: "{{ ansible_user | default(shoal_lab_vm_user) }}"
+  when: (shoal_secrets_dir | default('') | length) > 0
   tags: [config]
 
 - name: Ensure NetBox configuration directory exists

--- a/infra/ansible/roles/compose_stack/templates/docker-compose.lab.yml.j2
+++ b/infra/ansible/roles/compose_stack/templates/docker-compose.lab.yml.j2
@@ -144,6 +144,9 @@ services:
     image: shoal:lab
     container_name: shoal-app
     network_mode: host
+    # Lab nested SOL: virsh + host PTYs for jobs started via NetBox/API.
+    # Privileged is lab-only (BMC secrets already on this host).
+    privileged: true
     environment:
       - SHOAL_HTTP_ADDR=:{{ shoal_app_http_port }}
       - SHOAL_LOG_LEVEL={{ shoal_log_level | default('info') }}
@@ -163,6 +166,8 @@ services:
       - SHOAL_ISO_PUBLISH_DIR=/srv/iso
       - SHOAL_ISO_BASE_URL=http://{{ shoal_lab_network_gateway }}:{{ shoal_iso_server_port }}
       - SHOAL_API_TOKEN={{ shoal_api_token | default('') }}
+      # Durable BMC job credentials so orphan cleanup after restart can auth.
+      - SHOAL_SECRETS_DIR=/var/lib/shoal/secrets
 {% if (shoal_fewshot_dir | default('') | length) > 0 %}
       - SHOAL_FEWSHOT_DIR=/var/lib/shoal/fewshot
 {% endif %}
@@ -171,6 +176,9 @@ services:
 {% endif %}
     volumes:
       - {{ shoal_iso_server_dir }}:/srv/iso
+      - /var/run/libvirt:/var/run/libvirt
+      - /dev:/dev
+      - {{ shoal_secrets_dir | default('/var/lib/shoal/secrets') }}:/var/lib/shoal/secrets
 {% if (shoal_fewshot_dir | default('') | length) > 0 %}
       - {{ shoal_fewshot_dir }}:/var/lib/shoal/fewshot
 {% endif %}

--- a/infra/ansible/roles/compose_stack/templates/docker-compose.lab.yml.j2
+++ b/infra/ansible/roles/compose_stack/templates/docker-compose.lab.yml.j2
@@ -166,6 +166,8 @@ services:
       - SHOAL_ISO_PUBLISH_DIR=/srv/iso
       - SHOAL_ISO_BASE_URL=http://{{ shoal_lab_network_gateway }}:{{ shoal_iso_server_port }}
       - SHOAL_API_TOKEN={{ shoal_api_token | default('') }}
+      - SHOAL_POLL_IDLE_INTERVAL={{ shoal_poll_idle_interval | default('5m') }}
+      - SHOAL_POLL_WATCH_INTERVAL={{ shoal_poll_watch_interval | default('30s') }}
       # Durable BMC job credentials so orphan cleanup after restart can auth.
       - SHOAL_SECRETS_DIR=/var/lib/shoal/secrets
 {% if (shoal_fewshot_dir | default('') | length) > 0 %}

--- a/infra/ansible/roles/compose_stack/templates/env.j2
+++ b/infra/ansible/roles/compose_stack/templates/env.j2
@@ -34,3 +34,5 @@ SHOAL_NETBOX_TOKEN={{ shoal_netbox_api_token | default('') }}
 {% if (shoal_api_token | default('') | length) > 0 %}
 SHOAL_API_TOKEN={{ shoal_api_token }}
 {% endif %}
+SHOAL_POLL_IDLE_INTERVAL={{ shoal_poll_idle_interval | default('5m') }}
+SHOAL_POLL_WATCH_INTERVAL={{ shoal_poll_watch_interval | default('30s') }}

--- a/infra/ansible/roles/compose_stack/templates/netbox-plugins.py.j2
+++ b/infra/ansible/roles/compose_stack/templates/netbox-plugins.py.j2
@@ -11,6 +11,13 @@ PLUGINS_CONFIG = {
     "netbox_shoal": {
         "SHOAL_BASE_URL": "{{ shoal_netbox_plugin_base_url }}",
         "SHOAL_API_TOKEN": "{{ shoal_api_token | default('') }}",
-        "SHOAL_REQUEST_TIMEOUT": 10,
+        # Start can wait on media attach + SOL register.
+        "SHOAL_REQUEST_TIMEOUT": {{ shoal_netbox_plugin_request_timeout | default(30) }},
+        # Demo write path (Start/Cancel on device Status tab).
+        "SHOAL_ENABLE_ACTIONS": {{ 'True' if (shoal_netbox_plugin_enable_actions | default(true)) else 'False' }},
+        # Prefill only — BMC passwords stay on Shoal (SHOAL_BMC_* in shoal-app).
+        "SHOAL_DEFAULT_BMC_ENDPOINT": "{{ shoal_netbox_plugin_default_bmc_endpoint | default('http://127.0.0.1:' ~ shoal_sushy_port) }}",
+        "SHOAL_DEFAULT_ISO_URL": "{{ shoal_netbox_plugin_default_iso_url | default('http://' ~ shoal_lab_network_gateway ~ ':' ~ shoal_iso_server_port ~ '/shoal-marker.iso') }}",
+        "SHOAL_DEFAULT_PROFILE_REF": "{{ shoal_netbox_plugin_default_profile_ref | default('spike') }}",
     }
 }

--- a/infra/ansible/roles/netbox_bootstrap/tasks/main.yml
+++ b/infra/ansible/roles/netbox_bootstrap/tasks/main.yml
@@ -109,6 +109,27 @@
   when: site_info.json.results | length > 0
   tags: [site]
 
+- name: Create Server device role
+  uri:
+    url: "{{ shoal_netbox_url }}/api/dcim/device-roles/"
+    method: POST
+    headers: "{{ netbox_auth_header }}"
+    body_format: json
+    body:
+      name: "Server"
+      slug: "server"
+      color: "2196f3"
+      vm_role: false
+    status_code: [200, 201, 400]
+  register: server_role_create
+  no_log: true
+  failed_when: >
+    server_role_create.status | int not in [200, 201, 400] or
+    (server_role_create.status | int == 400 and
+     'already exists' not in (server_role_create.json | default({}) | to_json | lower) and
+     'unique' not in (server_role_create.json | default({}) | to_json | lower))
+  tags: [role]
+
 - name: Create Virtual BMC Node device role
   uri:
     url: "{{ shoal_netbox_url }}/api/dcim/device-roles/"

--- a/infra/ansible/roles/netbox_bootstrap/tasks/main.yml
+++ b/infra/ansible/roles/netbox_bootstrap/tasks/main.yml
@@ -267,10 +267,16 @@
     body_format: json
     body:
       name: "{{ item.name }}"
+      # serial == name so Shoal can resolve -device-id shoal-node-N → NetBox pk
+      # (plugin tabs key by device.pk; Deploy remaps name/serial when NetBox is set).
+      serial: "{{ item.name }}"
       role: "{{ shoal_device_role_id }}"
       device_type: "{{ shoal_device_type_id }}"
       site: "{{ shoal_site_id }}"
       status: "active"
+      custom_fields:
+        bmc_ip: "{{ item.ip }}"
+        lifecycle_state: "discovered"
     status_code: [200, 201, 400]
   loop: "{{ shoal_bmc_nodes }}"
   register: device_create
@@ -280,6 +286,36 @@
     (device_create.status | int == 400 and
      'already exists' not in (device_create.json | default({}) | to_json | lower) and
      'unique' not in (device_create.json | default({}) | to_json | lower))
+  tags: [devices]
+
+# Existing labs may have nodes without serial; patch so demo resolve works after re-bootstrap.
+- name: Ensure BMC node serial and bmc_ip for demo identity
+  uri:
+    url: "{{ shoal_netbox_url }}/api/dcim/devices/?name={{ item.name }}"
+    method: GET
+    headers: "{{ netbox_auth_header }}"
+    status_code: [200]
+  loop: "{{ shoal_bmc_nodes }}"
+  register: device_lookup
+  tags: [devices]
+
+- name: Patch BMC node serial + custom fields when found
+  uri:
+    url: "{{ shoal_netbox_url }}/api/dcim/devices/{{ item.json.results[0].id }}/"
+    method: PATCH
+    headers: "{{ netbox_auth_header }}"
+    body_format: json
+    body:
+      serial: "{{ item.item.name }}"
+      custom_fields:
+        bmc_ip: "{{ item.item.ip }}"
+    status_code: [200]
+  loop: "{{ device_lookup.results }}"
+  when:
+    - item.json is defined
+    - item.json.results is defined
+    - item.json.results | length > 0
+  no_log: true
   tags: [devices]
 
 - name: Display NetBox bootstrap status
@@ -294,8 +330,8 @@
       - Device Type: Virtual Server (ID: {{ shoal_device_type_id }})
       - Custom fields (dcim.device): lifecycle_state, credential_ref, bmc_ip
       
-      Registered devices:
+      Registered devices (serial = name for Shoal device_id resolve):
       {% for node in shoal_bmc_nodes %}
-      - {{ node.name }} ({{ node.ip }})
+      - {{ node.name }} serial={{ node.name }} bmc={{ node.ip }}
       {% endfor %}
   tags: [status]

--- a/internal/api/auth_test.go
+++ b/internal/api/auth_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/mattcburns/shoal/internal/api"
@@ -81,6 +82,24 @@ func TestAPIAuthProtectsNewTelemetryRoutes(t *testing.T) {
 		if rr.Code == http.StatusUnauthorized {
 			t.Fatalf("%s: valid bearer still unauthorized", path)
 		}
+	}
+}
+
+func TestAPIAuthProtectsDevicePower(t *testing.T) {
+	s := api.New(config.Config{APIToken: "secret-token"}, nil)
+	body := strings.NewReader(`{"reset_type":"On","bmc_endpoint":"https://bmc"}`)
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/devices/6/power", body)
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("want 401 without bearer, got %d", rr.Code)
+	}
+	rr = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodPost, "/v1/devices/6/power", strings.NewReader(`{"reset_type":"On","bmc_endpoint":"https://bmc"}`))
+	req.Header.Set("Authorization", "Bearer secret-token")
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code == http.StatusUnauthorized {
+		t.Fatal("valid bearer still unauthorized")
 	}
 }
 

--- a/internal/api/credentials.go
+++ b/internal/api/credentials.go
@@ -1,0 +1,95 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/mattcburns/shoal/internal/common/validate"
+)
+
+// DeviceCredentialsView is a non-secret view of stored BMC credentials.
+type DeviceCredentialsView struct {
+	DeviceID      string `json:"device_id"`
+	CredentialRef string `json:"credential_ref"`
+	Username      string `json:"username,omitempty"`
+	HasPassword   bool   `json:"has_password"`
+	BMCIP         string `json:"bmc_ip,omitempty"`
+}
+
+// DeviceCredentialsPut updates stored BMC credentials. Password is never returned.
+// Empty password keeps the existing secret when a credential already exists.
+type DeviceCredentialsPut struct {
+	Username string `json:"username"`
+	Password string `json:"password,omitempty"`
+	BMCIP    string `json:"bmc_ip,omitempty"`
+}
+
+// DeviceCredentials stores BMC user/pass in the secrets backend (not NetBox).
+type DeviceCredentials interface {
+	// Get returns a non-secret view. credentialRef, when set, skips NetBox lookup
+	// (plugin already has the custom field; calling NetBox from a Status render can stall).
+	Get(ctx context.Context, deviceID, credentialRef string) (DeviceCredentialsView, error)
+	Put(ctx context.Context, deviceID string, req DeviceCredentialsPut) (DeviceCredentialsView, error)
+	// Resolve returns username/password for power/jobs. Never log the result.
+	Resolve(ctx context.Context, deviceID string) (username, password string, err error)
+}
+
+// WithDeviceCredentials attaches GET/PUT /v1/devices/{id}/credentials.
+func (s *Server) WithDeviceCredentials(c DeviceCredentials) *Server {
+	s.creds = c
+	return s
+}
+
+func (s *Server) handleDeviceCredentialsGet(w http.ResponseWriter, r *http.Request) {
+	if s.creds == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]any{"error": "credentials store not configured"})
+		return
+	}
+	id := r.PathValue("id")
+	if id == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "missing device id"})
+		return
+	}
+	view, err := s.creds.Get(r.Context(), id, r.URL.Query().Get("credential_ref"))
+	if err != nil {
+		s.log.Warn("device credentials get", "device_id", id, "err", err.Error())
+		writeJSON(w, http.StatusNotFound, map[string]any{"error": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, view)
+}
+
+func (s *Server) handleDeviceCredentialsPut(w http.ResponseWriter, r *http.Request) {
+	if s.creds == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]any{"error": "credentials store not configured"})
+		return
+	}
+	id := r.PathValue("id")
+	if id == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "missing device id"})
+		return
+	}
+	var req DeviceCredentialsPut
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid json"})
+		return
+	}
+	if err := validate.DeviceCredentials(req.Username, req.Password); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"error": err.Error()})
+		return
+	}
+	view, err := s.creds.Put(r.Context(), id, req)
+	if err != nil {
+		s.log.Warn("device credentials put", "device_id", id, "err", err.Error())
+		msg := err.Error()
+		code := http.StatusBadRequest
+		if strings.Contains(msg, "not found") || strings.Contains(msg, "status 404") {
+			code = http.StatusNotFound
+		}
+		writeJSON(w, code, map[string]any{"error": msg})
+		return
+	}
+	writeJSON(w, http.StatusOK, view)
+}

--- a/internal/api/credentials_test.go
+++ b/internal/api/credentials_test.go
@@ -1,0 +1,139 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/mattcburns/shoal/internal/common/config"
+)
+
+type fakeCreds struct {
+	view DeviceCredentialsView
+	put  DeviceCredentialsPut
+	err  error
+	u, p string
+}
+
+func (f *fakeCreds) Get(_ context.Context, deviceID, _ string) (DeviceCredentialsView, error) {
+	if f.err != nil {
+		return DeviceCredentialsView{}, f.err
+	}
+	v := f.view
+	v.DeviceID = deviceID
+	return v, nil
+}
+
+func (f *fakeCreds) Put(_ context.Context, deviceID string, req DeviceCredentialsPut) (DeviceCredentialsView, error) {
+	f.put = req
+	if f.err != nil {
+		return DeviceCredentialsView{}, f.err
+	}
+	return DeviceCredentialsView{
+		DeviceID:      deviceID,
+		CredentialRef: "bmc-x",
+		Username:      req.Username,
+		HasPassword:   req.Password != "" || f.view.HasPassword,
+	}, nil
+}
+
+func (f *fakeCreds) Resolve(_ context.Context, _ string) (string, string, error) {
+	return f.u, f.p, f.err
+}
+
+func TestDeviceCredentialsGetPut(t *testing.T) {
+	fc := &fakeCreds{view: DeviceCredentialsView{Username: "root", HasPassword: true, CredentialRef: "bmc-C784MH3"}}
+	s := New(config.Config{}, nil).WithDeviceCredentials(fc)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/devices/6/credentials", nil)
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("GET status %d body=%s", rr.Code, rr.Body.String())
+	}
+	var got DeviceCredentialsView
+	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Username != "root" || !got.HasPassword || got.CredentialRef != "bmc-C784MH3" {
+		t.Fatalf("%+v", got)
+	}
+	if bytes.Contains(rr.Body.Bytes(), []byte("password")) && bytes.Contains(rr.Body.Bytes(), []byte(`"password":`)) {
+		t.Fatal("GET must not include password field")
+	}
+
+	body, _ := json.Marshal(DeviceCredentialsPut{Username: "root", Password: "secret"})
+	rr = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodPut, "/v1/devices/6/credentials", bytes.NewReader(body))
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("PUT status %d body=%s", rr.Code, rr.Body.String())
+	}
+	if fc.put.Username != "root" || fc.put.Password != "secret" {
+		t.Fatalf("put %+v", fc.put)
+	}
+}
+
+func TestDeviceCredentialsPutRequiresUsername(t *testing.T) {
+	s := New(config.Config{}, nil).WithDeviceCredentials(&fakeCreds{})
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/v1/devices/6/credentials", bytes.NewReader([]byte(`{"password":"x"}`)))
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status %d", rr.Code)
+	}
+}
+
+func TestDeviceCredentialsGetPassesCredentialRef(t *testing.T) {
+	fc := &fakeCreds{view: DeviceCredentialsView{Username: "root", HasPassword: true, CredentialRef: "bmc-C784MH3"}}
+	s := New(config.Config{}, nil).WithDeviceCredentials(fc)
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/devices/6/credentials?credential_ref=bmc-C784MH3", nil)
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status %d", rr.Code)
+	}
+}
+
+func TestDeviceCredentialsGetEmptyOK(t *testing.T) {
+	s := New(config.Config{}, nil).WithDeviceCredentials(&fakeCreds{})
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/devices/6/credentials", nil)
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status %d body=%s", rr.Code, rr.Body.String())
+	}
+	if bytes.Contains(rr.Body.Bytes(), []byte(`"password":`)) {
+		t.Fatal("GET must not include password field")
+	}
+}
+
+func TestDeviceCredentialsUnavailable(t *testing.T) {
+	s := New(config.Config{}, nil)
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/devices/6/credentials", nil)
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status %d", rr.Code)
+	}
+}
+
+func TestDevicePowerUsesStoredCredentials(t *testing.T) {
+	fp := &fakePower{}
+	fc := &fakeCreds{u: "idrac", p: "stored"}
+	s := New(config.Config{BMCUsername: "env", BMCPassword: "envpass"}, nil).
+		WithDeviceCredentials(fc).WithDevicePower(fp)
+	body, _ := json.Marshal(DevicePowerRequest{ResetType: "On", BMCEndpoint: "https://bmc"})
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/devices/6/power", bytes.NewReader(body))
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status %d body=%s", rr.Code, rr.Body.String())
+	}
+	if fp.lastReq.BMCUsername != "idrac" || fp.lastReq.BMCPassword != "stored" {
+		t.Fatalf("want stored creds, got %+v", fp.lastReq)
+	}
+}

--- a/internal/api/devices.go
+++ b/internal/api/devices.go
@@ -127,7 +127,7 @@ func (s *Server) handleDeviceSensors(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "missing device id"})
 		return
 	}
-	limit := 50
+	limit := maxListLimit
 	if v := r.URL.Query().Get("limit"); v != "" {
 		if n, err := strconv.Atoi(v); err == nil && n > 0 {
 			limit = n
@@ -153,5 +153,45 @@ func (s *Server) handleDeviceSensors(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]any{
 		"device_id": id,
 		"readings":  readings,
+	})
+}
+
+func (s *Server) handleDeviceFirmware(w http.ResponseWriter, r *http.Request) {
+	if s.observe == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]any{
+			"error": "observe not configured",
+		})
+		return
+	}
+	id := r.PathValue("id")
+	if id == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "missing device id"})
+		return
+	}
+	limit := maxListLimit
+	if v := r.URL.Query().Get("limit"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			limit = n
+		}
+	}
+	if limit > maxListLimit {
+		limit = maxListLimit
+	}
+	comps, err := s.observe.ListFirmware(r.Context(), id, limit)
+	if err != nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]any{"error": err.Error()})
+		return
+	}
+	if comps == nil {
+		comps = []telemetry.FirmwareComponent{}
+	}
+	var ts time.Time
+	if len(comps) > 0 {
+		ts = comps[0].TS
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"device_id":  id,
+		"ts":         ts,
+		"components": comps,
 	})
 }

--- a/internal/api/devices_test.go
+++ b/internal/api/devices_test.go
@@ -141,7 +141,7 @@ func TestDeviceSensors(t *testing.T) {
 	ctx := context.Background()
 	ts := time.Now().UTC()
 	_ = store.WriteSensor(ctx, telemetry.SensorReading{
-		DeviceID: "n3", TS: ts, Sensor: "Inlet Temp", Value: 24.5, Unit: "Cel",
+		DeviceID: "n3", TS: ts, Sensor: "Inlet Temp", Value: telemetry.SensorValue(24.5), Unit: "Cel",
 	})
 	obs := observe.New(nil, jobstore.NewMemory(), store, nil)
 	s := api.New(config.Config{}, nil).WithObserve(obs)
@@ -181,5 +181,43 @@ func TestDeviceSensorsWithoutTelemetry(t *testing.T) {
 	s.Handler().ServeHTTP(rr, req)
 	if rr.Code != http.StatusServiceUnavailable {
 		t.Fatalf("status %d", rr.Code)
+	}
+}
+
+func TestDeviceFirmwareAndPolledPower(t *testing.T) {
+	store := telemetry.NewMemory()
+	ctx := context.Background()
+	ts := time.Now().UTC()
+	_ = store.WriteFirmware(ctx, telemetry.FirmwareComponent{
+		DeviceID: "n4", TS: ts, ID: "Installed-0-BIOS", Name: "BIOS", Version: "1.8.0",
+	})
+	_ = store.WritePower(ctx, telemetry.PowerReading{DeviceID: "n4", TS: ts, PowerState: "Off"})
+	obs := observe.New(nil, jobstore.NewMemory(), store, nil)
+	s := api.New(config.Config{}, nil).WithObserve(obs)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/devices/n4/firmware", nil)
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status %d body=%s", rr.Code, rr.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	comps, ok := body["components"].([]any)
+	if !ok || len(comps) != 1 {
+		t.Fatalf("components: %+v", body["components"])
+	}
+
+	rr = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/v1/devices/n4/status", nil)
+	s.Handler().ServeHTTP(rr, req)
+	var st models.DeviceStatus
+	if err := json.Unmarshal(rr.Body.Bytes(), &st); err != nil {
+		t.Fatal(err)
+	}
+	if st.PowerState != "Off" {
+		t.Fatalf("power %+v", st)
 	}
 }

--- a/internal/api/poll.go
+++ b/internal/api/poll.go
@@ -1,0 +1,99 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/mattcburns/shoal/internal/common/validate"
+)
+
+// DevicePollRequest is POST /v1/devices/{id}/poll (on-demand SEL + sensors).
+type DevicePollRequest struct {
+	BMCEndpoint string `json:"bmc_endpoint,omitempty"`
+	BMCUsername string `json:"bmc_username,omitempty"`
+	BMCPassword string `json:"bmc_password,omitempty"`
+	SystemID    string `json:"system_id,omitempty"`
+}
+
+// DevicePollResult is the on-demand poll outcome. Password is never included.
+type DevicePollResult struct {
+	DeviceID        string `json:"device_id"`
+	SELNew          int    `json:"sel_new"`
+	SensorsWritten  int    `json:"sensors_written"`
+	FirmwareWritten int    `json:"firmware_written"`
+	PowerState      string `json:"power_state,omitempty"`
+}
+
+// DevicePoll runs one Redfish SEL+sensor poll into telemetry.
+type DevicePoll interface {
+	Poll(ctx context.Context, deviceID string, req DevicePollRequest) (DevicePollResult, error)
+}
+
+// WithDevicePoll attaches POST /v1/devices/{id}/poll.
+func (s *Server) WithDevicePoll(p DevicePoll) *Server {
+	s.poll = p
+	return s
+}
+
+func (s *Server) handleDevicePoll(w http.ResponseWriter, r *http.Request) {
+	if s.poll == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]any{
+			"error": "device poll not configured",
+		})
+		return
+	}
+	id := r.PathValue("id")
+	if id == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "missing device id"})
+		return
+	}
+	var req DevicePollRequest
+	if r.Body != nil {
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil && err != io.EOF {
+			writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid json"})
+			return
+		}
+	}
+	if (strings.TrimSpace(req.BMCUsername) == "" || req.BMCPassword == "") && s.creds != nil {
+		if u, p, err := s.creds.Resolve(r.Context(), id); err == nil {
+			if strings.TrimSpace(req.BMCUsername) == "" {
+				req.BMCUsername = u
+			}
+			if req.BMCPassword == "" {
+				req.BMCPassword = p
+			}
+		}
+	}
+	if strings.TrimSpace(req.BMCUsername) == "" {
+		req.BMCUsername = s.cfg.BMCUsername
+	}
+	if req.BMCPassword == "" {
+		req.BMCPassword = s.cfg.BMCPassword
+	}
+	if strings.TrimSpace(req.BMCEndpoint) == "" && s.creds != nil {
+		if view, err := s.creds.Get(r.Context(), id, ""); err == nil {
+			req.BMCEndpoint = endpointFromBMCIP(view.BMCIP)
+		}
+	}
+	if err := validate.DevicePoll(req.BMCEndpoint); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"error": err.Error()})
+		return
+	}
+	out, err := s.poll.Poll(r.Context(), id, req)
+	if err != nil {
+		s.log.Warn("device poll", "device_id", id, "err", err.Error())
+		writeJSON(w, http.StatusBadGateway, map[string]any{
+			"error":            err.Error(),
+			"device_id":        id,
+			"sel_new":          out.SELNew,
+			"sensors_written":  out.SensorsWritten,
+			"firmware_written": out.FirmwareWritten,
+			"power_state":      out.PowerState,
+		})
+		return
+	}
+	writeJSON(w, http.StatusOK, out)
+}

--- a/internal/api/poll_test.go
+++ b/internal/api/poll_test.go
@@ -1,0 +1,96 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/mattcburns/shoal/internal/common/config"
+)
+
+type fakePoll struct {
+	lastID  string
+	lastReq DevicePollRequest
+	err     error
+	out     DevicePollResult
+}
+
+func (f *fakePoll) Poll(_ context.Context, deviceID string, req DevicePollRequest) (DevicePollResult, error) {
+	f.lastID = deviceID
+	f.lastReq = req
+	if f.err != nil {
+		out := f.out
+		out.DeviceID = deviceID
+		return out, f.err
+	}
+	out := f.out
+	if out.DeviceID == "" {
+		out.DeviceID = deviceID
+	}
+	return out, nil
+}
+
+func TestDevicePollSuccess(t *testing.T) {
+	fp := &fakePoll{out: DevicePollResult{SELNew: 1, SensorsWritten: 26}}
+	s := New(config.Config{BMCUsername: "env", BMCPassword: "envpass"}, nil).WithDevicePoll(fp)
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/devices/6/poll", strings.NewReader(`{"bmc_endpoint":"https://172.16.21.202"}`))
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status %d body=%s", rr.Code, rr.Body.String())
+	}
+	if fp.lastID != "6" || fp.lastReq.BMCEndpoint != "https://172.16.21.202" {
+		t.Fatalf("%+v", fp.lastReq)
+	}
+	if fp.lastReq.BMCUsername != "env" || fp.lastReq.BMCPassword != "envpass" {
+		t.Fatal("expected env BMC defaults when body omits creds")
+	}
+	var got DevicePollResult
+	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.SensorsWritten != 26 || got.SELNew != 1 {
+		t.Fatalf("%+v", got)
+	}
+}
+
+func TestDevicePollFillsEndpointAndCreds(t *testing.T) {
+	fp := &fakePoll{out: DevicePollResult{SensorsWritten: 3}}
+	fc := &fakeCreds{view: DeviceCredentialsView{BMCIP: "172.16.21.202"}, u: "root", p: "secret"}
+	s := New(config.Config{}, nil).WithDeviceCredentials(fc).WithDevicePoll(fp)
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/devices/6/poll", strings.NewReader(`{}`))
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status %d body=%s", rr.Code, rr.Body.String())
+	}
+	if fp.lastReq.BMCEndpoint != "https://172.16.21.202" {
+		t.Fatalf("endpoint %+v", fp.lastReq)
+	}
+	if fp.lastReq.BMCUsername != "root" || fp.lastReq.BMCPassword != "secret" {
+		t.Fatalf("creds %+v", fp.lastReq)
+	}
+}
+
+func TestDevicePollUnavailable(t *testing.T) {
+	s := New(config.Config{}, nil)
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/devices/6/poll", strings.NewReader(`{"bmc_endpoint":"https://bmc"}`))
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status %d", rr.Code)
+	}
+}
+
+func TestDevicePollRejectsMissingEndpoint(t *testing.T) {
+	s := New(config.Config{}, nil).WithDevicePoll(&fakePoll{})
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/devices/6/poll", strings.NewReader(`{}`))
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status %d", rr.Code)
+	}
+}

--- a/internal/api/power.go
+++ b/internal/api/power.go
@@ -1,0 +1,100 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/mattcburns/shoal/internal/common/validate"
+)
+
+// DevicePowerRequest is POST /v1/devices/{id}/power.
+type DevicePowerRequest struct {
+	ResetType   string `json:"reset_type"`
+	BMCEndpoint string `json:"bmc_endpoint"`
+	BMCUsername string `json:"bmc_username,omitempty"`
+	BMCPassword string `json:"bmc_password,omitempty"`
+	SystemID    string `json:"system_id,omitempty"`
+}
+
+// DevicePowerResult is the BMC power action outcome.
+type DevicePowerResult struct {
+	DeviceID   string `json:"device_id"`
+	ResetType  string `json:"reset_type"`
+	PowerState string `json:"power_state,omitempty"`
+	SystemID   string `json:"system_id,omitempty"`
+}
+
+// DevicePower applies a Redfish reset for operator power control (not a Deploy job).
+type DevicePower interface {
+	Power(ctx context.Context, deviceID string, req DevicePowerRequest) (DevicePowerResult, error)
+}
+
+// WithDevicePower attaches POST /v1/devices/{id}/power.
+func (s *Server) WithDevicePower(p DevicePower) *Server {
+	s.power = p
+	return s
+}
+
+func (s *Server) handleDevicePower(w http.ResponseWriter, r *http.Request) {
+	if s.power == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]any{
+			"error": "device power not configured",
+		})
+		return
+	}
+	id := r.PathValue("id")
+	if id == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "missing device id"})
+		return
+	}
+	var req DevicePowerRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid json"})
+		return
+	}
+	if (strings.TrimSpace(req.BMCUsername) == "" || req.BMCPassword == "") && s.creds != nil {
+		if u, p, err := s.creds.Resolve(r.Context(), id); err == nil {
+			if strings.TrimSpace(req.BMCUsername) == "" {
+				req.BMCUsername = u
+			}
+			if req.BMCPassword == "" {
+				req.BMCPassword = p
+			}
+		}
+	}
+	if strings.TrimSpace(req.BMCUsername) == "" {
+		req.BMCUsername = s.cfg.BMCUsername
+	}
+	if req.BMCPassword == "" {
+		req.BMCPassword = s.cfg.BMCPassword
+	}
+	if strings.TrimSpace(req.BMCEndpoint) == "" && s.creds != nil {
+		if view, err := s.creds.Get(r.Context(), id, ""); err == nil {
+			req.BMCEndpoint = endpointFromBMCIP(view.BMCIP)
+		}
+	}
+	if err := validate.DevicePower(req.ResetType, req.BMCEndpoint); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"error": err.Error()})
+		return
+	}
+	out, err := s.power.Power(r.Context(), id, req)
+	if err != nil {
+		s.log.Warn("device power", "device_id", id, "reset_type", req.ResetType, "err", err.Error())
+		writeJSON(w, http.StatusBadGateway, map[string]any{"error": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+func endpointFromBMCIP(ip string) string {
+	ip = strings.TrimSpace(ip)
+	if ip == "" {
+		return ""
+	}
+	if strings.HasPrefix(ip, "http://") || strings.HasPrefix(ip, "https://") {
+		return ip
+	}
+	return "https://" + ip
+}

--- a/internal/api/power_test.go
+++ b/internal/api/power_test.go
@@ -1,0 +1,99 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/mattcburns/shoal/internal/common/config"
+)
+
+type fakePower struct {
+	lastID  string
+	lastReq DevicePowerRequest
+	err     error
+	out     DevicePowerResult
+}
+
+func (f *fakePower) Power(_ context.Context, deviceID string, req DevicePowerRequest) (DevicePowerResult, error) {
+	f.lastID = deviceID
+	f.lastReq = req
+	if f.err != nil {
+		return DevicePowerResult{}, f.err
+	}
+	out := f.out
+	if out.DeviceID == "" {
+		out.DeviceID = deviceID
+	}
+	if out.ResetType == "" {
+		out.ResetType = req.ResetType
+	}
+	return out, nil
+}
+
+func TestDevicePowerSuccess(t *testing.T) {
+	fp := &fakePower{out: DevicePowerResult{PowerState: "On", ResetType: "On"}}
+	s := New(config.Config{BMCUsername: "root", BMCPassword: "lab"}, nil).WithDevicePower(fp)
+	body, _ := json.Marshal(DevicePowerRequest{
+		ResetType: "On", BMCEndpoint: "https://172.16.21.202",
+	})
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/devices/6/power", bytes.NewReader(body))
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status %d body=%s", rr.Code, rr.Body.String())
+	}
+	if fp.lastID != "6" || fp.lastReq.ResetType != "On" {
+		t.Fatalf("%+v", fp.lastReq)
+	}
+	if fp.lastReq.BMCUsername != "root" || fp.lastReq.BMCPassword != "lab" {
+		t.Fatal("expected env BMC defaults when body omits creds")
+	}
+	var got DevicePowerResult
+	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.PowerState != "On" {
+		t.Fatalf("%+v", got)
+	}
+}
+
+func TestDevicePowerRejectsBadType(t *testing.T) {
+	s := New(config.Config{}, nil).WithDevicePower(&fakePower{})
+	body := []byte(`{"reset_type":"Explode","bmc_endpoint":"https://bmc"}`)
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/devices/6/power", bytes.NewReader(body))
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status %d", rr.Code)
+	}
+}
+
+func TestDevicePowerFillsEndpointFromStoredBMCIP(t *testing.T) {
+	fp := &fakePower{out: DevicePowerResult{PowerState: "Off", ResetType: "On"}}
+	fc := &fakeCreds{view: DeviceCredentialsView{BMCIP: "172.16.21.202"}, u: "root", p: "x"}
+	s := New(config.Config{}, nil).WithDeviceCredentials(fc).WithDevicePower(fp)
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/devices/6/power", strings.NewReader(`{"reset_type":"On"}`))
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status %d body=%s", rr.Code, rr.Body.String())
+	}
+	if fp.lastReq.BMCEndpoint != "https://172.16.21.202" {
+		t.Fatalf("endpoint %+v", fp.lastReq)
+	}
+}
+
+func TestDevicePowerUnavailable(t *testing.T) {
+	s := New(config.Config{}, nil)
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/devices/6/power", strings.NewReader(`{"reset_type":"On","bmc_endpoint":"https://bmc"}`))
+	s.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status %d", rr.Code)
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -31,6 +31,9 @@ type Server struct {
 	start    JobStarter
 	discover *discover.Service
 	observe  *observe.Service
+	power    DevicePower
+	creds    DeviceCredentials
+	poll     DevicePoll
 }
 
 // New constructs a Server with routes registered.
@@ -67,6 +70,11 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("GET /v1/devices/{id}/events", s.handleDeviceEvents)
 	s.mux.HandleFunc("GET /v1/devices/{id}/jobs", s.handleDeviceJobs)
 	s.mux.HandleFunc("GET /v1/devices/{id}/sensors", s.handleDeviceSensors)
+	s.mux.HandleFunc("GET /v1/devices/{id}/firmware", s.handleDeviceFirmware)
+	s.mux.HandleFunc("POST /v1/devices/{id}/power", s.handleDevicePower)
+	s.mux.HandleFunc("POST /v1/devices/{id}/poll", s.handleDevicePoll)
+	s.mux.HandleFunc("GET /v1/devices/{id}/credentials", s.handleDeviceCredentialsGet)
+	s.mux.HandleFunc("PUT /v1/devices/{id}/credentials", s.handleDeviceCredentialsPut)
 }
 
 func (s *Server) handleHealthz(w http.ResponseWriter, _ *http.Request) {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -216,6 +216,20 @@ func cmdServe(args []string) int {
 				log.Info("profile store enabled", "dir", cfg.ProfileDir)
 			}
 		}
+		// Phase 4: Telemetry is Postgres-only — no silent memory fallback.
+		// Open before Orchestrator so SOL markers can append job_log for the NetBox UI.
+		var telemStore telemetry.Store
+		if cfg.TelemetryDatabaseURL != "" {
+			db, err := telemetry.OpenAndMigrate(ctx, cfg.TelemetryDatabaseURL)
+			if err != nil {
+				log.Error("telemetry store open failed; observe events/poll and job_log disabled", "err", err.Error())
+			} else {
+				defer db.Close()
+				telemStore = telemetry.NewPostgres(db)
+			}
+		} else {
+			log.Warn("SHOAL_TELEMETRY_DATABASE_URL unset; observe events/poll and job_log disabled")
+		}
 		orchOpts := job.Options{
 			Log:                    log,
 			Store:                  store,
@@ -223,6 +237,7 @@ func cmdServe(args []string) int {
 			NewBMC:                 redfish.NewBMC,
 			Watches:                watchSvc,
 			NetBox:                 nb,
+			Telemetry:              telemStore,
 			Profiles:               profStore,
 			ISOBaseURL:             cfg.ISOBaseURL,
 			ISOPublishDir:          cfg.ISOPublishDir,
@@ -232,6 +247,8 @@ func cmdServe(args []string) int {
 			CAFile:                 cfg.RedfishCAFile,
 			ReconcileFailOrphan:    cfg.ReconcileFailOrphans,
 			DefaultSerialTransport: cfg.SerialTransport,
+			DefaultBMCUsername:     cfg.BMCUsername,
+			DefaultBMCPassword:     cfg.BMCPassword,
 		}
 		if cfg.ISOPublishDir != "" && cfg.ISOBaseURL != "" {
 			orchOpts.ISOBuilder = iso.NewScriptBuilder(cfg.ISOBuildScript, log)
@@ -245,19 +262,6 @@ func cmdServe(args []string) int {
 			log.Warn("orphan reconcile", "err", err.Error())
 		}
 
-		// Phase 4: Observe status. Telemetry is Postgres-only — no silent memory fallback.
-		var telemStore telemetry.Store
-		if cfg.TelemetryDatabaseURL != "" {
-			db, err := telemetry.OpenAndMigrate(ctx, cfg.TelemetryDatabaseURL)
-			if err != nil {
-				log.Error("telemetry store open failed; observe events/poll disabled", "err", err.Error())
-			} else {
-				defer db.Close()
-				telemStore = telemetry.NewPostgres(db)
-			}
-		} else {
-			log.Warn("SHOAL_TELEMETRY_DATABASE_URL unset; observe events/poll disabled")
-		}
 		obsSvc := observe.New(log, store, telemStore, watchSvc)
 		srvAPI.WithObserve(obsSvc)
 		log.Info("observe device status API enabled", "telemetry", telemStore != nil)

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -77,7 +77,7 @@ Commands:
   serve      Run the HTTP API server
   deploy     Provisioning: run | status | cancel | iso
   discover   Assets: ingest | confirm
-  observe    Status / poll / ocr (failure-screen graphics OCR)
+  observe    Status / poll / ocr / power (host On, ForceOff, ForceRestart)
 
   profile    Profiles: generate | save | show | list | approve
 
@@ -145,6 +145,13 @@ func cmdServe(args []string) int {
 	slog.SetDefault(log)
 
 	srvAPI := api.New(cfg, log)
+	secretBackend := openSecrets(cfg)
+	var nbClient *netbox.Client
+	if cfg.NetBoxURL != "" && cfg.NetBoxToken != "" {
+		nbClient = netbox.New(cfg.NetBoxURL, cfg.NetBoxToken)
+	}
+	srvAPI.WithDeviceCredentials(deviceCreds{secrets: secretBackend, nb: nbClient})
+	srvAPI.WithDevicePower(devicePower{cfg: cfg, newBMC: redfish.NewBMC})
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
@@ -186,7 +193,6 @@ func cmdServe(args []string) int {
 		}
 		srvAPI.WithJobStore(store)
 		// Wire Orchestrator so cancel works and orphans are reconciled on boot.
-		secretBackend := openSecrets(cfg)
 		watchSvc := sol.NewWatchService(log, nil)
 		watchSvc.NewTransport = sol.NewCombinedTransportFactory(
 			sol.RedfishSOLConfig{
@@ -204,8 +210,8 @@ func cmdServe(args []string) int {
 			},
 		)
 		var nb netbox.LifecycleWriter
-		if cfg.NetBoxURL != "" && cfg.NetBoxToken != "" {
-			nb = netbox.New(cfg.NetBoxURL, cfg.NetBoxToken)
+		if nbClient != nil {
+			nb = nbClient
 		}
 		var profStore profile.Store
 		if cfg.ProfileDir != "" {
@@ -269,6 +275,12 @@ func cmdServe(args []string) int {
 		// Background SEL/sensor poll only with durable telemetry.
 		if telemStore != nil {
 			poller := poll.New(log, telemStore, redfish.NewBMC)
+			if cfg.PollIdleInterval > 0 {
+				poller.IdleInterval = cfg.PollIdleInterval
+			}
+			if cfg.PollWatchInterval > 0 {
+				poller.WatchInterval = cfg.PollWatchInterval
+			}
 			poller.Watching = watchSvc
 			// Use real Core reconciler when AI is configured; else deterministic poll path.
 			if rec != nil {
@@ -288,9 +300,10 @@ func cmdServe(args []string) int {
 				}
 			}()
 			go poller.Run(ctx)
+			srvAPI.WithDevicePoll(devicePoll{p: poller, cfg: cfg})
 			log.Info("observe SEL/sensor poller started",
-				"idle", poll.DefaultIdleInterval.String(),
-				"watch", poll.DefaultWatchInterval.String(),
+				"idle", poller.IdleInterval.String(),
+				"watch", poller.WatchInterval.String(),
 			)
 		}
 	}

--- a/internal/cli/credentials.go
+++ b/internal/cli/credentials.go
@@ -1,0 +1,177 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/mattcburns/shoal/internal/api"
+	"github.com/mattcburns/shoal/internal/common/models"
+	"github.com/mattcburns/shoal/internal/common/netbox"
+	"github.com/mattcburns/shoal/internal/common/secrets"
+)
+
+type deviceNB interface {
+	GetDevice(ctx context.Context, key string) (models.DeviceIdentity, error)
+	SetCredentialRef(ctx context.Context, deviceKey, ref, bmcIP string) error
+}
+
+type deviceCreds struct {
+	secrets secrets.Backend
+	nb      deviceNB
+}
+
+func (d deviceCreds) Get(ctx context.Context, deviceID, credentialRef string) (api.DeviceCredentialsView, error) {
+	var id models.DeviceIdentity
+	if ref := strings.TrimSpace(credentialRef); ref != "" {
+		id.ID = deviceID
+		id.CredentialRef = ref
+	} else {
+		got, err := d.lookup(ctx, deviceID)
+		if err != nil {
+			if !isNotFound(err) {
+				return api.DeviceCredentialsView{}, err
+			}
+		} else {
+			id = got
+		}
+	}
+	ref := credRefFor(id, deviceID)
+	id.CredentialRef = ref
+	var cred secrets.Credential
+	if d.secrets != nil && ref != "" {
+		got, err := d.secrets.Get(ctx, ref)
+		if err != nil && !errors.Is(err, secrets.ErrNotFound) {
+			return api.DeviceCredentialsView{}, err
+		}
+		if err == nil {
+			cred = got
+		}
+	}
+	return viewFrom(deviceID, id, cred), nil
+}
+
+func (d deviceCreds) Put(ctx context.Context, deviceID string, req api.DeviceCredentialsPut) (api.DeviceCredentialsView, error) {
+	if d.secrets == nil {
+		return api.DeviceCredentialsView{}, fmt.Errorf("secrets backend not configured (set SHOAL_SECRETS_DIR)")
+	}
+	id, err := d.lookup(ctx, deviceID)
+	if err != nil {
+		if isNotFound(err) {
+			return api.DeviceCredentialsView{}, fmt.Errorf("device %q not found", deviceID)
+		}
+		return api.DeviceCredentialsView{}, err
+	}
+	if d.nb != nil && strings.TrimSpace(id.Serial) == "" && strings.TrimSpace(id.ID) == "" {
+		return api.DeviceCredentialsView{}, fmt.Errorf("device %q not found", deviceID)
+	}
+	existing, _ := d.secrets.Get(ctx, credRefFor(id, deviceID))
+	user := strings.TrimSpace(req.Username)
+	if user == "" {
+		user = existing.Username
+	}
+	if user == "" {
+		return api.DeviceCredentialsView{}, fmt.Errorf("username is required")
+	}
+	pass := req.Password
+	if pass == "" {
+		pass = existing.Password
+	}
+	if pass == "" {
+		return api.DeviceCredentialsView{}, fmt.Errorf("password is required for new credentials")
+	}
+	ref := credRefFor(id, deviceID)
+	if err := d.secrets.Put(ctx, ref, secrets.Credential{Username: user, Password: pass}); err != nil {
+		return api.DeviceCredentialsView{}, err
+	}
+	id.CredentialRef = ref
+	if ip := strings.TrimSpace(req.BMCIP); ip != "" {
+		id.BMCIP = ip
+	}
+	if d.nb != nil {
+		if err := d.nb.SetCredentialRef(ctx, deviceID, ref, strings.TrimSpace(req.BMCIP)); err != nil {
+			return api.DeviceCredentialsView{}, fmt.Errorf("netbox: %w", err)
+		}
+	}
+	cred, err := d.secrets.Get(ctx, ref)
+	if err != nil {
+		return api.DeviceCredentialsView{}, err
+	}
+	return viewFrom(deviceID, id, cred), nil
+}
+
+func (d deviceCreds) Resolve(ctx context.Context, deviceID string) (username, password string, err error) {
+	view, err := d.Get(ctx, deviceID, "")
+	if err != nil {
+		return "", "", err
+	}
+	if d.secrets == nil || view.CredentialRef == "" {
+		return "", "", secrets.ErrNotFound
+	}
+	cred, err := d.secrets.Get(ctx, view.CredentialRef)
+	if err != nil {
+		return "", "", err
+	}
+	if cred.Username == "" && cred.Password == "" {
+		return "", "", secrets.ErrNotFound
+	}
+	return cred.Username, cred.Password, nil
+}
+
+func (d deviceCreds) lookup(ctx context.Context, deviceID string) (models.DeviceIdentity, error) {
+	if d.nb == nil {
+		return models.DeviceIdentity{}, nil
+	}
+	return d.nb.GetDevice(ctx, deviceID)
+}
+
+func isNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "not found") || strings.Contains(msg, "status 404")
+}
+
+func credRefFor(id models.DeviceIdentity, deviceID string) string {
+	if r := strings.TrimSpace(id.CredentialRef); r != "" {
+		return r
+	}
+	serial := strings.TrimSpace(id.Serial)
+	if serial == "" {
+		serial = strings.TrimSpace(deviceID)
+	}
+	return "bmc-" + sanitizeCredRef(serial)
+}
+
+func viewFrom(deviceID string, id models.DeviceIdentity, cred secrets.Credential) api.DeviceCredentialsView {
+	did := strings.TrimSpace(id.ID)
+	if did == "" {
+		did = deviceID
+	}
+	return api.DeviceCredentialsView{
+		DeviceID:      did,
+		CredentialRef: id.CredentialRef,
+		Username:      cred.Username,
+		HasPassword:   cred.Password != "",
+		BMCIP:         id.BMCIP,
+	}
+}
+
+func sanitizeCredRef(s string) string {
+	s = strings.Map(func(r rune) rune {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '-' || r == '_' {
+			return r
+		}
+		return '-'
+	}, s)
+	if s == "" {
+		return "x"
+	}
+	return s
+}
+
+var _ api.DeviceCredentials = deviceCreds{}
+var _ deviceNB = (*netbox.Client)(nil)
+var _ deviceNB = (*netbox.Memory)(nil)

--- a/internal/cli/credentials_test.go
+++ b/internal/cli/credentials_test.go
@@ -1,0 +1,137 @@
+package cli
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/mattcburns/shoal/internal/api"
+	"github.com/mattcburns/shoal/internal/common/models"
+	"github.com/mattcburns/shoal/internal/common/netbox"
+	"github.com/mattcburns/shoal/internal/common/secrets"
+)
+
+func TestDeviceCredsPutGetNoPasswordLeak(t *testing.T) {
+	nb := netbox.NewMemory()
+	_, err := nb.UpsertDevice(context.Background(), models.DeviceIdentity{
+		Name: "C784MH3", Serial: "C784MH3", BMCIP: "172.16.21.202",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	d := deviceCreds{secrets: secrets.NewMemory(), nb: nb}
+	view, err := d.Put(context.Background(), "C784MH3", api.DeviceCredentialsPut{
+		Username: "root", Password: "s3cret",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if view.Username != "root" || !view.HasPassword || view.CredentialRef != "bmc-C784MH3" {
+		t.Fatalf("%+v", view)
+	}
+	got, err := d.Get(context.Background(), "C784MH3", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Username != "root" || !got.HasPassword {
+		t.Fatalf("%+v", got)
+	}
+	u, p, err := d.Resolve(context.Background(), "C784MH3")
+	if err != nil || u != "root" || p != "s3cret" {
+		t.Fatalf("resolve %q %q %v", u, p, err)
+	}
+	dev, _ := nb.GetDevice(context.Background(), "C784MH3")
+	if dev.CredentialRef != "bmc-C784MH3" {
+		t.Fatalf("netbox ref %q", dev.CredentialRef)
+	}
+}
+
+func TestDeviceCredsKeepPasswordOnUsernameUpdate(t *testing.T) {
+	d := deviceCreds{secrets: secrets.NewMemory()}
+	if _, err := d.Put(context.Background(), "6", api.DeviceCredentialsPut{Username: "root", Password: "pw"}); err != nil {
+		t.Fatal(err)
+	}
+	got, err := d.Put(context.Background(), "6", api.DeviceCredentialsPut{Username: "admin"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Username != "admin" || !got.HasPassword {
+		t.Fatalf("%+v", got)
+	}
+	_, p, err := d.Resolve(context.Background(), "6")
+	if err != nil || p != "pw" {
+		t.Fatalf("password not kept: %q %v", p, err)
+	}
+}
+
+func TestDeviceCredsPutByNetBoxIDDoesNotWipeClassification(t *testing.T) {
+	nb := netbox.NewMemory()
+	id, err := nb.UpsertDevice(context.Background(), models.DeviceIdentity{
+		Name: "C784MH3", Serial: "C784MH3", BMCIP: "172.16.21.202",
+		Vendor: "Dell Inc.", Model: "PowerEdge R750",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	d := deviceCreds{secrets: secrets.NewMemory(), nb: nb}
+	view, err := d.Put(context.Background(), id, api.DeviceCredentialsPut{Username: "root", Password: "s3cret"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if view.CredentialRef != "bmc-C784MH3" || view.Username != "root" {
+		t.Fatalf("%+v", view)
+	}
+	dev, err := nb.GetDevice(context.Background(), id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dev.Vendor != "Dell Inc." || dev.Model != "PowerEdge R750" {
+		t.Fatalf("classification wiped: %+v", dev)
+	}
+	if dev.CredentialRef != "bmc-C784MH3" || dev.BMCIP != "172.16.21.202" {
+		t.Fatalf("cf %+v", dev)
+	}
+}
+
+func TestDeviceCredsGetWithHintSkipsNetBox(t *testing.T) {
+	nb := netbox.NewMemory()
+	sec := secrets.NewMemory()
+	d := deviceCreds{secrets: sec, nb: nb}
+	if err := sec.Put(context.Background(), "bmc-C784MH3", secrets.Credential{Username: "root", Password: "pw"}); err != nil {
+		t.Fatal(err)
+	}
+	got, err := d.Get(context.Background(), "6", "bmc-C784MH3")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Username != "root" || !got.HasPassword || got.CredentialRef != "bmc-C784MH3" {
+		t.Fatalf("%+v", got)
+	}
+}
+
+func TestDeviceCredsGetEmptyWhenUnknown(t *testing.T) {
+	d := deviceCreds{secrets: secrets.NewMemory(), nb: netbox.NewMemory()}
+	got, err := d.Get(context.Background(), "6", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.HasPassword || got.Username != "" {
+		t.Fatalf("%+v", got)
+	}
+}
+
+func TestDeviceCredsPutUnknownDevice(t *testing.T) {
+	d := deviceCreds{secrets: secrets.NewMemory(), nb: netbox.NewMemory()}
+	_, err := d.Put(context.Background(), "6", api.DeviceCredentialsPut{Username: "root", Password: "x"})
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("err %v", err)
+	}
+}
+
+func TestDeviceCredsPutRequiresPasswordForNew(t *testing.T) {
+	d := deviceCreds{secrets: secrets.NewMemory()}
+	_, err := d.Put(context.Background(), "6", api.DeviceCredentialsPut{Username: "root"})
+	if err == nil || !strings.Contains(err.Error(), "password is required") {
+		t.Fatalf("err %v", err)
+	}
+}

--- a/internal/cli/deploy.go
+++ b/internal/cli/deploy.go
@@ -187,6 +187,16 @@ func cmdDeployRun(args []string) int {
 	if cfg.ISOPublishDir != "" && cfg.ISOBaseURL != "" {
 		isoBuilder = iso.NewScriptBuilder(cfg.ISOBuildScript, log)
 	}
+	// Optional job_log writer for NetBox Jobs tab (same DSN as JobStore).
+	var telemStore telemetry.Store
+	if cfg.TelemetryDatabaseURL != "" {
+		if db, err := telemetry.OpenAndMigrate(context.Background(), cfg.TelemetryDatabaseURL); err != nil {
+			log.Warn("telemetry for job_log unavailable", "err", err.Error())
+		} else {
+			defer db.Close()
+			telemStore = telemetry.NewPostgres(db)
+		}
+	}
 	orch := job.NewOrchestrator(job.Options{
 		Log:                    log,
 		Store:                  store,
@@ -194,6 +204,7 @@ func cmdDeployRun(args []string) int {
 		NewBMC:                 redfish.NewBMC,
 		Watches:                watchSvc,
 		NetBox:                 nb,
+		Telemetry:              telemStore,
 		Profiles:               profStore,
 		ISOBaseURL:             cfg.ISOBaseURL,
 		ISOBuilder:             isoBuilder,

--- a/internal/cli/observe.go
+++ b/internal/cli/observe.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/mattcburns/shoal/internal/api"
 	"github.com/mattcburns/shoal/internal/common/config"
 	"github.com/mattcburns/shoal/internal/common/models"
 	"github.com/mattcburns/shoal/internal/common/redfish"
@@ -21,7 +22,7 @@ import (
 
 func cmdObserve(args []string) int {
 	if len(args) < 1 {
-		fmt.Fprintln(os.Stderr, "usage: shoal observe <status|poll|ocr> [flags]")
+		fmt.Fprintln(os.Stderr, "usage: shoal observe <status|poll|ocr|power> [flags]")
 		return 2
 	}
 	switch args[0] {
@@ -31,6 +32,8 @@ func cmdObserve(args []string) int {
 		return cmdObservePoll(args[1:])
 	case "ocr":
 		return cmdObserveOCR(args[1:])
+	case "power":
+		return cmdObservePower(args[1:])
 	default:
 		fmt.Fprintf(os.Stderr, "unknown observe subcommand %q\n", args[0])
 		return 2
@@ -175,7 +178,7 @@ func cmdObservePoll(args []string) int {
 
 	// Deterministic normalize only (no ai.Fake). Core reconciler optional later.
 	p := poll.New(log, telem, redfish.NewBMC)
-	selN, sensN, err := p.PollOnce(ctx, poll.Target{
+	res, err := p.PollOnce(ctx, poll.Target{
 		DeviceID: *deviceID,
 		SystemID: *systemID,
 		BMC: redfish.Config{
@@ -188,9 +191,11 @@ func cmdObservePoll(args []string) int {
 		},
 	})
 	out := map[string]any{
-		"device_id":       *deviceID,
-		"sel_new":         selN,
-		"sensors_written": sensN,
+		"device_id":        *deviceID,
+		"sel_new":          res.SELNew,
+		"sensors_written":  res.SensorsWritten,
+		"firmware_written": res.FirmwareWritten,
+		"power_state":      res.PowerState,
 	}
 	if err != nil {
 		out["error"] = err.Error()
@@ -323,6 +328,46 @@ func cmdObserveOCR(args []string) int {
 		// Capture debug already in JSON when redfish path used.
 		return 1
 	}
+	return 0
+}
+
+func cmdObservePower(args []string) int {
+	cfg, err := config.Load()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "config: %v\n", err)
+		return 1
+	}
+	fs := flag.NewFlagSet("observe power", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	deviceID := fs.String("device-id", "", "device id (required)")
+	bmcURL := fs.String("bmc-url", "", "Redfish base URL (required)")
+	bmcUser := fs.String("bmc-user", cfg.BMCUsername, "BMC username")
+	bmcPass := fs.String("bmc-pass", cfg.BMCPassword, "BMC password (never logged)")
+	systemID := fs.String("system-id", "", "optional Redfish system id")
+	resetType := fs.String("reset-type", "", "On | ForceOff | ForceRestart | GracefulRestart | GracefulShutdown")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if *deviceID == "" || *bmcURL == "" || *resetType == "" {
+		fmt.Fprintln(os.Stderr, "observe power: -device-id, -bmc-url, and -reset-type required")
+		return 2
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	out, err := (devicePower{cfg: cfg}).Power(ctx, *deviceID, api.DevicePowerRequest{
+		ResetType:   *resetType,
+		BMCEndpoint: *bmcURL,
+		BMCUsername: *bmcUser,
+		BMCPassword: *bmcPass,
+		SystemID:    *systemID,
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "power: %v\n", err)
+		return 1
+	}
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	_ = enc.Encode(out)
 	return 0
 }
 

--- a/internal/cli/observe.go
+++ b/internal/cli/observe.go
@@ -160,7 +160,7 @@ func cmdObservePoll(args []string) int {
 	}
 
 	log := newLogger(cfg.LogLevel)
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
 
 	// Durable store required — no silent memory fallback.

--- a/internal/cli/poll.go
+++ b/internal/cli/poll.go
@@ -1,0 +1,50 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/mattcburns/shoal/internal/api"
+	"github.com/mattcburns/shoal/internal/common/config"
+	"github.com/mattcburns/shoal/internal/common/redfish"
+	"github.com/mattcburns/shoal/internal/observe/poll"
+)
+
+type devicePoll struct {
+	p   *poll.Poller
+	cfg config.Config
+}
+
+func (d devicePoll) Poll(ctx context.Context, deviceID string, req api.DevicePollRequest) (api.DevicePollResult, error) {
+	if d.p == nil {
+		return api.DevicePollResult{}, fmt.Errorf("poller not configured")
+	}
+	t := poll.Target{
+		DeviceID: deviceID,
+		SystemID: req.SystemID,
+		BMC: redfish.Config{
+			BaseURL:  req.BMCEndpoint,
+			Username: req.BMCUsername,
+			Password: req.BMCPassword,
+			AuthMode: d.cfg.RedfishAuthMode,
+			TLSMode:  d.cfg.RedfishTLSMode,
+			CAFile:   d.cfg.RedfishCAFile,
+		},
+	}
+	// Keep this device on the background interval after an on-demand poll.
+	_ = d.p.SetTarget(t)
+	res, err := d.p.PollOnce(ctx, t)
+	out := api.DevicePollResult{
+		DeviceID:        deviceID,
+		SELNew:          res.SELNew,
+		SensorsWritten:  res.SensorsWritten,
+		FirmwareWritten: res.FirmwareWritten,
+		PowerState:      res.PowerState,
+	}
+	if err != nil {
+		return out, err
+	}
+	return out, nil
+}
+
+var _ api.DevicePoll = devicePoll{}

--- a/internal/cli/poll_test.go
+++ b/internal/cli/poll_test.go
@@ -1,0 +1,32 @@
+package cli
+
+import (
+	"context"
+	"testing"
+
+	"github.com/mattcburns/shoal/internal/api"
+	"github.com/mattcburns/shoal/internal/common/config"
+	"github.com/mattcburns/shoal/internal/common/redfish"
+	"github.com/mattcburns/shoal/internal/common/telemetry"
+	"github.com/mattcburns/shoal/internal/observe/poll"
+)
+
+func TestDevicePollSetsTargetAndWritesSensors(t *testing.T) {
+	store := telemetry.NewMemory()
+	fake := redfish.NewFake()
+	fake.Sensors = []redfish.SensorSample{
+		{Name: "Inlet", Reading: 21, Units: "Cel", Kind: "temperature", HasReading: true},
+	}
+	p := poll.New(nil, store, func(redfish.Config) (redfish.BMC, error) { return fake, nil })
+	d := devicePoll{p: p, cfg: config.Config{}}
+	out, err := d.Poll(context.Background(), "6", api.DevicePollRequest{BMCEndpoint: "https://bmc"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.SensorsWritten != 1 {
+		t.Fatalf("%+v", out)
+	}
+	if len(p.Targets()) != 1 || p.Targets()[0].DeviceID != "6" {
+		t.Fatalf("targets %+v", p.Targets())
+	}
+}

--- a/internal/cli/power.go
+++ b/internal/cli/power.go
@@ -1,0 +1,60 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/mattcburns/shoal/internal/api"
+	"github.com/mattcburns/shoal/internal/common/config"
+	"github.com/mattcburns/shoal/internal/common/redfish"
+)
+
+type devicePower struct {
+	cfg    config.Config
+	newBMC redfish.Factory
+}
+
+func (d devicePower) Power(ctx context.Context, deviceID string, req api.DevicePowerRequest) (api.DevicePowerResult, error) {
+	newBMC := d.newBMC
+	if newBMC == nil {
+		newBMC = redfish.NewBMC
+	}
+	bmc, err := newBMC(redfish.Config{
+		BaseURL:  req.BMCEndpoint,
+		Username: req.BMCUsername,
+		Password: req.BMCPassword,
+		AuthMode: d.cfg.RedfishAuthMode,
+		TLSMode:  d.cfg.RedfishTLSMode,
+		CAFile:   d.cfg.RedfishCAFile,
+	})
+	if err != nil {
+		return api.DevicePowerResult{}, fmt.Errorf("bmc: %w", err)
+	}
+	if err := bmc.Open(ctx); err != nil {
+		return api.DevicePowerResult{}, fmt.Errorf("bmc open: %w", err)
+	}
+	defer func() { _ = bmc.Close(context.Background()) }()
+
+	if err := bmc.Reset(ctx, req.SystemID, req.ResetType); err != nil {
+		return api.DevicePowerResult{}, err
+	}
+	info, err := bmc.GetSystem(ctx, req.SystemID)
+	if err != nil {
+		return api.DevicePowerResult{
+			DeviceID:  deviceID,
+			ResetType: req.ResetType,
+			SystemID:  req.SystemID,
+		}, nil
+	}
+	sysID := info.ID
+	if strings.TrimSpace(sysID) == "" {
+		sysID = req.SystemID
+	}
+	return api.DevicePowerResult{
+		DeviceID:   deviceID,
+		ResetType:  req.ResetType,
+		PowerState: info.PowerState,
+		SystemID:   sysID,
+	}, nil
+}

--- a/internal/common/config/config.go
+++ b/internal/common/config/config.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 )
 
 // Config is the app configuration contract (env-backed).
@@ -49,6 +50,10 @@ type Config struct {
 	ProfileDir string
 	// APIToken protects /v1/* when non-empty (Bearer). Empty = open (lab MVP default).
 	APIToken string
+	// PollIdleInterval is the background SEL/sensor poll period when no SOL watch is active.
+	PollIdleInterval time.Duration
+	// PollWatchInterval is the elevated poll period while a SOL watch is active.
+	PollWatchInterval time.Duration
 }
 
 // Load reads SHOAL_* environment variables with Phase 1-friendly defaults.
@@ -85,6 +90,16 @@ func Load() (Config, error) {
 		ProfileDir:           os.Getenv("SHOAL_PROFILE_DIR"),
 		APIToken:             os.Getenv("SHOAL_API_TOKEN"),
 	}
+	idle, err := envDuration("SHOAL_POLL_IDLE_INTERVAL", 5*time.Minute)
+	if err != nil {
+		return Config{}, err
+	}
+	c.PollIdleInterval = idle
+	watch, err := envDuration("SHOAL_POLL_WATCH_INTERVAL", 30*time.Second)
+	if err != nil {
+		return Config{}, err
+	}
+	c.PollWatchInterval = watch
 
 	if v := os.Getenv("SHOAL_RECONCILE_FAIL_ORPHANS"); v != "" {
 		b, err := strconv.ParseBool(v)
@@ -159,4 +174,19 @@ func envOr(key, def string) string {
 		return v
 	}
 	return def
+}
+
+func envDuration(key string, def time.Duration) (time.Duration, error) {
+	v := strings.TrimSpace(os.Getenv(key))
+	if v == "" {
+		return def, nil
+	}
+	d, err := time.ParseDuration(v)
+	if err != nil {
+		return 0, fmt.Errorf("config: %s: %w", key, err)
+	}
+	if d <= 0 {
+		return 0, fmt.Errorf("config: %s must be > 0", key)
+	}
+	return d, nil
 }

--- a/internal/common/config/config_test.go
+++ b/internal/common/config/config_test.go
@@ -2,6 +2,7 @@ package config_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/mattcburns/shoal/internal/common/config"
 )
@@ -21,6 +22,7 @@ func TestLoadDefaults(t *testing.T) {
 		"SHOAL_REDFISH_AUTH_MODE", "SHOAL_REDFISH_TLS_MODE", "SHOAL_REDFISH_CA_FILE",
 		"SHOAL_BMC_USERNAME", "SHOAL_BMC_PASSWORD", "SHOAL_ISO_BASE_URL",
 		"SHOAL_RECONCILE_FAIL_ORPHANS", "SHOAL_SECRETS_DIR",
+		"SHOAL_POLL_IDLE_INTERVAL", "SHOAL_POLL_WATCH_INTERVAL",
 	} {
 		t.Setenv(k, "")
 	}
@@ -41,6 +43,12 @@ func TestLoadDefaults(t *testing.T) {
 	if !c.ReconcileFailOrphans {
 		t.Fatal("ReconcileFailOrphans default true")
 	}
+	if c.PollIdleInterval != 5*time.Minute {
+		t.Fatalf("PollIdleInterval=%s", c.PollIdleInterval)
+	}
+	if c.PollWatchInterval != 30*time.Second {
+		t.Fatalf("PollWatchInterval=%s", c.PollWatchInterval)
+	}
 }
 
 func TestLoadCustom(t *testing.T) {
@@ -52,6 +60,8 @@ func TestLoadCustom(t *testing.T) {
 	t.Setenv("SHOAL_SERIAL_SSH_HOST", "192.168.122.100")
 	t.Setenv("SHOAL_SERIAL_SSH_USER", "lab")
 	t.Setenv("SHOAL_SERIAL_SSH_KEY", "/tmp/key")
+	t.Setenv("SHOAL_POLL_IDLE_INTERVAL", "2m")
+	t.Setenv("SHOAL_POLL_WATCH_INTERVAL", "10s")
 	c, err := config.Load()
 	if err != nil {
 		t.Fatal(err)
@@ -70,6 +80,20 @@ func TestLoadCustom(t *testing.T) {
 	}
 	if c.SerialSSHHost != "192.168.122.100" || c.SerialSSHKey != "/tmp/key" {
 		t.Fatalf("serial ssh: host=%q key=%q", c.SerialSSHHost, c.SerialSSHKey)
+	}
+	if c.PollIdleInterval != 2*time.Minute || c.PollWatchInterval != 10*time.Second {
+		t.Fatalf("poll intervals idle=%s watch=%s", c.PollIdleInterval, c.PollWatchInterval)
+	}
+}
+
+func TestLoadInvalidPollInterval(t *testing.T) {
+	t.Setenv("SHOAL_POLL_IDLE_INTERVAL", "nope")
+	if _, err := config.Load(); err == nil {
+		t.Fatal("expected error")
+	}
+	t.Setenv("SHOAL_POLL_IDLE_INTERVAL", "0s")
+	if _, err := config.Load(); err == nil {
+		t.Fatal("expected error for zero")
 	}
 }
 

--- a/internal/common/models/models.go
+++ b/internal/common/models/models.go
@@ -257,6 +257,8 @@ type DeviceIdentity struct {
 	ID             string         `json:"id,omitempty"`
 	Name           string         `json:"name,omitempty"`
 	Serial         string         `json:"serial"`
+	Vendor         string         `json:"vendor,omitempty"`
+	Model          string         `json:"model,omitempty"`
 	LifecycleState LifecycleState `json:"lifecycle_state"`
 	CredentialRef  string         `json:"credential_ref"`
 	BMCIP          string         `json:"bmc_ip"`

--- a/internal/common/netbox/client.go
+++ b/internal/common/netbox/client.go
@@ -136,6 +136,67 @@ func (c *Client) ResolveDeviceID(ctx context.Context, key string) (string, error
 	return key, nil
 }
 
+func looksLikeNetBoxID(key string) bool {
+	if key == "" {
+		return false
+	}
+	for i := 0; i < len(key); i++ {
+		if key[i] < '0' || key[i] > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// GetDevice loads identity by serial, name, or NetBox id. Password is never included.
+func (c *Client) GetDevice(ctx context.Context, key string) (models.DeviceIdentity, error) {
+	if c.BaseURL == "" || c.Token == "" {
+		return models.DeviceIdentity{}, fmt.Errorf("netbox: missing url or token")
+	}
+	key = strings.TrimSpace(key)
+	id := key
+	if !looksLikeNetBoxID(key) {
+		resolved, err := c.ResolveDeviceID(ctx, key)
+		if err != nil {
+			return models.DeviceIdentity{}, err
+		}
+		id = resolved
+	}
+	var raw struct {
+		ID     int    `json:"id"`
+		Name   string `json:"name"`
+		Serial string `json:"serial"`
+		CF     struct {
+			LifecycleState string `json:"lifecycle_state"`
+			CredentialRef  string `json:"credential_ref"`
+			BMCIP          string `json:"bmc_ip"`
+		} `json:"custom_fields"`
+		DeviceType struct {
+			Model        string `json:"model"`
+			Manufacturer struct {
+				Name string `json:"name"`
+			} `json:"manufacturer"`
+		} `json:"device_type"`
+	}
+	if err := c.doJSON(ctx, http.MethodGet, "/api/dcim/devices/"+id+"/", nil, &raw); err != nil {
+		return models.DeviceIdentity{}, err
+	}
+	out := models.DeviceIdentity{
+		ID:             fmt.Sprintf("%d", raw.ID),
+		Name:           raw.Name,
+		Serial:         raw.Serial,
+		Vendor:         raw.DeviceType.Manufacturer.Name,
+		Model:          raw.DeviceType.Model,
+		LifecycleState: models.LifecycleState(raw.CF.LifecycleState),
+		CredentialRef:  raw.CF.CredentialRef,
+		BMCIP:          raw.CF.BMCIP,
+	}
+	if out.ID == "0" && id != "" {
+		out.ID = id
+	}
+	return out, nil
+}
+
 func (c *Client) createDevice(ctx context.Context, id models.DeviceIdentity) (string, error) {
 	siteID, err := c.lookupID(ctx, "/api/dcim/sites/", "slug", c.SiteSlug)
 	if err != nil {
@@ -242,6 +303,32 @@ func (c *Client) SetLifecycle(ctx context.Context, deviceKey string, state model
 		return c.doJSON(ctx, http.MethodPatch, "/api/dcim/devices/"+netboxID+"/", fb, nil)
 	}
 	return nil
+}
+
+// SetCredentialRef writes credential_ref (and optional bmc_ip) custom fields only.
+// It never creates a device and never changes role, type, or lifecycle_state.
+func (c *Client) SetCredentialRef(ctx context.Context, deviceKey, ref, bmcIP string) error {
+	if c.BaseURL == "" || c.Token == "" {
+		return fmt.Errorf("netbox: missing url or token")
+	}
+	ref = strings.TrimSpace(ref)
+	if ref == "" {
+		return fmt.Errorf("netbox: credential_ref required")
+	}
+	id, err := c.GetDevice(ctx, deviceKey)
+	if err != nil {
+		return err
+	}
+	netboxID := strings.TrimSpace(id.ID)
+	if netboxID == "" || netboxID == "0" {
+		return fmt.Errorf("netbox: device %q not found", deviceKey)
+	}
+	cf := map[string]any{"credential_ref": ref}
+	if ip := strings.TrimSpace(bmcIP); ip != "" {
+		cf["bmc_ip"] = ip
+	}
+	body := map[string]any{"custom_fields": cf}
+	return c.doJSON(ctx, http.MethodPatch, "/api/dcim/devices/"+netboxID+"/", body, nil)
 }
 
 func (c *Client) lookupID(ctx context.Context, path, filterKey, filterVal string) (int, error) {
@@ -514,6 +601,49 @@ func (m *Memory) SetLifecycle(_ context.Context, deviceKey string, state models.
 		return nil
 	}
 	return fmt.Errorf("netbox/memory: device %q not found", deviceKey)
+}
+
+// GetDevice implements lookup for credentials/power.
+func (m *Memory) GetDevice(_ context.Context, key string) (models.DeviceIdentity, error) {
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return models.DeviceIdentity{}, fmt.Errorf("netbox/memory: device key required")
+	}
+	if id, ok := m.ByID[key]; ok {
+		return id, nil
+	}
+	if id, ok := m.BySerial[key]; ok {
+		return id, nil
+	}
+	for _, id := range m.ByID {
+		if id.Name == key {
+			return id, nil
+		}
+	}
+	return models.DeviceIdentity{}, fmt.Errorf("netbox/memory: device %q not found", key)
+}
+
+// SetCredentialRef implements credential_ref (+ optional bmc_ip) update for tests.
+func (m *Memory) SetCredentialRef(ctx context.Context, deviceKey, ref, bmcIP string) error {
+	ref = strings.TrimSpace(ref)
+	if ref == "" {
+		return fmt.Errorf("netbox/memory: credential_ref required")
+	}
+	id, err := m.GetDevice(ctx, deviceKey)
+	if err != nil {
+		return err
+	}
+	id.CredentialRef = ref
+	if ip := strings.TrimSpace(bmcIP); ip != "" {
+		id.BMCIP = ip
+	}
+	if id.Serial != "" {
+		m.BySerial[id.Serial] = id
+	}
+	if id.ID != "" {
+		m.ByID[id.ID] = id
+	}
+	return nil
 }
 
 // ResolveDeviceID implements DeviceResolver for tests/lab fakes.

--- a/internal/common/netbox/client.go
+++ b/internal/common/netbox/client.go
@@ -141,15 +141,7 @@ func (c *Client) createDevice(ctx context.Context, id models.DeviceIdentity) (st
 	if err != nil {
 		return "", fmt.Errorf("netbox: site: %w", err)
 	}
-	roleID, err := c.lookupID(ctx, "/api/dcim/device-roles/", "slug", c.DeviceRoleSlug)
-	if err != nil {
-		return "", fmt.Errorf("netbox: role: %w", err)
-	}
-	mfgID, err := c.ensureManufacturer(ctx)
-	if err != nil {
-		return "", err
-	}
-	typeID, err := c.ensureDeviceType(ctx, mfgID, id)
+	roleID, _, typeID, err := c.ensureClassification(ctx, id)
 	if err != nil {
 		return "", err
 	}
@@ -200,6 +192,10 @@ func (c *Client) patchDevice(ctx context.Context, netboxID string, id models.Dev
 	}
 	if id.Name != "" {
 		body["name"] = id.Name
+	}
+	if roleID, _, typeID, err := c.ensureClassification(ctx, id); err == nil {
+		body["role"] = roleID
+		body["device_type"] = typeID
 	}
 	err := c.doJSON(ctx, http.MethodPatch, "/api/dcim/devices/"+netboxID+"/", body, nil)
 	if err != nil {
@@ -264,25 +260,25 @@ func (c *Client) lookupID(ctx context.Context, path, filterKey, filterVal string
 	return out.Results[0].ID, nil
 }
 
-func (c *Client) ensureManufacturer(ctx context.Context) (int, error) {
-	id, err := c.lookupID(ctx, "/api/dcim/manufacturers/", "name", c.ManufacturerName)
-	if err == nil {
-		return id, nil
+const physicalServerRoleSlug = "server"
+
+func labVirtualIdentity(id models.DeviceIdentity) bool {
+	v := strings.TrimSpace(id.Vendor)
+	m := strings.TrimSpace(id.Model)
+	if v == "" && m == "" {
+		return true
 	}
-	var created struct {
-		ID int `json:"id"`
+	if strings.EqualFold(v, "Shoal Virtual") {
+		return true
 	}
-	slug := strings.ToLower(strings.ReplaceAll(c.ManufacturerName, " ", "-"))
-	body := map[string]any{"name": c.ManufacturerName, "slug": slug}
-	if err := c.doJSON(ctx, http.MethodPost, "/api/dcim/manufacturers/", body, &created); err != nil {
-		// race: re-get
-		return c.lookupID(ctx, "/api/dcim/manufacturers/", "name", c.ManufacturerName)
-	}
-	return created.ID, nil
+	ml := strings.ToLower(m)
+	return strings.Contains(ml, "sushy") || strings.HasPrefix(ml, "shoal-")
 }
 
-func (c *Client) ensureDeviceType(ctx context.Context, mfgID int, id models.DeviceIdentity) (int, error) {
-	// DeviceIdentity is identity-only; use a stable lab device-type model name.
+func (c *Client) ensureClassification(ctx context.Context, id models.DeviceIdentity) (roleID, mfgID, typeID int, err error) {
+	roleSlug := c.DeviceRoleSlug
+	roleName := "Virtual BMC Node"
+	mfgName := c.ManufacturerName
 	model := "shoal-node"
 	if id.Name != "" {
 		model = "shoal-" + id.Name
@@ -290,7 +286,76 @@ func (c *Client) ensureDeviceType(ctx context.Context, mfgID int, id models.Devi
 			model = model[:40]
 		}
 	}
-	// search by model
+	if !labVirtualIdentity(id) {
+		roleSlug = physicalServerRoleSlug
+		roleName = "Server"
+		if v := strings.TrimSpace(id.Vendor); v != "" {
+			mfgName = v
+		}
+		if m := strings.TrimSpace(id.Model); m != "" {
+			model = m
+			if len(model) > 64 {
+				model = model[:64]
+			}
+		}
+	}
+	roleID, err = c.ensureDeviceRole(ctx, roleSlug, roleName)
+	if err != nil {
+		return 0, 0, 0, fmt.Errorf("netbox: role: %w", err)
+	}
+	mfgID, err = c.ensureManufacturer(ctx, mfgName)
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	typeID, err = c.ensureDeviceType(ctx, mfgID, model)
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	return roleID, mfgID, typeID, nil
+}
+
+func (c *Client) ensureDeviceRole(ctx context.Context, slug, name string) (int, error) {
+	id, err := c.lookupID(ctx, "/api/dcim/device-roles/", "slug", slug)
+	if err == nil {
+		return id, nil
+	}
+	var created struct {
+		ID int `json:"id"`
+	}
+	body := map[string]any{
+		"name":    name,
+		"slug":    slug,
+		"color":   "2196f3",
+		"vm_role": false,
+	}
+	if err := c.doJSON(ctx, http.MethodPost, "/api/dcim/device-roles/", body, &created); err != nil {
+		return c.lookupID(ctx, "/api/dcim/device-roles/", "slug", slug)
+	}
+	return created.ID, nil
+}
+
+func (c *Client) ensureManufacturer(ctx context.Context, name string) (int, error) {
+	if strings.TrimSpace(name) == "" {
+		name = c.ManufacturerName
+	}
+	id, err := c.lookupID(ctx, "/api/dcim/manufacturers/", "name", name)
+	if err == nil {
+		return id, nil
+	}
+	var created struct {
+		ID int `json:"id"`
+	}
+	body := map[string]any{"name": name, "slug": netboxSlug(name)}
+	if err := c.doJSON(ctx, http.MethodPost, "/api/dcim/manufacturers/", body, &created); err != nil {
+		return c.lookupID(ctx, "/api/dcim/manufacturers/", "name", name)
+	}
+	return created.ID, nil
+}
+
+func (c *Client) ensureDeviceType(ctx context.Context, mfgID int, model string) (int, error) {
+	if strings.TrimSpace(model) == "" {
+		model = "shoal-node"
+	}
 	q := url.Values{"model": {model}}
 	var out struct {
 		Results []struct {
@@ -300,23 +365,47 @@ func (c *Client) ensureDeviceType(ctx context.Context, mfgID int, id models.Devi
 	if err := c.doJSON(ctx, http.MethodGet, "/api/dcim/device-types/?"+q.Encode(), nil, &out); err == nil && len(out.Results) > 0 {
 		return out.Results[0].ID, nil
 	}
-	slug := strings.ToLower(strings.ReplaceAll(model, " ", "-"))
 	body := map[string]any{
 		"manufacturer": mfgID,
 		"model":        model,
-		"slug":         slug,
+		"slug":         netboxSlug(model),
 	}
 	var created struct {
 		ID int `json:"id"`
 	}
 	if err := c.doJSON(ctx, http.MethodPost, "/api/dcim/device-types/", body, &created); err != nil {
-		// try get again
 		if err2 := c.doJSON(ctx, http.MethodGet, "/api/dcim/device-types/?"+q.Encode(), nil, &out); err2 == nil && len(out.Results) > 0 {
 			return out.Results[0].ID, nil
 		}
 		return 0, err
 	}
 	return created.ID, nil
+}
+
+func netboxSlug(s string) string {
+	s = strings.ToLower(strings.TrimSpace(s))
+	var b strings.Builder
+	hyphen := false
+	for _, r := range s {
+		ok := (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9')
+		if ok {
+			b.WriteRune(r)
+			hyphen = false
+			continue
+		}
+		if !hyphen {
+			b.WriteByte('-')
+			hyphen = true
+		}
+	}
+	out := strings.Trim(b.String(), "-")
+	if out == "" {
+		return "unknown"
+	}
+	if len(out) > 50 {
+		out = out[:50]
+	}
+	return out
 }
 
 func (c *Client) doJSON(ctx context.Context, method, path string, body any, out any) error {

--- a/internal/common/netbox/client.go
+++ b/internal/common/netbox/client.go
@@ -51,6 +51,14 @@ type LifecycleWriter interface {
 	SetLifecycle(ctx context.Context, deviceKey string, state models.LifecycleState) error
 }
 
+// DeviceResolver maps operator-facing device keys (name, serial, or NetBox
+// numeric id) to the NetBox primary key string Shoal uses as device_id.
+// Optional on Deploy; when present, Start remaps hostname-style lab keys
+// (e.g. shoal-node-1) so NetBox plugin tabs (keyed by device.pk) see jobs.
+type DeviceResolver interface {
+	ResolveDeviceID(ctx context.Context, key string) (string, error)
+}
+
 // UpsertDevice finds a device by serial or creates one; sets lifecycle custom field when possible.
 func (c *Client) UpsertDevice(ctx context.Context, id models.DeviceIdentity) (string, error) {
 	if c.BaseURL == "" || c.Token == "" {
@@ -86,6 +94,46 @@ func (c *Client) findBySerial(ctx context.Context, serial string) (string, error
 		return "", nil
 	}
 	return fmt.Sprintf("%d", out.Results[0].ID), nil
+}
+
+func (c *Client) findByName(ctx context.Context, name string) (string, error) {
+	q := url.Values{"name": {name}}
+	var out struct {
+		Results []struct {
+			ID int `json:"id"`
+		} `json:"results"`
+	}
+	if err := c.doJSON(ctx, http.MethodGet, "/api/dcim/devices/?"+q.Encode(), nil, &out); err != nil {
+		return "", err
+	}
+	if len(out.Results) == 0 {
+		return "", nil
+	}
+	return fmt.Sprintf("%d", out.Results[0].ID), nil
+}
+
+// ResolveDeviceID implements DeviceResolver.
+// Order: serial match, name match, then return key unchanged (numeric id or
+// free-form lab key when NetBox has no row yet).
+func (c *Client) ResolveDeviceID(ctx context.Context, key string) (string, error) {
+	if c.BaseURL == "" || c.Token == "" {
+		return "", fmt.Errorf("netbox: missing url or token")
+	}
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return "", fmt.Errorf("netbox: device key required")
+	}
+	if id, err := c.findBySerial(ctx, key); err != nil {
+		return "", err
+	} else if id != "" {
+		return id, nil
+	}
+	if id, err := c.findByName(ctx, key); err != nil {
+		return "", err
+	} else if id != "" {
+		return id, nil
+	}
+	return key, nil
 }
 
 func (c *Client) createDevice(ctx context.Context, id models.DeviceIdentity) (string, error) {
@@ -379,7 +427,34 @@ func (m *Memory) SetLifecycle(_ context.Context, deviceKey string, state models.
 	return fmt.Errorf("netbox/memory: device %q not found", deviceKey)
 }
 
+// ResolveDeviceID implements DeviceResolver for tests/lab fakes.
+func (m *Memory) ResolveDeviceID(_ context.Context, key string) (string, error) {
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return "", fmt.Errorf("netbox/memory: device key required")
+	}
+	if id, ok := m.BySerial[key]; ok && id.ID != "" {
+		return id.ID, nil
+	}
+	// Name match: Memory stores Name on DeviceIdentity when set.
+	for _, id := range m.ByID {
+		if id.Name == key && id.ID != "" {
+			return id.ID, nil
+		}
+		// Common lab case: name == serial.
+		if id.Serial == key && id.ID != "" {
+			return id.ID, nil
+		}
+	}
+	if id, ok := m.ByID[key]; ok && id.ID != "" {
+		return id.ID, nil
+	}
+	return key, nil
+}
+
 var _ API = (*Client)(nil)
 var _ API = (*Memory)(nil)
 var _ LifecycleWriter = (*Client)(nil)
 var _ LifecycleWriter = (*Memory)(nil)
+var _ DeviceResolver = (*Client)(nil)
+var _ DeviceResolver = (*Memory)(nil)

--- a/internal/common/netbox/client_test.go
+++ b/internal/common/netbox/client_test.go
@@ -174,3 +174,79 @@ func TestClientFindCreate(t *testing.T) {
 		t.Fatalf("id %q", id)
 	}
 }
+
+func TestClientCreatePhysicalUsesServerRole(t *testing.T) {
+	var deviceBody map[string]any
+	var typeBody map[string]any
+	var mfgBody map[string]any
+	var roleBody map[string]any
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/dcim/devices/", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			_ = json.NewEncoder(w).Encode(map[string]any{"results": []any{}})
+		case http.MethodPost:
+			_ = json.NewDecoder(r.Body).Decode(&deviceBody)
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": 9})
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	})
+	mux.HandleFunc("/api/dcim/sites/", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"results": []any{map[string]any{"id": 1}}})
+	})
+	mux.HandleFunc("/api/dcim/device-roles/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			_ = json.NewEncoder(w).Encode(map[string]any{"results": []any{}})
+			return
+		}
+		_ = json.NewDecoder(r.Body).Decode(&roleBody)
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": 11})
+	})
+	mux.HandleFunc("/api/dcim/manufacturers/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			_ = json.NewEncoder(w).Encode(map[string]any{"results": []any{}})
+			return
+		}
+		_ = json.NewDecoder(r.Body).Decode(&mfgBody)
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": 12})
+	})
+	mux.HandleFunc("/api/dcim/device-types/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			_ = json.NewEncoder(w).Encode(map[string]any{"results": []any{}})
+			return
+		}
+		_ = json.NewDecoder(r.Body).Decode(&typeBody)
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": 13})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	c := netbox.New(srv.URL, "token")
+	id, err := c.UpsertDevice(context.Background(), models.DeviceIdentity{
+		Serial: "C784MH3", Vendor: "Dell Inc.", Model: "PowerEdge R750",
+		BMCIP: "172.16.21.202", LifecycleState: models.StateDiscovered,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if id != "9" {
+		t.Fatalf("id %q", id)
+	}
+	if roleBody["slug"] != "server" || roleBody["name"] != "Server" {
+		t.Fatalf("role %+v", roleBody)
+	}
+	if mfgBody["name"] != "Dell Inc." || mfgBody["slug"] != "dell-inc" {
+		t.Fatalf("mfg %+v", mfgBody)
+	}
+	if typeBody["model"] != "PowerEdge R750" || typeBody["slug"] != "poweredge-r750" {
+		t.Fatalf("type %+v", typeBody)
+	}
+	if deviceBody["role"] != float64(11) || deviceBody["device_type"] != float64(13) {
+		t.Fatalf("device %+v", deviceBody)
+	}
+}

--- a/internal/common/netbox/client_test.go
+++ b/internal/common/netbox/client_test.go
@@ -46,6 +46,37 @@ func TestMemorySetLifecycle(t *testing.T) {
 	}
 }
 
+func TestMemoryGetDeviceAndSetCredentialRef(t *testing.T) {
+	m := netbox.NewMemory()
+	id, err := m.UpsertDevice(context.Background(), models.DeviceIdentity{
+		Name: "C784MH3", Serial: "C784MH3", BMCIP: "172.16.21.202",
+		Vendor: "Dell Inc.", Model: "PowerEdge R750",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := m.GetDevice(context.Background(), id)
+	if err != nil || got.Serial != "C784MH3" || got.Vendor != "Dell Inc." {
+		t.Fatalf("%+v %v", got, err)
+	}
+	if err := m.SetCredentialRef(context.Background(), id, "bmc-C784MH3", ""); err != nil {
+		t.Fatal(err)
+	}
+	got, err = m.GetDevice(context.Background(), "C784MH3")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.CredentialRef != "bmc-C784MH3" || got.BMCIP != "172.16.21.202" {
+		t.Fatalf("%+v", got)
+	}
+	if got.Vendor != "Dell Inc." || got.Model != "PowerEdge R750" {
+		t.Fatalf("classification wiped: %+v", got)
+	}
+	if err := m.SetCredentialRef(context.Background(), "missing", "bmc-x", ""); err == nil {
+		t.Fatal("expected not found")
+	}
+}
+
 func TestMemoryResolveDeviceID(t *testing.T) {
 	m := netbox.NewMemory()
 	id, err := m.UpsertDevice(context.Background(), models.DeviceIdentity{
@@ -94,6 +125,128 @@ func TestClientResolveDeviceID(t *testing.T) {
 	got, err = c.ResolveDeviceID(context.Background(), "no-such")
 	if err != nil || got != "no-such" {
 		t.Fatalf("passthrough %q %v", got, err)
+	}
+}
+
+func TestClientGetDeviceByNumericIDSkipsList(t *testing.T) {
+	var listed bool
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/dcim/devices/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		if r.URL.RawQuery != "" {
+			listed = true
+			_ = json.NewEncoder(w).Encode(map[string]any{"results": []any{}})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id": 6, "name": "C784MH3", "serial": "C784MH3",
+			"custom_fields": map[string]any{"credential_ref": "bmc-C784MH3", "bmc_ip": "172.16.21.202"},
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	c := netbox.New(srv.URL, "tok")
+	got, err := c.GetDevice(context.Background(), "6")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if listed {
+		t.Fatal("numeric NetBox id must not search by serial/name")
+	}
+	if got.ID != "6" || got.CredentialRef != "bmc-C784MH3" {
+		t.Fatalf("%+v", got)
+	}
+}
+
+func TestClientGetDevice(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/dcim/devices/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		if r.URL.RawQuery != "" {
+			if r.URL.Query().Get("serial") == "C784MH3" {
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"results": []any{map[string]any{"id": 6}},
+				})
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"results": []any{}})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id": 6, "name": "C784MH3", "serial": "C784MH3",
+			"custom_fields": map[string]any{
+				"lifecycle_state": "discovered",
+				"credential_ref":  "bmc-C784MH3",
+				"bmc_ip":          "172.16.21.202",
+			},
+			"device_type": map[string]any{
+				"model":        "PowerEdge R750",
+				"manufacturer": map[string]any{"name": "Dell Inc."},
+			},
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	c := netbox.New(srv.URL, "tok")
+	got, err := c.GetDevice(context.Background(), "C784MH3")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ID != "6" || got.Serial != "C784MH3" || got.Vendor != "Dell Inc." || got.Model != "PowerEdge R750" {
+		t.Fatalf("%+v", got)
+	}
+	if got.CredentialRef != "bmc-C784MH3" || got.BMCIP != "172.16.21.202" {
+		t.Fatalf("%+v", got)
+	}
+}
+
+func TestClientSetCredentialRef(t *testing.T) {
+	var patched map[string]any
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/dcim/devices/", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			if r.URL.RawQuery != "" {
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"results": []any{map[string]any{"id": 6}},
+				})
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id": 6, "name": "C784MH3", "serial": "C784MH3",
+				"custom_fields": map[string]any{"bmc_ip": "172.16.21.202"},
+			})
+		case http.MethodPatch:
+			_ = json.NewDecoder(r.Body).Decode(&patched)
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	c := netbox.New(srv.URL, "tok")
+	if err := c.SetCredentialRef(context.Background(), "6", "bmc-C784MH3", ""); err != nil {
+		t.Fatal(err)
+	}
+	cf, _ := patched["custom_fields"].(map[string]any)
+	if cf["credential_ref"] != "bmc-C784MH3" {
+		t.Fatalf("patch %+v", patched)
+	}
+	if _, ok := patched["role"]; ok {
+		t.Fatalf("must not patch role: %+v", patched)
+	}
+	if _, ok := patched["device_type"]; ok {
+		t.Fatalf("must not patch device_type: %+v", patched)
+	}
+	if _, ok := cf["bmc_ip"]; ok {
+		t.Fatalf("empty bmc_ip must not overwrite: %+v", patched)
 	}
 }
 

--- a/internal/common/netbox/client_test.go
+++ b/internal/common/netbox/client_test.go
@@ -46,6 +46,57 @@ func TestMemorySetLifecycle(t *testing.T) {
 	}
 }
 
+func TestMemoryResolveDeviceID(t *testing.T) {
+	m := netbox.NewMemory()
+	id, err := m.UpsertDevice(context.Background(), models.DeviceIdentity{
+		Name: "shoal-node-1", Serial: "shoal-node-1", LifecycleState: models.StateDiscovered,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := m.ResolveDeviceID(context.Background(), "shoal-node-1")
+	if err != nil || got != id {
+		t.Fatalf("serial resolve: %v %q want %q", err, got, id)
+	}
+	got, err = m.ResolveDeviceID(context.Background(), id)
+	if err != nil || got != id {
+		t.Fatalf("id passthrough: %v %q", err, got)
+	}
+	got, err = m.ResolveDeviceID(context.Background(), "unknown-lab-key")
+	if err != nil || got != "unknown-lab-key" {
+		t.Fatalf("unknown keep: %v %q", err, got)
+	}
+}
+
+func TestClientResolveDeviceID(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/dcim/devices/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		q := r.URL.Query()
+		if q.Get("serial") == "shoal-node-1" || q.Get("name") == "shoal-node-1" {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"results": []any{map[string]any{"id": 3}},
+			})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"results": []any{}})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	c := netbox.New(srv.URL, "tok")
+	got, err := c.ResolveDeviceID(context.Background(), "shoal-node-1")
+	if err != nil || got != "3" {
+		t.Fatalf("got %q err %v", got, err)
+	}
+	got, err = c.ResolveDeviceID(context.Background(), "no-such")
+	if err != nil || got != "no-such" {
+		t.Fatalf("passthrough %q %v", got, err)
+	}
+}
+
 func TestClientSetLifecycle(t *testing.T) {
 	var patched bool
 	mux := http.NewServeMux()

--- a/internal/common/redfish/bmc.go
+++ b/internal/common/redfish/bmc.go
@@ -23,7 +23,11 @@ type BMC interface {
 	InsertVirtualMedia(ctx context.Context, mediaURI, imageURL string) error
 	EjectVirtualMedia(ctx context.Context, mediaURI string) error
 	// Power resetType: On | ForceOff | ForceRestart | GracefulRestart | ...
+	// Deploy uses this; On when already On is rewritten to ForceRestart so
+	// one-time virtual media is observed.
 	Power(ctx context.Context, systemID, resetType string) error
+	// Reset applies the Redfish reset type as requested, with no On→ForceRestart rewrite.
+	Reset(ctx context.Context, systemID, resetType string) error
 	// CleanupMediaAndBoot ejects all inserted media for the system and clears boot override.
 	CleanupMediaAndBoot(ctx context.Context, systemID string) error
 	// ListSEL returns log entries (SEL/event logs) for the system, managers, and chassis.
@@ -32,6 +36,9 @@ type BMC interface {
 	// ListSensors returns thermal/power sensor samples for chassis related to systemID.
 	// Best-effort: missing Thermal/Power yield empty slice or partial results.
 	ListSensors(ctx context.Context, systemID string) ([]SensorSample, error)
+	// ListFirmware returns UpdateService FirmwareInventory (gather-only; no flash).
+	// Missing UpdateService is an empty slice, not an error (sushy).
+	ListFirmware(ctx context.Context) ([]FirmwareComponent, error)
 	// CaptureScreenshot attempts OEM/documented console frame capture (Dell, Supermicro first).
 	// File/operator capture is preferred in lab; this path is for real BMC hardware.
 	// On failure, returned Screenshot.Debug (and error text) include probe steps without secrets.

--- a/internal/common/redfish/client.go
+++ b/internal/common/redfish/client.go
@@ -357,9 +357,9 @@ func (c *client) ListVirtualMedia(_ context.Context, systemID string) ([]Virtual
 		}
 	}
 
-	if len(out) == 0 {
-		return nil, fmt.Errorf("redfish: no virtual media found")
-	}
+	// Empty is valid: sushy-tools eject removes the libvirt CD device entirely,
+	// so a successful cleanup leaves zero slots until the next InsertMedia path
+	// recreates them. Callers that need a tray for insert must check len==0.
 	return out, nil
 }
 

--- a/internal/common/redfish/client.go
+++ b/internal/common/redfish/client.go
@@ -456,22 +456,27 @@ func (c *client) EjectVirtualMedia(_ context.Context, mediaURI string) error {
 	return nil
 }
 
-// Power performs a reset action (idempotent for On when already on).
+// Power performs a reset action. On when already On becomes ForceRestart so
+// one-time virtual media is observed (Deploy). Operator power control uses Reset.
 func (c *client) Power(ctx context.Context, systemID, resetType string) error {
-	sys, err := c.computerSystem(systemID)
-	if err != nil {
-		return err
-	}
 	info, err := c.GetSystem(ctx, systemID)
 	if err != nil {
 		return err
 	}
-	rt := gofishredfish.ResetType(resetType)
 	if resetType == "On" && strings.EqualFold(info.PowerState, "On") {
-		// Force restart so one-time media is observed.
-		rt = gofishredfish.ForceRestartResetType
+		resetType = "ForceRestart"
 	}
-	if err := sys.Reset(rt); err != nil {
+	return c.Reset(ctx, systemID, resetType)
+}
+
+// Reset applies the named Redfish reset type with no rewriting.
+func (c *client) Reset(ctx context.Context, systemID, resetType string) error {
+	_ = ctx
+	sys, err := c.computerSystem(systemID)
+	if err != nil {
+		return err
+	}
+	if err := sys.Reset(gofishredfish.ResetType(resetType)); err != nil {
 		return fmt.Errorf("redfish: power %s: %w", resetType, err)
 	}
 	return nil

--- a/internal/common/redfish/fake.go
+++ b/internal/common/redfish/fake.go
@@ -24,11 +24,13 @@ type Fake struct {
 	FailNextCleanup bool
 
 	// SEL and Sensors are returned by ListSEL / ListSensors (Phase 4 Observe).
-	SEL     []SELEntry
-	Sensors []SensorSample
-	// ListSELErr / ListSensorsErr force errors when set.
-	ListSELErr     error
-	ListSensorsErr error
+	SEL      []SELEntry
+	Sensors  []SensorSample
+	Firmware []FirmwareComponent
+	// ListSELErr / ListSensorsErr / ListFirmwareErr force errors when set.
+	ListSELErr      error
+	ListSensorsErr  error
+	ListFirmwareErr error
 
 	// Screenshot is returned by CaptureScreenshot when set.
 	Screenshot    *Screenshot
@@ -177,10 +179,34 @@ func (f *Fake) EjectVirtualMedia(_ context.Context, mediaURI string) error {
 func (f *Fake) Power(_ context.Context, systemID, resetType string) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	rt := resetType
+	if rt == "On" {
+		for _, s := range f.Systems {
+			if (systemID == "" || s.ID == systemID) && strings.EqualFold(s.PowerState, "On") {
+				rt = "ForceRestart"
+				break
+			}
+		}
+	}
+	return f.resetLocked(systemID, rt)
+}
+
+func (f *Fake) Reset(_ context.Context, systemID, resetType string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.resetLocked(systemID, resetType)
+}
+
+func (f *Fake) resetLocked(systemID, resetType string) error {
 	f.PowerCalls = append(f.PowerCalls, resetType)
+	state := "On"
+	switch resetType {
+	case "ForceOff", "GracefulShutdown":
+		state = "Off"
+	}
 	for i, s := range f.Systems {
 		if systemID == "" || s.ID == systemID {
-			s.PowerState = "On"
+			s.PowerState = state
 			f.Systems[i] = s
 		}
 	}
@@ -227,6 +253,17 @@ func (f *Fake) ListSEL(_ context.Context, _ string, opts SELOptions) ([]SELEntry
 	return out, nil
 }
 
+func (f *Fake) ListFirmware(_ context.Context) ([]FirmwareComponent, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.ListFirmwareErr != nil {
+		return nil, f.ListFirmwareErr
+	}
+	out := make([]FirmwareComponent, len(f.Firmware))
+	copy(out, f.Firmware)
+	return out, nil
+}
+
 func (f *Fake) ListSensors(_ context.Context, _ string) ([]SensorSample, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -235,6 +272,11 @@ func (f *Fake) ListSensors(_ context.Context, _ string) ([]SensorSample, error) 
 	}
 	out := make([]SensorSample, len(f.Sensors))
 	copy(out, f.Sensors)
+	for i := range out {
+		if !out[i].HasReading && out[i].Note == "" {
+			out[i].HasReading = true
+		}
+	}
 	return out, nil
 }
 

--- a/internal/common/redfish/firmware.go
+++ b/internal/common/redfish/firmware.go
@@ -1,0 +1,91 @@
+package redfish
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	gofishredfish "github.com/stmcginnis/gofish/redfish"
+)
+
+const maxFirmwareEntries = 200
+
+// ListFirmware returns installed firmware/software inventory from UpdateService.
+func (c *client) ListFirmware(_ context.Context) ([]FirmwareComponent, error) {
+	api, err := c.apiClient()
+	if err != nil {
+		return nil, err
+	}
+	if api.Service == nil {
+		return nil, fmt.Errorf("redfish: nil service root")
+	}
+	us, err := api.Service.UpdateService()
+	if err != nil || us == nil {
+		return nil, nil
+	}
+	items, err := us.FirmwareInventories()
+	if err != nil {
+		return nil, fmt.Errorf("redfish: firmware inventory: %w", err)
+	}
+	if len(items) == 0 {
+		sw, swErr := us.SoftwareInventories()
+		if swErr == nil {
+			items = sw
+		}
+	}
+	out := make([]FirmwareComponent, 0, len(items))
+	seen := map[string]struct{}{}
+	for _, inv := range items {
+		if inv == nil {
+			continue
+		}
+		row := mapSoftwareInventory(inv)
+		if !keepFirmwareInventory(row.ID, row.Name) {
+			continue
+		}
+		key := strings.ToLower(row.ID)
+		if key == "" {
+			key = strings.ToLower(row.Name + "|" + row.Version)
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, row)
+		if len(out) >= maxFirmwareEntries {
+			break
+		}
+	}
+	return out, nil
+}
+
+func mapSoftwareInventory(inv *gofishredfish.SoftwareInventory) FirmwareComponent {
+	id := inv.ID
+	if id == "" {
+		id = inv.ODataID
+	}
+	return FirmwareComponent{
+		ID:           id,
+		Name:         inv.Name,
+		Version:      inv.Version,
+		SoftwareID:   inv.SoftwareID,
+		Manufacturer: inv.Manufacturer,
+		ReleaseDate:  inv.ReleaseDate,
+		Health:       string(inv.Status.Health),
+		State:        string(inv.Status.State),
+		Updateable:   inv.Updateable,
+	}
+}
+
+func keepFirmwareInventory(id, name string) bool {
+	idLower := strings.ToLower(id)
+	blob := idLower + " " + strings.ToLower(name)
+	if strings.Contains(blob, "available") || strings.Contains(blob, "previous") {
+		return false
+	}
+	// Dell lists both Current-* and Installed-* for the same image.
+	if strings.HasPrefix(idLower, "current-") {
+		return false
+	}
+	return true
+}

--- a/internal/common/redfish/firmware_test.go
+++ b/internal/common/redfish/firmware_test.go
@@ -1,0 +1,36 @@
+package redfish
+
+import (
+	"context"
+	"testing"
+)
+
+func TestKeepFirmwareInventory(t *testing.T) {
+	if !keepFirmwareInventory("Installed-0-BIOS", "BIOS") {
+		t.Fatal("installed bios")
+	}
+	if keepFirmwareInventory("Available-0-BIOS", "BIOS") {
+		t.Fatal("skip available")
+	}
+	if keepFirmwareInventory("Previous-1-iDRAC", "iDRAC") {
+		t.Fatal("skip previous")
+	}
+	if keepFirmwareInventory("Current-159-1.15.2__BIOS.Setup.1-1", "BIOS") {
+		t.Fatal("skip current")
+	}
+}
+
+func TestFakeListFirmware(t *testing.T) {
+	f := NewFake()
+	f.Firmware = []FirmwareComponent{
+		{ID: "Installed-0-BIOS", Name: "BIOS", Version: "1.2.3"},
+		{ID: "Available-0-BIOS", Name: "BIOS", Version: "1.2.4"},
+	}
+	got, err := f.ListFirmware(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("fake does not filter: %+v", got)
+	}
+}

--- a/internal/common/redfish/sel_list_test.go
+++ b/internal/common/redfish/sel_list_test.go
@@ -13,6 +13,39 @@ import (
 	gofishredfish "github.com/stmcginnis/gofish/redfish"
 )
 
+func TestSensorUnavailableNote(t *testing.T) {
+	got := sensorUnavailableNote(nil, true)
+	if got != "No reading while host is off" {
+		t.Fatalf("%q", got)
+	}
+	got = sensorUnavailableNote(nil, false)
+	if got != "BMC did not return a reading" {
+		t.Fatalf("%q", got)
+	}
+}
+
+func TestUniqueSensorName(t *testing.T) {
+	seen := map[string]struct{}{}
+	a := uniqueSensorName(seen, "InputPowerSensor", "PSU.Slot.1_InputPower")
+	if a != "InputPowerSensor" {
+		t.Fatalf("first=%q", a)
+	}
+	seen[strings.ToLower(a)] = struct{}{}
+	b := uniqueSensorName(seen, "InputPowerSensor", "PSU.Slot.2_InputPower")
+	if b != "InputPowerSensor (PSU.Slot.2_InputPower)" {
+		t.Fatalf("second=%q", b)
+	}
+}
+
+func TestDiscretePowerGood(t *testing.T) {
+	if !discretePowerGood("CPU1 VCCIN PG") || !discretePowerGood("System Board Pfault Fail Safe") {
+		t.Fatal("expected discrete PG names")
+	}
+	if discretePowerGood("PS1 Voltage 1") || discretePowerGood("Inlet Temp") {
+		t.Fatal("analog rails should not be treated as PG bits")
+	}
+}
+
 func TestLogServiceRank(t *testing.T) {
 	sel := &gofishredfish.LogService{LogEntryType: gofishredfish.SELLogEntryTypes}
 	sel.Name, sel.ID, sel.ODataID = "SEL Log", "Sel", "/redfish/v1/Managers/1/LogServices/Sel"

--- a/internal/common/redfish/sel_list_test.go
+++ b/internal/common/redfish/sel_list_test.go
@@ -1,0 +1,166 @@
+package redfish
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	gofishredfish "github.com/stmcginnis/gofish/redfish"
+)
+
+func TestLogServiceRank(t *testing.T) {
+	sel := &gofishredfish.LogService{LogEntryType: gofishredfish.SELLogEntryTypes}
+	sel.Name, sel.ID, sel.ODataID = "SEL Log", "Sel", "/redfish/v1/Managers/1/LogServices/Sel"
+
+	lc := &gofishredfish.LogService{}
+	lc.Name, lc.ID, lc.ODataID = "LC Log", "Lclog", "/redfish/v1/Managers/1/LogServices/Lclog"
+
+	fault := &gofishredfish.LogService{}
+	fault.Name, fault.ID, fault.ODataID = "Fault List", "FaultList", "/redfish/v1/Managers/1/LogServices/FaultList"
+
+	if logServiceRank(sel) != logRankSEL {
+		t.Fatalf("SEL rank=%d want %d", logServiceRank(sel), logRankSEL)
+	}
+	if logServiceRank(lc) != logRankVerbose {
+		t.Fatalf("Lclog rank=%d want %d", logServiceRank(lc), logRankVerbose)
+	}
+	if logServiceRank(fault) != logRankVerbose {
+		t.Fatalf("FaultList rank=%d want %d", logServiceRank(fault), logRankVerbose)
+	}
+	if logServiceRank(sel) <= logServiceRank(lc) {
+		t.Fatal("SEL should outrank Lclog")
+	}
+}
+
+func TestListSELSkipsLifecycleLog(t *testing.T) {
+	var lcHits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		p := r.URL.Path
+		if strings.Contains(p, "Lclog") && strings.Contains(p, "Entries") {
+			lcHits.Add(1)
+			http.Error(w, "lclog should not be fetched", http.StatusInternalServerError)
+			return
+		}
+		body, ok := selSkipLCLogJSON(p)
+		if !ok {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = io.WriteString(w, body)
+	}))
+	t.Cleanup(srv.Close)
+
+	c := openFakeClient(t, srv.URL)
+	got, err := c.ListSEL(context.Background(), "1", SELOptions{MaxEntries: 10})
+	if err != nil {
+		t.Fatalf("ListSEL: %v", err)
+	}
+	if lcHits.Load() != 0 {
+		t.Fatalf("Lclog Entries fetched %d times; want 0", lcHits.Load())
+	}
+	if len(got) != 1 || got[0].Message != "chassis closed" {
+		t.Fatalf("got %+v", got)
+	}
+	if got[0].LogService != "SEL Log" {
+		t.Fatalf("log service=%q", got[0].LogService)
+	}
+}
+
+func selSkipLCLogJSON(path string) (string, bool) {
+	switch path {
+	case "/redfish/v1", "/redfish/v1/":
+		return `{
+			"@odata.id": "/redfish/v1/",
+			"Id": "RootService",
+			"Name": "Root Service",
+			"RedfishVersion": "1.9.0",
+			"Systems": {"@odata.id": "/redfish/v1/Systems"},
+			"Managers": {"@odata.id": "/redfish/v1/Managers"},
+			"Chassis": {"@odata.id": "/redfish/v1/Chassis"}
+		}`, true
+	case "/redfish/v1/Systems":
+		return collectionJSON("/redfish/v1/Systems", "/redfish/v1/Systems/1"), true
+	case "/redfish/v1/Systems/1":
+		return `{
+			"@odata.id": "/redfish/v1/Systems/1",
+			"Id": "1",
+			"Name": "System.1",
+			"Manufacturer": "Dell Inc.",
+			"Model": "PowerEdge R750",
+			"PowerState": "Off"
+		}`, true
+	case "/redfish/v1/Managers":
+		return collectionJSON("/redfish/v1/Managers", "/redfish/v1/Managers/1"), true
+	case "/redfish/v1/Managers/1":
+		return `{
+			"@odata.id": "/redfish/v1/Managers/1",
+			"Id": "1",
+			"Name": "Manager",
+			"LogServices": {"@odata.id": "/redfish/v1/Managers/1/LogServices"}
+		}`, true
+	case "/redfish/v1/Managers/1/LogServices":
+		return collectionJSON("/redfish/v1/Managers/1/LogServices",
+			"/redfish/v1/Managers/1/LogServices/Sel",
+			"/redfish/v1/Managers/1/LogServices/Lclog"), true
+	case "/redfish/v1/Managers/1/LogServices/Sel":
+		return `{
+			"@odata.id": "/redfish/v1/Managers/1/LogServices/Sel",
+			"Id": "Sel",
+			"Name": "SEL Log",
+			"LogEntryType": "SEL",
+			"Entries": {"@odata.id": "/redfish/v1/Managers/1/LogServices/Sel/Entries"}
+		}`, true
+	case "/redfish/v1/Managers/1/LogServices/Lclog":
+		return `{
+			"@odata.id": "/redfish/v1/Managers/1/LogServices/Lclog",
+			"Id": "Lclog",
+			"Name": "LC Log",
+			"LogEntryType": "Event",
+			"Entries": {"@odata.id": "/redfish/v1/Managers/1/LogServices/Lclog/Entries"}
+		}`, true
+	case "/redfish/v1/Managers/1/LogServices/Sel/Entries":
+		return `{
+			"@odata.id": "/redfish/v1/Managers/1/LogServices/Sel/Entries",
+			"Members@odata.count": 1,
+			"Members": [{"@odata.id": "/redfish/v1/Managers/1/LogServices/Sel/Entries/1"}]
+		}`, true
+	case "/redfish/v1/Managers/1/LogServices/Sel/Entries/1":
+		return `{
+			"@odata.id": "/redfish/v1/Managers/1/LogServices/Sel/Entries/1",
+			"Id": "1",
+			"Name": "Log Entry 1",
+			"Message": "chassis closed",
+			"Severity": "OK",
+			"EntryType": "SEL",
+			"Created": "2025-05-02T09:10:01-05:00"
+		}`, true
+	case "/redfish/v1/Chassis":
+		return `{
+			"@odata.id": "/redfish/v1/Chassis",
+			"Name": "Chassis Collection",
+			"Members@odata.count": 0,
+			"Members": []
+		}`, true
+	default:
+		return "", false
+	}
+}
+
+func collectionJSON(self string, members ...string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, `{"@odata.id":%q,"Name":"Collection","Members@odata.count":%d,"Members":[`, self, len(members))
+	for i, m := range members {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		fmt.Fprintf(&b, `{"@odata.id":%q}`, m)
+	}
+	b.WriteString(`]}`)
+	return b.String()
+}

--- a/internal/common/redfish/sel_sensors.go
+++ b/internal/common/redfish/sel_sensors.go
@@ -6,8 +6,40 @@ import (
 	"strings"
 	"time"
 
+	gofishcommon "github.com/stmcginnis/gofish/common"
 	gofishredfish "github.com/stmcginnis/gofish/redfish"
 )
+
+const (
+	logRankVerbose = 0 // Dell Lclog / FaultList: skip unless nothing else yielded entries
+	logRankNormal  = 1
+	logRankSEL     = 2
+)
+
+// logServiceRank prefers IPMI SEL over vendor dumps (iDRAC LC log can be thousands
+// of entries; gofish Entries() GETs every member and blows a poll deadline).
+func logServiceRank(ls *gofishredfish.LogService) int {
+	if ls == nil {
+		return logRankVerbose
+	}
+	if ls.LogEntryType == gofishredfish.SELLogEntryTypes {
+		return logRankSEL
+	}
+	blob := strings.ToLower(ls.Name + " " + ls.ID + " " + ls.ODataID)
+	switch {
+	case strings.Contains(blob, "lclog"),
+		strings.Contains(blob, "lifecycle"),
+		strings.Contains(blob, "faultlist"),
+		strings.Contains(blob, "fault-list"):
+		return logRankVerbose
+	case strings.Contains(blob, "sel"),
+		strings.Contains(blob, "systemevent"),
+		strings.Contains(blob, "system_event"):
+		return logRankSEL
+	default:
+		return logRankNormal
+	}
+}
 
 // ListSEL collects log entries from the computer system, managers, and chassis.
 //
@@ -15,8 +47,14 @@ import (
 // (or no LogServices) — normal for sushy-tools.
 // Non-nil error means a hard failure: not open, system not found (when requested),
 // or every discovered log service failed while reading entries (and no entries returned).
+//
+// Reads IPMI SEL first. Vendor lifecycle / fault dumps (iDRAC Lclog, FaultList)
+// are skipped unless no other service returned entries. Entry collections are
+// fetched with $top=MaxEntries so a huge log cannot stall Observe poll.
 func (c *client) ListSEL(ctx context.Context, systemID string, opts SELOptions) ([]SELEntry, error) {
-	_ = ctx
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	api, err := c.apiClient()
 	if err != nil {
 		return nil, err
@@ -26,9 +64,47 @@ func (c *client) ListSEL(ctx context.Context, systemID string, opts SELOptions) 
 		max = 200
 	}
 
+	var discovered []*gofishredfish.LogService
+	var firstReadErr error
+	var sysErr error
+
+	sys, sysErr := c.computerSystem(systemID)
+	if sysErr != nil {
+		firstReadErr = sysErr
+	} else if sys != nil {
+		if services, err := sys.LogServices(); err == nil {
+			discovered = append(discovered, services...)
+		}
+	}
+
+	if managers, err := api.Service.Managers(); err == nil {
+		for _, m := range managers {
+			if m == nil {
+				continue
+			}
+			if services, err := m.LogServices(); err == nil {
+				discovered = append(discovered, services...)
+			}
+		}
+	} else if firstReadErr == nil {
+		firstReadErr = fmt.Errorf("redfish: managers: %w", err)
+	}
+
+	if chassis, err := api.Service.Chassis(); err == nil {
+		for _, ch := range chassis {
+			if ch == nil {
+				continue
+			}
+			if services, err := ch.LogServices(); err == nil {
+				discovered = append(discovered, services...)
+			}
+		}
+	} else if firstReadErr == nil {
+		firstReadErr = fmt.Errorf("redfish: chassis: %w", err)
+	}
+
 	seen := make(map[string]struct{})
 	var out []SELEntry
-	var firstReadErr error
 	logServicesSeen := 0
 	entryReadOK := 0
 	entryReadFail := 0
@@ -38,6 +114,9 @@ func (c *client) ListSEL(ctx context.Context, systemID string, opts SELOptions) 
 		for _, e := range entries {
 			if e == nil {
 				continue
+			}
+			if len(out) >= max {
+				return
 			}
 			se := mapLogEntry(logName, e)
 			key := se.ODataID
@@ -55,90 +134,72 @@ func (c *client) ListSEL(ctx context.Context, systemID string, opts SELOptions) 
 		}
 	}
 
-	readLogServices := func(services []*gofishredfish.LogService) {
-		for _, ls := range services {
-			if ls == nil {
+	readOne := func(ls *gofishredfish.LogService, allowUnfiltered bool) {
+		if ls == nil {
+			return
+		}
+		if err := ctx.Err(); err != nil {
+			if firstReadErr == nil {
+				firstReadErr = err
+			}
+			return
+		}
+		logServicesSeen++
+		remain := max - len(out)
+		if remain <= 0 {
+			return
+		}
+		entries, err := ls.FilteredEntries(gofishcommon.WithTop(remain))
+		if err != nil && allowUnfiltered {
+			entries, err = ls.Entries()
+		}
+		if err != nil {
+			entryReadFail++
+			if firstReadErr == nil {
+				firstReadErr = err
+			}
+			return
+		}
+		appendEntries(ls.Name, entries)
+	}
+
+	// Pass 0: SEL. Pass 1: other non-verbose. Pass 2: LC/fault dumps only if still empty.
+	for pass := logRankSEL; pass >= logRankVerbose; pass-- {
+		if len(out) >= max {
+			break
+		}
+		if pass == logRankVerbose && len(out) > 0 {
+			break
+		}
+		if err := ctx.Err(); err != nil {
+			if firstReadErr == nil {
+				firstReadErr = err
+			}
+			break
+		}
+		for _, ls := range discovered {
+			if logServiceRank(ls) != pass {
 				continue
 			}
-			logServicesSeen++
-			entries, err := ls.Entries()
-			if err != nil {
-				entryReadFail++
-				if firstReadErr == nil {
-					firstReadErr = err
-				}
-				continue
-			}
-			appendEntries(ls.Name, entries)
+			readOne(ls, pass >= logRankNormal)
 			if len(out) >= max {
-				return
+				break
 			}
 		}
-	}
-
-	// System log services — system lookup failure is hard when systemID is set
-	// or when there is not exactly one system for empty id.
-	sys, sysErr := c.computerSystem(systemID)
-	if sysErr != nil {
-		// Still try managers/chassis (BMC may log there only), but remember error.
-		if firstReadErr == nil {
-			firstReadErr = sysErr
-		}
-	} else if sys != nil {
-		if services, err := sys.LogServices(); err == nil {
-			readLogServices(services)
-		}
-		// LogServices() missing/empty is soft.
-	}
-	if len(out) >= max {
-		return out[:max], nil
-	}
-
-	if managers, err := api.Service.Managers(); err == nil {
-		for _, m := range managers {
-			if m == nil {
-				continue
-			}
-			if services, err := m.LogServices(); err == nil {
-				readLogServices(services)
-				if len(out) >= max {
-					return out[:max], nil
-				}
-			}
-		}
-	} else if firstReadErr == nil {
-		firstReadErr = fmt.Errorf("redfish: managers: %w", err)
-	}
-
-	if chassis, err := api.Service.Chassis(); err == nil {
-		for _, ch := range chassis {
-			if ch == nil {
-				continue
-			}
-			if services, err := ch.LogServices(); err == nil {
-				readLogServices(services)
-				if len(out) >= max {
-					return out[:max], nil
-				}
-			}
-		}
-	} else if firstReadErr == nil {
-		firstReadErr = fmt.Errorf("redfish: chassis: %w", err)
 	}
 
 	if len(out) > max {
 		out = out[:max]
 	}
 
-	// Hard fail only when we could not return any entries and something went wrong
-	// reading entries from discovered log services, or system resolution failed with
-	// no other data path producing entries.
 	if len(out) == 0 {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		if entryReadFail > 0 && logServicesSeen > 0 {
 			return nil, fmt.Errorf("redfish: log entry reads failed (%d services, %d read errors): %w",
 				logServicesSeen, entryReadFail, firstReadErr)
 		}
-		// systemID explicitly requested but system missing and no entries elsewhere
 		if systemID != "" && sysErr != nil {
 			return nil, fmt.Errorf("redfish: list SEL: %w", sysErr)
 		}
@@ -199,18 +260,30 @@ func parseRedfishTime(s string) time.Time {
 // Chassis collection failure is an error. Missing Thermal/Power on a chassis is soft
 // (skipped). Empty chassis or empty sensors with successful enumeration is OK.
 func (c *client) ListSensors(ctx context.Context, systemID string) ([]SensorSample, error) {
-	_ = ctx
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	_ = systemID
 	api, err := c.apiClient()
 	if err != nil {
 		return nil, err
 	}
 	chassis, err := api.Service.Chassis()
-	if err != nil {
-		return nil, fmt.Errorf("redfish: chassis for sensors: %w", err)
+	if len(chassis) == 0 {
+		if err != nil {
+			return nil, fmt.Errorf("redfish: chassis for sensors: %w", err)
+		}
+		return nil, nil
 	}
+	// Partial collection (one enclosure member failed) is usable; only empty+err is fatal.
 	var out []SensorSample
 	for _, ch := range chassis {
+		if err := ctx.Err(); err != nil {
+			if len(out) > 0 {
+				return out, nil
+			}
+			return nil, err
+		}
 		if ch == nil {
 			continue
 		}

--- a/internal/common/redfish/sel_sensors.go
+++ b/internal/common/redfish/sel_sensors.go
@@ -255,15 +255,17 @@ func parseRedfishTime(s string) time.Time {
 	return time.Time{}
 }
 
-// ListSensors collects temperature, fan, and voltage samples from chassis Thermal/Power.
+// ListSensors collects chassis samples: Redfish Sensor resources first (power,
+// current, usage, temps), then Thermal temps/fans. Power.Voltages is only used
+// when the Sensors collection is empty — iDRAC Power.Voltages is mostly discrete
+// power-good rails that drown Observe/NetBox in 0V rows while the host is off.
 //
-// Chassis collection failure is an error. Missing Thermal/Power on a chassis is soft
-// (skipped). Empty chassis or empty sensors with successful enumeration is OK.
+// Chassis collection failure is an error. Missing Thermal/Power/Sensors on a
+// chassis is soft. Empty chassis or empty sensors with successful enumeration is OK.
 func (c *client) ListSensors(ctx context.Context, systemID string) ([]SensorSample, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-	_ = systemID
 	api, err := c.apiClient()
 	if err != nil {
 		return nil, err
@@ -275,8 +277,26 @@ func (c *client) ListSensors(ctx context.Context, systemID string) ([]SensorSamp
 		}
 		return nil, nil
 	}
-	// Partial collection (one enclosure member failed) is usable; only empty+err is fatal.
+	hostOff := false
+	if sys, err := c.computerSystem(systemID); err == nil && sys != nil {
+		hostOff = strings.EqualFold(string(sys.PowerState), "Off")
+	}
+
 	var out []SensorSample
+	seen := make(map[string]struct{})
+	add := func(s SensorSample) {
+		name := strings.TrimSpace(s.Name)
+		if name == "" {
+			return
+		}
+		s.Name = name
+		key := strings.ToLower(name)
+		if _, ok := seen[key]; ok {
+			return
+		}
+		seen[key] = struct{}{}
+		out = append(out, s)
+	}
 	for _, ch := range chassis {
 		if err := ctx.Err(); err != nil {
 			if len(out) > 0 {
@@ -287,38 +307,57 @@ func (c *client) ListSensors(ctx context.Context, systemID string) ([]SensorSamp
 		if ch == nil {
 			continue
 		}
+		fromSensors := false
+		if list, err := ch.Sensors(); err == nil {
+			for _, s := range list {
+				if s == nil {
+					continue
+				}
+				fromSensors = true
+				kind := strings.ToLower(string(s.ReadingType))
+				if kind == "" {
+					kind = "sensor"
+				}
+				sample := SensorSample{
+					Name:            uniqueSensorName(seen, firstNonEmpty(s.Name, s.ID), s.ID),
+					Reading:         float64(s.Reading),
+					HasReading:      sensorReporting(s),
+					Units:           s.ReadingUnits,
+					PhysicalContext: string(s.PhysicalContext),
+					Status:          strings.TrimSpace(string(s.Status.State)),
+					Kind:            kind,
+				}
+				if !sample.HasReading {
+					sample.Note = sensorUnavailableNote(s, hostOff)
+				}
+				add(sample)
+			}
+		}
+		if fromSensors {
+			// Sensors collection already has temps; Thermal 0°C rows would
+			// look like readings when Redfish actually omitted them.
+			continue
+		}
 		if thermal, err := ch.Thermal(); err == nil && thermal != nil {
 			for _, t := range thermal.Temperatures {
-				name := t.Name
-				if name == "" {
-					name = t.MemberID
-				}
-				if name == "" {
-					name = t.ID
-				}
-				out = append(out, SensorSample{
-					Name:            name,
+				add(SensorSample{
+					Name:            firstNonEmpty(t.Name, t.MemberID, t.ID),
 					Reading:         float64(t.ReadingCelsius),
+					HasReading:      true,
 					Units:           "Cel",
 					PhysicalContext: string(t.PhysicalContext),
 					Kind:            "temperature",
 				})
 			}
 			for _, f := range thermal.Fans {
-				name := f.Name
-				if name == "" {
-					name = f.MemberID
-				}
-				if name == "" {
-					name = f.ID
-				}
 				units := string(f.ReadingUnits)
 				if units == "" {
 					units = "RPM"
 				}
-				out = append(out, SensorSample{
-					Name:            name,
+				add(SensorSample{
+					Name:            firstNonEmpty(f.Name, f.MemberID, f.ID),
 					Reading:         float64(f.Reading),
+					HasReading:      true,
 					Units:           units,
 					PhysicalContext: string(f.PhysicalContext),
 					Kind:            "fan",
@@ -327,16 +366,14 @@ func (c *client) ListSensors(ctx context.Context, systemID string) ([]SensorSamp
 		}
 		if power, err := ch.Power(); err == nil && power != nil {
 			for _, v := range power.Voltages {
-				name := v.Name
-				if name == "" {
-					name = v.MemberID
+				name := firstNonEmpty(v.Name, v.MemberID, v.ID)
+				if discretePowerGood(name) {
+					continue
 				}
-				if name == "" {
-					name = v.ID
-				}
-				out = append(out, SensorSample{
+				add(SensorSample{
 					Name:            name,
 					Reading:         float64(v.ReadingVolts),
+					HasReading:      true,
 					Units:           "V",
 					PhysicalContext: string(v.PhysicalContext),
 					Kind:            "voltage",
@@ -345,4 +382,57 @@ func (c *client) ListSensors(ctx context.Context, systemID string) ([]SensorSamp
 		}
 	}
 	return out, nil
+}
+
+func sensorReporting(s *gofishredfish.Sensor) bool {
+	if s == nil {
+		return false
+	}
+	return strings.TrimSpace(string(s.Status.State)) != ""
+}
+
+func sensorUnavailableNote(s *gofishredfish.Sensor, hostOff bool) string {
+	st := ""
+	if s != nil {
+		st = strings.TrimSpace(string(s.Status.State))
+	}
+	if st != "" && !strings.EqualFold(st, "enabled") {
+		return "BMC sensor state: " + st
+	}
+	if hostOff {
+		return "No reading while host is off"
+	}
+	return "BMC did not return a reading"
+}
+
+func uniqueSensorName(seen map[string]struct{}, name, id string) string {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return strings.TrimSpace(id)
+	}
+	if _, ok := seen[strings.ToLower(name)]; !ok {
+		return name
+	}
+	id = strings.TrimSpace(id)
+	if id == "" || strings.EqualFold(id, name) {
+		return name
+	}
+	return name + " (" + id + ")"
+}
+
+func firstNonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if s := strings.TrimSpace(v); s != "" {
+			return s
+		}
+	}
+	return ""
+}
+
+// discretePowerGood is an iDRAC Power.Voltages name that is a digital
+// power-good / fault bit, not an analog rail reading.
+func discretePowerGood(name string) bool {
+	n := strings.ToLower(name)
+	return strings.Contains(n, " pg") || strings.HasSuffix(n, "pg") ||
+		strings.Contains(n, "vshort") || strings.Contains(n, "pfault")
 }

--- a/internal/common/redfish/types.go
+++ b/internal/common/redfish/types.go
@@ -77,10 +77,25 @@ type SELEntry struct {
 	LogService string // parent log service name or URI fragment
 }
 
+// FirmwareComponent is one Redfish SoftwareInventory / FirmwareInventory item.
+type FirmwareComponent struct {
+	ID           string
+	Name         string
+	Version      string
+	SoftwareID   string
+	Manufacturer string
+	ReleaseDate  string
+	Health       string
+	State        string
+	Updateable   bool
+}
+
 // SensorSample is one thermal/power sensor reading from Redfish.
 type SensorSample struct {
 	Name            string
 	Reading         float64
+	HasReading      bool   // false when Redfish omitted Reading (JSON null)
+	Note            string // why HasReading is false, for operator UI
 	Units           string
 	PhysicalContext string
 	Status          string // Health / State summary when available

--- a/internal/common/telemetry/memory.go
+++ b/internal/common/telemetry/memory.go
@@ -15,10 +15,12 @@ import (
 
 // Memory is an in-process Store for unit tests.
 type Memory struct {
-	mu      sync.RWMutex
-	events  []models.NormalizedEvent
-	sensors []SensorReading
-	jobLogs []jobLogLine
+	mu       sync.RWMutex
+	events   []models.NormalizedEvent
+	sensors  []SensorReading
+	jobLogs  []jobLogLine
+	power    map[string]PowerReading
+	firmware []FirmwareComponent
 }
 
 type jobLogLine struct {
@@ -70,6 +72,94 @@ func (m *Memory) WriteSensor(_ context.Context, r SensorReading) error {
 	defer m.mu.Unlock()
 	m.sensors = append(m.sensors, r)
 	return nil
+}
+
+// WritePower upserts the latest power state for a device.
+func (m *Memory) WritePower(_ context.Context, r PowerReading) error {
+	if r.DeviceID == "" {
+		return fmt.Errorf("telemetry: power device_id required")
+	}
+	if r.PowerState == "" {
+		return fmt.Errorf("telemetry: power_state required")
+	}
+	if r.TS.IsZero() {
+		r.TS = time.Now().UTC()
+	} else {
+		r.TS = r.TS.UTC()
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.power == nil {
+		m.power = map[string]PowerReading{}
+	}
+	m.power[r.DeviceID] = r
+	return nil
+}
+
+// WriteFirmware appends one firmware inventory row.
+func (m *Memory) WriteFirmware(_ context.Context, c FirmwareComponent) error {
+	if c.DeviceID == "" {
+		return fmt.Errorf("telemetry: firmware device_id required")
+	}
+	if c.ID == "" && c.Name == "" {
+		return fmt.Errorf("telemetry: firmware id or name required")
+	}
+	if c.TS.IsZero() {
+		c.TS = time.Now().UTC()
+	} else {
+		c.TS = c.TS.UTC()
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.firmware = append(m.firmware, c)
+	return nil
+}
+
+// LatestPower returns the last written power state (zero value if none).
+func (m *Memory) LatestPower(_ context.Context, deviceID string) (PowerReading, error) {
+	if deviceID == "" {
+		return PowerReading{}, fmt.Errorf("telemetry: device_id required")
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.power == nil {
+		return PowerReading{}, nil
+	}
+	return m.power[deviceID], nil
+}
+
+// ListFirmware returns the latest firmware snapshot for a device.
+func (m *Memory) ListFirmware(_ context.Context, deviceID string, limit int) ([]FirmwareComponent, error) {
+	if deviceID == "" {
+		return nil, fmt.Errorf("telemetry: device_id required")
+	}
+	if limit <= 0 {
+		limit = 200
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	var latest time.Time
+	for _, c := range m.firmware {
+		if c.DeviceID == deviceID && c.TS.After(latest) {
+			latest = c.TS
+		}
+	}
+	var out []FirmwareComponent
+	for _, c := range m.firmware {
+		if c.DeviceID == deviceID && c.TS.Equal(latest) {
+			out = append(out, c)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Name == out[j].Name {
+			return out[i].ID < out[j].ID
+		}
+		return out[i].Name < out[j].Name
+	})
+	if len(out) > limit {
+		out = out[:limit]
+	}
+	return out, nil
 }
 
 // WriteJobLog appends a job log line.
@@ -131,18 +221,35 @@ func (m *Memory) ListSensors(_ context.Context, deviceID string, since time.Time
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	var out []SensorReading
-	for _, r := range m.sensors {
-		if r.DeviceID != deviceID {
-			continue
+	if since.IsZero() {
+		var latest time.Time
+		for _, r := range m.sensors {
+			if r.DeviceID == deviceID && r.TS.After(latest) {
+				latest = r.TS
+			}
 		}
-		if !since.IsZero() && r.TS.Before(since) {
-			continue
+		for _, r := range m.sensors {
+			if r.DeviceID == deviceID && r.TS.Equal(latest) {
+				out = append(out, r)
+			}
 		}
-		out = append(out, r)
+		sort.Slice(out, func(i, j int) bool {
+			return out[i].Sensor < out[j].Sensor
+		})
+	} else {
+		for _, r := range m.sensors {
+			if r.DeviceID != deviceID {
+				continue
+			}
+			if r.TS.Before(since) {
+				continue
+			}
+			out = append(out, r)
+		}
+		sort.Slice(out, func(i, j int) bool {
+			return out[i].TS.After(out[j].TS)
+		})
 	}
-	sort.Slice(out, func(i, j int) bool {
-		return out[i].TS.After(out[j].TS)
-	})
 	if len(out) > limit {
 		out = out[:limit]
 	}

--- a/internal/common/telemetry/postgres.go
+++ b/internal/common/telemetry/postgres.go
@@ -62,14 +62,117 @@ func (p *Postgres) WriteSensor(ctx context.Context, r SensorReading) error {
 		r.TS = r.TS.UTC()
 	}
 	_, err := p.db.ExecContext(ctx, `
-INSERT INTO sensor_readings (device_id, ts, sensor, value, unit)
-VALUES ($1,$2,$3,$4,$5)`,
-		r.DeviceID, r.TS, r.Sensor, r.Value, nullStr(r.Unit),
+INSERT INTO sensor_readings (device_id, ts, sensor, value, unit, note)
+VALUES ($1,$2,$3,$4,$5,$6)`,
+		r.DeviceID, r.TS, r.Sensor, nullFloat(r.Value), nullStr(r.Unit), nullStr(r.Note),
 	)
 	if err != nil {
 		return fmt.Errorf("telemetry: write sensor: %w", err)
 	}
 	return nil
+}
+
+// WritePower upserts the latest power state for a device.
+func (p *Postgres) WritePower(ctx context.Context, r PowerReading) error {
+	if r.DeviceID == "" {
+		return fmt.Errorf("telemetry: power device_id required")
+	}
+	if r.PowerState == "" {
+		return fmt.Errorf("telemetry: power_state required")
+	}
+	if r.TS.IsZero() {
+		r.TS = time.Now().UTC()
+	} else {
+		r.TS = r.TS.UTC()
+	}
+	_, err := p.db.ExecContext(ctx, `
+INSERT INTO device_power (device_id, ts, power_state)
+VALUES ($1,$2,$3)
+ON CONFLICT (device_id) DO UPDATE SET ts = EXCLUDED.ts, power_state = EXCLUDED.power_state`,
+		r.DeviceID, r.TS, r.PowerState)
+	if err != nil {
+		return fmt.Errorf("telemetry: write power: %w", err)
+	}
+	return nil
+}
+
+// WriteFirmware inserts one firmware_inventory row.
+func (p *Postgres) WriteFirmware(ctx context.Context, c FirmwareComponent) error {
+	if c.DeviceID == "" {
+		return fmt.Errorf("telemetry: firmware device_id required")
+	}
+	if c.ID == "" && c.Name == "" {
+		return fmt.Errorf("telemetry: firmware id or name required")
+	}
+	if c.TS.IsZero() {
+		c.TS = time.Now().UTC()
+	} else {
+		c.TS = c.TS.UTC()
+	}
+	_, err := p.db.ExecContext(ctx, `
+INSERT INTO firmware_inventory (device_id, ts, component_id, name, version, manufacturer, software_id, health, updateable, release_date)
+VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)`,
+		c.DeviceID, c.TS, c.ID, nullStr(c.Name), nullStr(c.Version), nullStr(c.Manufacturer),
+		nullStr(c.SoftwareID), nullStr(c.Health), c.Updateable, nullStr(c.ReleaseDate))
+	if err != nil {
+		return fmt.Errorf("telemetry: write firmware: %w", err)
+	}
+	return nil
+}
+
+// LatestPower returns the last polled power state (zero value if none).
+func (p *Postgres) LatestPower(ctx context.Context, deviceID string) (PowerReading, error) {
+	if deviceID == "" {
+		return PowerReading{}, fmt.Errorf("telemetry: device_id required")
+	}
+	var r PowerReading
+	err := p.db.QueryRowContext(ctx, `
+SELECT device_id, ts, power_state FROM device_power WHERE device_id = $1`, deviceID).
+		Scan(&r.DeviceID, &r.TS, &r.PowerState)
+	if err == sql.ErrNoRows {
+		return PowerReading{}, nil
+	}
+	if err != nil {
+		return PowerReading{}, fmt.Errorf("telemetry: latest power: %w", err)
+	}
+	return r, nil
+}
+
+// ListFirmware returns the latest firmware snapshot for a device.
+func (p *Postgres) ListFirmware(ctx context.Context, deviceID string, limit int) ([]FirmwareComponent, error) {
+	if deviceID == "" {
+		return nil, fmt.Errorf("telemetry: device_id required")
+	}
+	if limit <= 0 {
+		limit = 200
+	}
+	rows, err := p.db.QueryContext(ctx, `
+SELECT device_id, ts, component_id, name, version, manufacturer, software_id, health, updateable, release_date
+FROM firmware_inventory
+WHERE device_id = $1
+  AND ts = (SELECT MAX(ts) FROM firmware_inventory WHERE device_id = $1)
+ORDER BY name, component_id
+LIMIT $2`, deviceID, limit)
+	if err != nil {
+		return nil, fmt.Errorf("telemetry: list firmware: %w", err)
+	}
+	defer rows.Close()
+	var out []FirmwareComponent
+	for rows.Next() {
+		var c FirmwareComponent
+		var name, ver, mfg, sid, health, rel sql.NullString
+		if err := rows.Scan(&c.DeviceID, &c.TS, &c.ID, &name, &ver, &mfg, &sid, &health, &c.Updateable, &rel); err != nil {
+			return nil, fmt.Errorf("telemetry: scan firmware: %w", err)
+		}
+		c.Name = name.String
+		c.Version = ver.String
+		c.Manufacturer = mfg.String
+		c.SoftwareID = sid.String
+		c.Health = health.String
+		c.ReleaseDate = rel.String
+		out = append(out, c)
+	}
+	return out, rows.Err()
 }
 
 // WriteJobLog inserts one job_log row.
@@ -152,12 +255,15 @@ func (p *Postgres) ListSensors(ctx context.Context, deviceID string, since time.
 	)
 	if since.IsZero() {
 		rows, err = p.db.QueryContext(ctx, `
-SELECT device_id, ts, sensor, value, unit
-FROM sensor_readings WHERE device_id = $1
-ORDER BY ts DESC LIMIT $2`, deviceID, limit)
+SELECT device_id, ts, sensor, value, unit, note
+FROM sensor_readings
+WHERE device_id = $1
+  AND ts = (SELECT MAX(ts) FROM sensor_readings WHERE device_id = $1)
+ORDER BY sensor
+LIMIT $2`, deviceID, limit)
 	} else {
 		rows, err = p.db.QueryContext(ctx, `
-SELECT device_id, ts, sensor, value, unit
+SELECT device_id, ts, sensor, value, unit, note
 FROM sensor_readings WHERE device_id = $1 AND ts >= $2
 ORDER BY ts DESC LIMIT $3`, deviceID, since.UTC(), limit)
 	}
@@ -169,15 +275,17 @@ ORDER BY ts DESC LIMIT $3`, deviceID, since.UTC(), limit)
 	var out []SensorReading
 	for rows.Next() {
 		var r SensorReading
-		var unit sql.NullString
+		var unit, note sql.NullString
 		var val sql.NullFloat64
-		if err := rows.Scan(&r.DeviceID, &r.TS, &r.Sensor, &val, &unit); err != nil {
+		if err := rows.Scan(&r.DeviceID, &r.TS, &r.Sensor, &val, &unit, &note); err != nil {
 			return nil, fmt.Errorf("telemetry: scan sensor: %w", err)
 		}
 		if val.Valid {
-			r.Value = val.Float64
+			v := val.Float64
+			r.Value = &v
 		}
 		r.Unit = unit.String
+		r.Note = note.String
 		out = append(out, r)
 	}
 	return out, rows.Err()
@@ -227,6 +335,13 @@ func nullStr(s string) any {
 		return nil
 	}
 	return s
+}
+
+func nullFloat(v *float64) any {
+	if v == nil {
+		return nil
+	}
+	return *v
 }
 
 func newEventID() string {

--- a/internal/common/telemetry/postgres_integration_test.go
+++ b/internal/common/telemetry/postgres_integration_test.go
@@ -45,7 +45,7 @@ func TestLabPostgresStoreWriteList(t *testing.T) {
 		DeviceID: device,
 		TS:       ts,
 		Sensor:   "probe-temp",
-		Value:    21.5,
+		Value:    telemetry.SensorValue(21.5),
 		Unit:     "Cel",
 	}); err != nil {
 		t.Fatalf("write sensor: %v", err)
@@ -69,7 +69,7 @@ func TestLabPostgresStoreWriteList(t *testing.T) {
 	if err != nil {
 		t.Fatalf("list sensors: %v", err)
 	}
-	if len(sens) == 0 || sens[0].Value != 21.5 {
+	if len(sens) == 0 || sens[0].Value == nil || *sens[0].Value != 21.5 {
 		t.Fatalf("sensors: %+v", sens)
 	}
 

--- a/internal/common/telemetry/schema.sql
+++ b/internal/common/telemetry/schema.sql
@@ -48,13 +48,35 @@ CREATE TABLE IF NOT EXISTS sensor_readings (
   unit TEXT
 );
 
+ALTER TABLE sensor_readings ADD COLUMN IF NOT EXISTS note TEXT;
+
 CREATE TABLE IF NOT EXISTS job_log (
   job_id TEXT NOT NULL,
   ts TIMESTAMPTZ NOT NULL,
   line TEXT NOT NULL
 );
 
+CREATE TABLE IF NOT EXISTS device_power (
+  device_id TEXT PRIMARY KEY,
+  ts TIMESTAMPTZ NOT NULL,
+  power_state TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS firmware_inventory (
+  device_id TEXT NOT NULL,
+  ts TIMESTAMPTZ NOT NULL,
+  component_id TEXT NOT NULL,
+  name TEXT,
+  version TEXT,
+  manufacturer TEXT,
+  software_id TEXT,
+  health TEXT,
+  updateable BOOLEAN,
+  release_date TEXT
+);
+
 CREATE INDEX IF NOT EXISTS jobs_state_idx ON jobs (state);
 CREATE INDEX IF NOT EXISTS jobs_device_idx ON jobs (device_id);
 CREATE INDEX IF NOT EXISTS events_device_ts_idx ON events (device_id, ts);
 CREATE INDEX IF NOT EXISTS job_log_job_ts_idx ON job_log (job_id, ts);
+CREATE INDEX IF NOT EXISTS firmware_inventory_device_ts_idx ON firmware_inventory (device_id, ts);

--- a/internal/common/telemetry/store.go
+++ b/internal/common/telemetry/store.go
@@ -13,9 +13,14 @@ type SensorReading struct {
 	DeviceID string    `json:"device_id"`
 	TS       time.Time `json:"ts"`
 	Sensor   string    `json:"sensor"`
-	Value    float64   `json:"value"`
-	Unit     string    `json:"unit,omitempty"`
+	// Value is nil when the BMC listed the sensor but did not return a reading.
+	Value *float64 `json:"value"`
+	Unit  string   `json:"unit,omitempty"`
+	Note  string   `json:"note,omitempty"`
 }
+
+// SensorValue is a helper for tests and call sites with a known numeric reading.
+func SensorValue(v float64) *float64 { return &v }
 
 // JobLogLine is one durable job_log row.
 type JobLogLine struct {
@@ -24,13 +29,42 @@ type JobLogLine struct {
 	Line  string    `json:"line"`
 }
 
+// PowerReading is the latest polled host power state for a device.
+type PowerReading struct {
+	DeviceID   string    `json:"device_id"`
+	TS         time.Time `json:"ts"`
+	PowerState string    `json:"power_state"`
+}
+
+// FirmwareComponent is one firmware inventory row from a poll snapshot.
+type FirmwareComponent struct {
+	DeviceID     string    `json:"device_id"`
+	TS           time.Time `json:"ts"`
+	ID           string    `json:"id"`
+	Name         string    `json:"name,omitempty"`
+	Version      string    `json:"version,omitempty"`
+	Manufacturer string    `json:"manufacturer,omitempty"`
+	SoftwareID   string    `json:"software_id,omitempty"`
+	Health       string    `json:"health,omitempty"`
+	Updateable   bool      `json:"updateable"`
+	ReleaseDate  string    `json:"release_date,omitempty"`
+}
+
 // Store is the durable telemetry surface (events, sensors, job log lines).
 // Job rows live in deploy/jobstore on the same DB.
 type Store interface {
 	WriteEvent(ctx context.Context, e models.NormalizedEvent) error
 	WriteSensor(ctx context.Context, r SensorReading) error
 	WriteJobLog(ctx context.Context, jobID string, ts time.Time, line string) error
+	WritePower(ctx context.Context, r PowerReading) error
+	WriteFirmware(ctx context.Context, c FirmwareComponent) error
+	LatestPower(ctx context.Context, deviceID string) (PowerReading, error)
+	ListFirmware(ctx context.Context, deviceID string, limit int) ([]FirmwareComponent, error)
 	ListEvents(ctx context.Context, deviceID string, since time.Time, limit int) ([]models.NormalizedEvent, error)
+	// ListSensors returns sensor rows for a device. When since is zero it is the
+	// latest poll snapshot (all readings that share the device's max ts), so a
+	// UI tab does not mix in older rails from previous polls. When since is set,
+	// it is a newest-first time series at or after that instant.
 	ListSensors(ctx context.Context, deviceID string, since time.Time, limit int) ([]SensorReading, error)
 	// ListJobLog returns job_log lines oldest-first (a log reads chronologically,
 	// unlike events/sensors which are newest-first "recent activity" feeds).

--- a/internal/common/telemetry/store_test.go
+++ b/internal/common/telemetry/store_test.go
@@ -76,7 +76,7 @@ func TestMemorySensorsAndJobLog(t *testing.T) {
 	ctx := context.Background()
 	ts := time.Now().UTC()
 	if err := st.WriteSensor(ctx, telemetry.SensorReading{
-		DeviceID: "d1", TS: ts, Sensor: "Inlet Temp", Value: 24.5, Unit: "Cel",
+		DeviceID: "d1", TS: ts, Sensor: "Inlet Temp", Value: telemetry.SensorValue(24.5), Unit: "Cel",
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -87,8 +87,43 @@ func TestMemorySensorsAndJobLog(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(sensors) != 1 || sensors[0].Value != 24.5 {
+	if len(sensors) != 1 || sensors[0].Value == nil || *sensors[0].Value != 24.5 {
 		t.Fatalf("%+v", sensors)
+	}
+	old := ts.Add(-time.Minute)
+	if err := st.WriteSensor(ctx, telemetry.SensorReading{
+		DeviceID: "d1", TS: old, Sensor: "CPU1 VCCIN PG", Value: telemetry.SensorValue(0), Unit: "V",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.WriteSensor(ctx, telemetry.SensorReading{
+		DeviceID: "d1", TS: ts, Sensor: "Pwr Consumption", Value: telemetry.SensorValue(30), Unit: "W",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	snap, err := st.ListSensors(ctx, "d1", time.Time{}, 50)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(snap) != 2 {
+		t.Fatalf("snapshot want 2 latest-poll rows, got %+v", snap)
+	}
+	for _, r := range snap {
+		if r.Sensor == "CPU1 VCCIN PG" {
+			t.Fatalf("stale PG rail in snapshot: %+v", snap)
+		}
+	}
+	if err := st.WriteSensor(ctx, telemetry.SensorReading{
+		DeviceID: "d2", TS: ts, Sensor: "CPU1 Temp", Note: "No reading while host is off",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	absent, err := st.ListSensors(ctx, "d2", time.Time{}, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(absent) != 1 || absent[0].Value != nil || absent[0].Note == "" {
+		t.Fatalf("absent reading: %+v", absent)
 	}
 	if st.JobLogCount("job-1") != 1 {
 		t.Fatal("job log")
@@ -134,6 +169,35 @@ func TestMemoryListJobLog(t *testing.T) {
 	}
 	if len(capped) != 1 || capped[0].Line != "first" {
 		t.Fatalf("limit: %+v", capped)
+	}
+}
+
+func TestMemoryFirmwareAndPower(t *testing.T) {
+	st := telemetry.NewMemory()
+	ctx := context.Background()
+	ts := time.Now().UTC()
+	if err := st.WriteFirmware(ctx, telemetry.FirmwareComponent{
+		DeviceID: "d1", TS: ts, ID: "BIOS", Name: "BIOS", Version: "1.0",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.WritePower(ctx, telemetry.PowerReading{DeviceID: "d1", TS: ts, PowerState: "On"}); err != nil {
+		t.Fatal(err)
+	}
+	fw, err := st.ListFirmware(ctx, "d1", 10)
+	if err != nil || len(fw) != 1 || fw[0].Version != "1.0" {
+		t.Fatalf("%v %+v", err, fw)
+	}
+	pw, err := st.LatestPower(ctx, "d1")
+	if err != nil || pw.PowerState != "On" {
+		t.Fatalf("%v %+v", err, pw)
+	}
+	if err := st.WritePower(ctx, telemetry.PowerReading{DeviceID: "d1", TS: ts.Add(time.Second), PowerState: "Off"}); err != nil {
+		t.Fatal(err)
+	}
+	pw, _ = st.LatestPower(ctx, "d1")
+	if pw.PowerState != "Off" {
+		t.Fatalf("upsert %+v", pw)
 	}
 }
 

--- a/internal/common/validate/validate.go
+++ b/internal/common/validate/validate.go
@@ -402,3 +402,42 @@ func CancelJobRequest(r models.CancelJobRequest) error {
 	}
 	return nil
 }
+
+// DevicePowerResetTypes is the operator allow-list for POST /v1/devices/{id}/power.
+var DevicePowerResetTypes = map[string]struct{}{
+	"On":               {},
+	"ForceOff":         {},
+	"ForceRestart":     {},
+	"GracefulRestart":  {},
+	"GracefulShutdown": {},
+}
+
+// DeviceCredentials requires a username. Password may be empty (keep existing).
+func DeviceCredentials(username, password string) error {
+	_ = password
+	if strings.TrimSpace(username) == "" {
+		return fmt.Errorf("validate: username is required")
+	}
+	return nil
+}
+
+// DevicePoll checks a BMC endpoint for on-demand SEL/sensor poll.
+func DevicePoll(bmcEndpoint string) error {
+	if strings.TrimSpace(bmcEndpoint) == "" {
+		return fmt.Errorf("validate: bmc_endpoint is required")
+	}
+	return nil
+}
+
+// DevicePower checks reset_type and BMC endpoint. Username/password may be empty
+// (Shoal env defaults). Never inspects password contents.
+func DevicePower(resetType, bmcEndpoint string) error {
+	if strings.TrimSpace(bmcEndpoint) == "" {
+		return fmt.Errorf("validate: bmc_endpoint is required")
+	}
+	rt := strings.TrimSpace(resetType)
+	if _, ok := DevicePowerResetTypes[rt]; !ok {
+		return fmt.Errorf("validate: reset_type must be one of On, ForceOff, ForceRestart, GracefulRestart, GracefulShutdown")
+	}
+	return nil
+}

--- a/internal/common/validate/validate_test.go
+++ b/internal/common/validate/validate_test.go
@@ -226,3 +226,36 @@ func TestStartJobRequest(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestDeviceCredentials(t *testing.T) {
+	if err := validate.DeviceCredentials("root", "x"); err != nil {
+		t.Fatal(err)
+	}
+	if err := validate.DeviceCredentials("root", ""); err != nil {
+		t.Fatal(err)
+	}
+	if err := validate.DeviceCredentials("", "x"); err == nil {
+		t.Fatal("expected username required")
+	}
+}
+
+func TestDevicePoll(t *testing.T) {
+	if err := validate.DevicePoll("https://bmc"); err != nil {
+		t.Fatal(err)
+	}
+	if err := validate.DevicePoll(""); err == nil {
+		t.Fatal("expected missing endpoint")
+	}
+}
+
+func TestDevicePower(t *testing.T) {
+	if err := validate.DevicePower("On", "https://bmc"); err != nil {
+		t.Fatal(err)
+	}
+	if err := validate.DevicePower("Explode", "https://bmc"); err == nil {
+		t.Fatal("expected bad reset_type")
+	}
+	if err := validate.DevicePower("On", ""); err == nil {
+		t.Fatal("expected missing endpoint")
+	}
+}

--- a/internal/deploy/job/orchestrator.go
+++ b/internal/deploy/job/orchestrator.go
@@ -19,6 +19,7 @@ import (
 	"github.com/mattcburns/shoal/internal/common/netbox"
 	"github.com/mattcburns/shoal/internal/common/redfish"
 	"github.com/mattcburns/shoal/internal/common/secrets"
+	"github.com/mattcburns/shoal/internal/common/telemetry"
 	"github.com/mattcburns/shoal/internal/common/validate"
 	"github.com/mattcburns/shoal/internal/common/watchport"
 	"github.com/mattcburns/shoal/internal/core/profile"
@@ -58,6 +59,8 @@ type Orchestrator struct {
 	newBMC                 redfish.Factory
 	watches                watchport.WatchRegistrar
 	netbox                 netbox.LifecycleWriter // optional; identity lifecycle only
+	resolver               netbox.DeviceResolver  // optional; remap name/serial → NetBox pk
+	telemetry              telemetry.Store        // optional; durable job_log from SOL markers
 	profiles               profile.Store          // optional; Phase 5b approval gate
 	isoBaseURL             string                 // Phase 5c: resolve profile iso_base → URL
 	isoBuilder             iso.Builder            // optional Phase 6a dynamic build
@@ -68,6 +71,10 @@ type Orchestrator struct {
 	caFile                 string
 	failOrphan             bool
 	defaultSerialTransport string
+	// defaultBMCUser/Pass fill Start when the request omits credentials (lab +
+	// NetBox plugin start without shipping passwords through the UI).
+	defaultBMCUser string
+	defaultBMCPass string
 
 	mu       sync.Mutex
 	running  map[string]*runState // jobID -> state
@@ -116,17 +123,23 @@ type terminalEvent struct {
 
 // Options configures the Orchestrator.
 type Options struct {
-	Log                 *slog.Logger
-	Store               jobstore.Store
-	Secrets             secrets.Backend
-	NewBMC              redfish.Factory
-	Watches             watchport.WatchRegistrar
-	NetBox              netbox.LifecycleWriter // optional Phase 5 lifecycle sync
-	Profiles            profile.Store          // optional Phase 5b profile load/approval
-	ISOBaseURL          string                 // optional Phase 5c profile → ISO URL resolve
-	ISOBuilder          iso.Builder            // optional Phase 6a dynamic build
-	ISOPublishDir       string                 // publish dir for dynamic build
-	ISODynamic          bool                   // build when ISOURL empty (needs builder+publish+base)
+	Log     *slog.Logger
+	Store   jobstore.Store
+	Secrets secrets.Backend
+	NewBMC  redfish.Factory
+	Watches watchport.WatchRegistrar
+	NetBox  netbox.LifecycleWriter // optional Phase 5 lifecycle sync
+	// DeviceResolver remaps device_id (name/serial → NetBox pk) at Start.
+	// When nil and NetBox implements DeviceResolver, NetBox is used.
+	DeviceResolver netbox.DeviceResolver
+	// Telemetry is optional; when set, SOL markers are appended to job_log
+	// for GET /v1/jobs/{id}/log and the NetBox Jobs tab.
+	Telemetry           telemetry.Store
+	Profiles            profile.Store // optional Phase 5b profile load/approval
+	ISOBaseURL          string        // optional Phase 5c profile → ISO URL resolve
+	ISOBuilder          iso.Builder   // optional Phase 6a dynamic build
+	ISOPublishDir       string        // publish dir for dynamic build
+	ISODynamic          bool          // build when ISOURL empty (needs builder+publish+base)
 	AuthMode            string
 	TLSMode             string
 	CAFile              string
@@ -135,6 +148,10 @@ type Options struct {
 	// ("libvirt" | "redfish_sol") used when StartJobRequest.SerialTransport is
 	// empty. Empty here means "libvirt" (unchanged behavior).
 	DefaultSerialTransport string
+	// DefaultBMCUsername/Password fill empty Start credentials from env
+	// (SHOAL_BMC_*), so NetBox start-job need not post passwords.
+	DefaultBMCUsername string
+	DefaultBMCPassword string
 }
 
 // NewOrchestrator constructs an Orchestrator and starts the terminal worker.
@@ -154,6 +171,12 @@ func NewOrchestrator(opts Options) *Orchestrator {
 	if tlsMode == "" {
 		tlsMode = "off"
 	}
+	resolver := opts.DeviceResolver
+	if resolver == nil {
+		if r, ok := opts.NetBox.(netbox.DeviceResolver); ok {
+			resolver = r
+		}
+	}
 	o := &Orchestrator{
 		log:                    log,
 		store:                  opts.Store,
@@ -161,6 +184,8 @@ func NewOrchestrator(opts Options) *Orchestrator {
 		newBMC:                 opts.NewBMC,
 		watches:                opts.Watches,
 		netbox:                 opts.NetBox,
+		resolver:               resolver,
+		telemetry:              opts.Telemetry,
 		profiles:               opts.Profiles,
 		isoBaseURL:             opts.ISOBaseURL,
 		isoBuilder:             opts.ISOBuilder,
@@ -171,6 +196,8 @@ func NewOrchestrator(opts Options) *Orchestrator {
 		caFile:                 opts.CAFile,
 		failOrphan:             opts.ReconcileFailOrphan, // composition root passes config default true
 		defaultSerialTransport: opts.DefaultSerialTransport,
+		defaultBMCUser:         opts.DefaultBMCUsername,
+		defaultBMCPass:         opts.DefaultBMCPassword,
 		running:                make(map[string]*runState),
 		terminal:               make(chan terminalEvent, 64),
 		stopCh:                 make(chan struct{}),
@@ -197,11 +224,24 @@ func (o *Orchestrator) terminalLoop() {
 		case <-o.stopCh:
 			return
 		case ev := <-o.terminal:
-			ctx, cancel := context.WithTimeout(context.Background(), TerminalWorkerTimeout)
-			if err := o.HandleTerminal(ctx, ev.jobID, ev.reason); err != nil {
-				o.log.Error("HandleTerminal failed", "job_id", ev.jobID, "reason", string(ev.reason), "err", err.Error())
-			}
-			cancel()
+			// A panic in terminal handling must not kill the whole process
+			// (Compose would restart and orphan-fail an otherwise-successful job).
+			func() {
+				defer func() {
+					if r := recover(); r != nil {
+						o.log.Error("HandleTerminal panic recovered",
+							"job_id", ev.jobID,
+							"reason", string(ev.reason),
+							"recover", fmt.Sprint(r),
+						)
+					}
+				}()
+				ctx, cancel := context.WithTimeout(context.Background(), TerminalWorkerTimeout)
+				defer cancel()
+				if err := o.HandleTerminal(ctx, ev.jobID, ev.reason); err != nil {
+					o.log.Error("HandleTerminal failed", "job_id", ev.jobID, "reason", string(ev.reason), "err", err.Error())
+				}
+			}()
 		}
 	}
 }
@@ -228,6 +268,8 @@ func (o *Orchestrator) Get(ctx context.Context, jobID string) (models.Provisioni
 // M6: non-spike profiles fill empty strategy/prep/seed/family/media fields before validate.
 // When ISOURL is empty, media_url / iso_base resolve via SHOAL_ISO_BASE_URL (Phase 5c).
 // Optional BuildISO / SHOAL_ISO_DYNAMIC builds and publishes a live image first (Phase 6a).
+// When a DeviceResolver is available (NetBox), device_id is remapped from name/serial
+// to the NetBox numeric primary key so plugin tabs and telemetry share one key.
 func (o *Orchestrator) Start(ctx context.Context, req models.StartJobRequest) (models.ProvisioningJob, error) {
 	if o.watches == nil {
 		return models.ProvisioningJob{}, fmt.Errorf("job: watch registrar not configured")
@@ -238,6 +280,11 @@ func (o *Orchestrator) Start(ctx context.Context, req models.StartJobRequest) (m
 		profileRef = "spike"
 	}
 	req.ProfileRef = profileRef
+
+	if err := o.resolveDeviceID(ctx, &req); err != nil {
+		return models.ProvisioningJob{}, err
+	}
+	o.applyDefaultCredentials(&req)
 
 	// M6: apply profile defaults before validation so profile-only starts work.
 	var prof models.ProvisioningProfile
@@ -426,13 +473,19 @@ func (o *Orchestrator) startStage(ctx context.Context, job models.ProvisioningJo
 	}
 	defer func() { _ = bmc.Close(context.Background()) }()
 
+	// Prefer explicit SystemID, then serial target / name (lab multi-system sushy),
+	// then device_id. After NetBox resolve, device_id is a numeric pk and is a
+	// poor Redfish system key — serial_target (shoal-node-1) still matches Name.
 	lookup := req.SystemID
+	if lookup == "" {
+		lookup = req.SerialTarget
+	}
 	if lookup == "" {
 		lookup = req.DeviceID
 	}
 	sys, err := bmc.GetSystem(ctx, lookup)
 	if err != nil {
-		if req.SystemID == "" && req.DeviceID != "" {
+		if req.SystemID == "" {
 			sys, err = bmc.GetSystem(ctx, "")
 		}
 		if err != nil {
@@ -976,18 +1029,23 @@ func (o *Orchestrator) handleTerminalOnce(ctx context.Context, jobID string, rea
 	var errMsg string
 	switch reason {
 	case ReasonDoneOK:
+		// SOL DONE means the install path succeeded. Cleanup remains mandatory
+		// best-effort, but must not reverse success: process crash, sushy tray
+		// removal, or post-restart secret loss must not mark a finished install failed.
 		to = models.StateProvisioned
 		errMsg = ""
-		// Phase 5: DONE post-check — cleanup must have left media/boot clear.
 		if cleanupErr != nil {
-			to = models.StateFailed
-			errMsg = "post-check: bmc cleanup incomplete: " + cleanupErr.Error()
-			o.log.Warn("DONE post-check failed", "job_id", jobID, "err", cleanupErr.Error())
-		} else if bmcURL != "" {
+			if cleanupAlreadyClean(cleanupErr) {
+				o.log.Info("DONE cleanup treated as already clean", "job_id", jobID, "err", cleanupErr.Error())
+			} else {
+				o.log.Error("DONE cleanup incomplete (job still provisioned)",
+					"job_id", jobID, "err", cleanupErr.Error())
+			}
+		}
+		if bmcURL != "" {
 			if err := o.postCheckClean(context.Background(), bmcURL, credRef, systemID); err != nil {
-				to = models.StateFailed
-				errMsg = "post-check: " + err.Error()
-				o.log.Warn("DONE post-check failed", "job_id", jobID, "err", err.Error())
+				o.log.Warn("DONE post-check warning (job still provisioned)",
+					"job_id", jobID, "err", err.Error())
 			}
 		}
 	case ReasonCancel:
@@ -1048,6 +1106,18 @@ func (o *Orchestrator) handleTerminalOnce(ctx context.Context, jobID string, rea
 	return nil
 }
 
+// cleanupAlreadyClean reports cleanup errors that mean "nothing left to eject"
+// (common on sushy after eject removes the CD device).
+func cleanupAlreadyClean(err error) bool {
+	if err == nil {
+		return true
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "no virtual media") ||
+		strings.Contains(msg, "no cd") ||
+		(strings.Contains(msg, "not found") && strings.Contains(msg, "media"))
+}
+
 // postCheckClean verifies media ejected and boot override cleared after cleanup.
 func (o *Orchestrator) postCheckClean(ctx context.Context, bmcURL, credRef, systemID string) error {
 	user, pass := "", ""
@@ -1069,8 +1139,13 @@ func (o *Orchestrator) postCheckClean(ctx context.Context, bmcURL, credRef, syst
 	defer func() { _ = bmc.Close(context.Background()) }()
 	vms, err := bmc.ListVirtualMedia(ctx, systemID)
 	if err != nil {
+		// Empty/missing media inventory after sushy eject is already-clean.
+		if cleanupAlreadyClean(err) {
+			return nil
+		}
 		return fmt.Errorf("list media post-check: %w", err)
 	}
+	// No slots left ⇒ nothing inserted (lab fidelity after eject).
 	for _, vm := range vms {
 		if vm.Inserted {
 			return fmt.Errorf("virtual media still inserted (%s)", vm.URI)
@@ -1153,6 +1228,9 @@ func (o *Orchestrator) probeCDCount(ctx context.Context, req models.StartJobRequ
 	}
 	defer func() { _ = bmc.Close(context.Background()) }()
 	lookup := req.SystemID
+	if lookup == "" {
+		lookup = req.SerialTarget
+	}
 	if lookup == "" {
 		lookup = req.DeviceID
 	}
@@ -1357,9 +1435,11 @@ func (o *Orchestrator) cleanupBMC(ctx context.Context, bmcURL, credRef, systemID
 	}
 }
 
-// ReconcileOrphans fails in-flight PROVISIONING jobs left from a previous process.
-// Default policy (failOrphan=true): cleanup + FAILED for each.
-// Re-attach SOL is deferred (MVP: fail orphans is the safe default).
+// ReconcileOrphans finishes in-flight PROVISIONING jobs left from a previous process.
+// Default policy (failOrphan=true): cleanup + terminal state for each.
+// Jobs that already recorded a successful DONE marker (phase DONE / 100%) are
+// completed as done_ok so a crash mid-cleanup does not erase a successful install.
+// Other orphans fail (re-attach SOL is deferred; fail is the safe default).
 func (o *Orchestrator) ReconcileOrphans(ctx context.Context) error {
 	jobs, err := o.store.ListByState(ctx, models.StateProvisioning)
 	if err != nil {
@@ -1373,9 +1453,19 @@ func (o *Orchestrator) ReconcileOrphans(ctx context.Context) error {
 			)
 			continue
 		}
+		reason := ReasonBMC
+		decision := "fail_orphan"
+		why := "unrecoverable_after_restart"
+		if orphanLooksSuccessfullyComplete(j) {
+			// Process died after SOL DONE but before lifecycle commit — honor success.
+			reason = ReasonDoneOK
+			decision = "complete_orphan_done"
+			why = "phase_done_after_restart"
+		}
 		o.log.Warn("reconciling orphan job",
 			"job_id", j.ID, "device_id", j.DeviceID,
-			"decision", "fail_orphan", "reason", "unrecoverable_after_restart",
+			"decision", decision, "reason", why,
+			"phase", j.Phase, "percent", percentLog(j.Percent),
 		)
 		// Seed runState from durable job fields for cleanup coordinates.
 		o.mu.Lock()
@@ -1388,11 +1478,36 @@ func (o *Orchestrator) ReconcileOrphans(ctx context.Context) error {
 			}
 		}
 		o.mu.Unlock()
-		if err := o.HandleTerminal(ctx, j.ID, ReasonBMC); err != nil {
+		if err := o.HandleTerminal(ctx, j.ID, reason); err != nil {
 			o.log.Error("orphan reconcile failed", "job_id", j.ID, "err", err.Error())
 		}
 	}
 	return nil
+}
+
+// orphanLooksSuccessfullyComplete reports whether a still-PROVISIONING job row
+// already reflects a successful install (DONE marker applied) so restart should
+// not fail the job.
+func orphanLooksSuccessfullyComplete(j models.ProvisioningJob) bool {
+	if strings.EqualFold(strings.TrimSpace(j.Phase), "DONE") {
+		return true
+	}
+	if j.Percent != nil && *j.Percent >= 100 && j.LastMarkerSeq > 0 {
+		// Percent 100 alone can appear mid-stage; require a marker seq and
+		// a success-shaped phase when not exactly DONE.
+		switch strings.ToUpper(strings.TrimSpace(j.Phase)) {
+		case "DONE", "VERIFY", "COMPLETE", "FINISHED":
+			return true
+		}
+	}
+	return false
+}
+
+func percentLog(p *int) any {
+	if p == nil {
+		return nil
+	}
+	return *p
 }
 
 func (o *Orchestrator) enqueueTerminal(jobID string, reason TerminalReason) {
@@ -1446,6 +1561,7 @@ func (p *progressAdapter) ApplyMarker(ctx context.Context, jobID string, m model
 	if err := p.orch.store.UpdateProgress(ctx, jobID, phase, m.Percent, m.Seq, soft); err != nil {
 		return err
 	}
+	p.orch.appendJobLog(ctx, jobID, m)
 	// Best-effort stage phase mirror.
 	if j, err := p.orch.store.Get(ctx, jobID); err == nil && j.CurrentStage != "" && len(j.Stages) > 0 {
 		stages := setStageState(j.Stages, j.CurrentStage, models.JobStageStateRunning, phase, soft)
@@ -1484,6 +1600,13 @@ func (p *progressAdapter) ReportStall(ctx context.Context, jobID string, reason 
 		return nil
 	}
 	_ = p.orch.store.UpdateProgress(ctx, jobID, "STALL", nil, 0, reason)
+	p.orch.appendJobLog(ctx, jobID, models.SOLMarker{
+		SchemaVer: sol.SchemaVersion,
+		Timestamp: time.Now().UTC(),
+		Phase:     "STALL",
+		State:     "ERROR",
+		Detail:    reason,
+	})
 	p.orch.enqueueTerminal(jobID, ReasonStall)
 	return nil
 }
@@ -1520,6 +1643,13 @@ func (p *progressAdapter) ReportTransportError(ctx context.Context, jobID string
 		msg = err.Error()
 	}
 	_ = p.orch.store.UpdateProgress(ctx, jobID, "TRANSPORT", nil, 0, msg)
+	p.orch.appendJobLog(ctx, jobID, models.SOLMarker{
+		SchemaVer: sol.SchemaVersion,
+		Timestamp: time.Now().UTC(),
+		Phase:     "TRANSPORT",
+		State:     "ERROR",
+		Detail:    msg,
+	})
 	p.orch.enqueueTerminal(jobID, ReasonTransport)
 	return nil
 }
@@ -1530,6 +1660,61 @@ func (p *progressAdapter) stillProvisioning(ctx context.Context, jobID string) b
 		return true // fail open so real errors still surface
 	}
 	return j.State == models.StateProvisioning
+}
+
+// applyDefaultCredentials fills empty username/password from orchestrator defaults
+// (composition root wires SHOAL_BMC_*). Does not override credential_ref-only starts.
+func (o *Orchestrator) applyDefaultCredentials(req *models.StartJobRequest) {
+	if strings.TrimSpace(req.CredentialRef) != "" {
+		return
+	}
+	if strings.TrimSpace(req.BMCUsername) == "" && o.defaultBMCUser != "" {
+		req.BMCUsername = o.defaultBMCUser
+	}
+	if strings.TrimSpace(req.BMCPassword) == "" && o.defaultBMCPass != "" {
+		req.BMCPassword = o.defaultBMCPass
+	}
+}
+
+// resolveDeviceID remaps req.DeviceID via NetBox when a resolver is configured.
+// Failures are logged and non-fatal so spike jobs without NetBox rows still start.
+func (o *Orchestrator) resolveDeviceID(ctx context.Context, req *models.StartJobRequest) error {
+	if o.resolver == nil {
+		return nil
+	}
+	key := strings.TrimSpace(req.DeviceID)
+	if key == "" {
+		return nil
+	}
+	resolved, err := o.resolver.ResolveDeviceID(ctx, key)
+	if err != nil {
+		o.log.Warn("netbox device resolve failed; using device_id as-is",
+			"device_id", key, "err", err.Error())
+		return nil
+	}
+	resolved = strings.TrimSpace(resolved)
+	if resolved == "" || resolved == key {
+		return nil
+	}
+	o.log.Info("resolved device_id via NetBox",
+		"from", key, "to", resolved)
+	req.DeviceID = resolved
+	return nil
+}
+
+// appendJobLog best-effort writes a SHOAL| line to telemetry job_log.
+func (o *Orchestrator) appendJobLog(ctx context.Context, jobID string, m models.SOLMarker) {
+	if o.telemetry == nil {
+		return
+	}
+	line := sol.FormatMarkerLine(m)
+	ts := m.Timestamp
+	if ts.IsZero() {
+		ts = time.Now().UTC()
+	}
+	if err := o.telemetry.WriteJobLog(ctx, jobID, ts, line); err != nil {
+		o.log.Warn("job_log write failed", "job_id", jobID, "err", err.Error())
+	}
 }
 
 var _ jobport.JobProgress = (*progressAdapter)(nil)

--- a/internal/deploy/job/orchestrator_test.go
+++ b/internal/deploy/job/orchestrator_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/mattcburns/shoal/internal/common/netbox"
 	"github.com/mattcburns/shoal/internal/common/redfish"
 	"github.com/mattcburns/shoal/internal/common/secrets"
+	"github.com/mattcburns/shoal/internal/common/telemetry"
 	"github.com/mattcburns/shoal/internal/deploy/job"
 	"github.com/mattcburns/shoal/internal/deploy/jobstore"
 	"github.com/mattcburns/shoal/internal/observe/sol"
@@ -110,6 +111,135 @@ func TestOrchestratorHappyPathDone(t *testing.T) {
 	// password must not appear on job JSON-ish fields
 	if final.BMCEndpoint == "" {
 		t.Fatal("bmc endpoint should persist")
+	}
+	// With NetBox Memory, serial lab-node-1 remaps to numeric pk for plugin tabs.
+	if j.DeviceID != "1" {
+		t.Fatalf("want device_id remapped to NetBox pk, got %q", j.DeviceID)
+	}
+}
+
+func TestStartFillsDefaultBMCCredentials(t *testing.T) {
+	ctx := context.Background()
+	store := jobstore.NewMemory()
+	sec := secrets.NewMemory()
+	fakeBMC := redfish.NewFake()
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	pr, pw := io.Pipe()
+	watch := sol.NewWatchService(log, nil)
+	watch.NewTransport = func(session models.WatchSession) sol.Transport {
+		return sol.NewReaderTransport(pr)
+	}
+	orch := job.NewOrchestrator(job.Options{
+		Log:     log,
+		Store:   store,
+		Secrets: sec,
+		NewBMC: func(cfg redfish.Config) (redfish.BMC, error) {
+			return fakeBMC, nil
+		},
+		Watches:             watch,
+		DefaultBMCUsername:  "env-admin",
+		DefaultBMCPassword:  "env-secret",
+		AuthMode:            "basic",
+		TLSMode:             "off",
+		ReconcileFailOrphan: true,
+	})
+	defer orch.Stop()
+	watch.SetProgress(orch.ProgressPort())
+
+	// No bmc_username/password in request — env defaults must apply.
+	j, err := orch.Start(ctx, models.StartJobRequest{
+		DeviceID:     "lab-1",
+		BMCEndpoint:  "http://bmc.test",
+		SerialTarget: "lab-1",
+		ISOURL:       "http://iso/shoal-marker.iso",
+	})
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	// Credential should be stored under job ref with default user.
+	cred, err := sec.Get(ctx, j.CredentialRef)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cred.Username != "env-admin" || cred.Password != "env-secret" {
+		t.Fatalf("cred=%+v", cred)
+	}
+	_ = pw.Close()
+	_ = orch.Cancel(ctx, j.ID)
+}
+
+func TestStartResolvesDeviceIDAndWritesJobLog(t *testing.T) {
+	ctx := context.Background()
+	store := jobstore.NewMemory()
+	sec := secrets.NewMemory()
+	fakeBMC := redfish.NewFake()
+	nb := netbox.NewMemory()
+	netboxID, err := nb.UpsertDevice(ctx, models.DeviceIdentity{
+		Name: "shoal-node-1", Serial: "shoal-node-1", LifecycleState: models.StateDiscovered,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	telem := telemetry.NewMemory()
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	pr, pw := io.Pipe()
+	watch := sol.NewWatchService(log, nil)
+	watch.NewTransport = func(session models.WatchSession) sol.Transport {
+		return sol.NewReaderTransport(pr)
+	}
+	orch := job.NewOrchestrator(job.Options{
+		Log:     log,
+		Store:   store,
+		Secrets: sec,
+		NewBMC: func(cfg redfish.Config) (redfish.BMC, error) {
+			return fakeBMC, nil
+		},
+		Watches:             watch,
+		NetBox:              nb,
+		Telemetry:           telem,
+		AuthMode:            "basic",
+		TLSMode:             "off",
+		ReconcileFailOrphan: true,
+	})
+	defer orch.Stop()
+	watch.SetProgress(orch.ProgressPort())
+
+	j, err := orch.Start(ctx, models.StartJobRequest{
+		DeviceID:     "shoal-node-1", // lab hostname → NetBox pk
+		BMCEndpoint:  "http://bmc.test",
+		BMCUsername:  "admin",
+		BMCPassword:  "secret",
+		SerialTarget: "shoal-node-1",
+		ISOURL:       "http://iso/shoal-marker.iso",
+	})
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	if j.DeviceID != netboxID {
+		t.Fatalf("device_id=%q want NetBox pk %q", j.DeviceID, netboxID)
+	}
+
+	writeMarker(t, pw, "SHOAL|1|1|2026-06-19T04:10:00Z|BOOT|5|OK|booting")
+	writeMarker(t, pw, "SHOAL|1|2|2026-06-19T04:10:10Z|DONE|100|OK|done")
+	_ = pw.Close()
+
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		final, _ := store.Get(ctx, j.ID)
+		if final.State == models.StateProvisioned {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	lines, err := telem.ListJobLog(ctx, j.ID, time.Time{}, 50)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(lines) < 2 {
+		t.Fatalf("want job_log lines from markers, got %d", len(lines))
+	}
+	if !strings.Contains(lines[0].Line, "SHOAL|") || !strings.Contains(lines[0].Line, "BOOT") {
+		t.Fatalf("first line %q", lines[0].Line)
 	}
 }
 
@@ -346,11 +476,12 @@ func TestOrchestratorDoneDespiteStuckSOLClose(t *testing.T) {
 func TestOrchestratorOrphanReconcile(t *testing.T) {
 	ctx := context.Background()
 	store := jobstore.NewMemory()
-	// Pre-seed orphan PROVISIONING job as if process restarted.
+	// Pre-seed orphan PROVISIONING job as if process restarted mid-install.
 	now := time.Now().UTC()
 	_ = store.Insert(ctx, models.ProvisioningJob{
 		ID: "orphan-1", DeviceID: "d", State: models.StateProvisioning,
-		BMCEndpoint: "http://bmc", StartedAt: &now, UpdatedAt: &now,
+		Phase: "WAITING_SOL", BMCEndpoint: "http://bmc",
+		StartedAt: &now, UpdatedAt: &now,
 	})
 	fakeBMC := redfish.NewFake()
 	// simulate leftover media from crashed job
@@ -376,6 +507,41 @@ func TestOrchestratorOrphanReconcile(t *testing.T) {
 	}
 	if got.State != models.StateFailed {
 		t.Fatalf("orphan state %s", got.State)
+	}
+}
+
+func TestOrchestratorOrphanReconcileDoneOK(t *testing.T) {
+	// Crash after SOL DONE marker was applied but before lifecycle commit.
+	ctx := context.Background()
+	store := jobstore.NewMemory()
+	now := time.Now().UTC()
+	pct := 100
+	_ = store.Insert(ctx, models.ProvisioningJob{
+		ID: "orphan-done", DeviceID: "d", State: models.StateProvisioning,
+		Phase: "DONE", Percent: &pct, LastMarkerSeq: 7,
+		BMCEndpoint: "http://bmc", SystemID: "1",
+		StartedAt: &now, UpdatedAt: &now,
+	})
+	fakeBMC := redfish.NewFake()
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	watch := sol.NewWatchService(log, nil)
+	orch := job.NewOrchestrator(job.Options{
+		Log: log, Store: store, Secrets: secrets.NewMemory(),
+		NewBMC:  func(cfg redfish.Config) (redfish.BMC, error) { return fakeBMC, nil },
+		Watches: watch, ReconcileFailOrphan: true,
+	})
+	defer orch.Stop()
+	watch.SetProgress(orch.ProgressPort())
+
+	if err := orch.ReconcileOrphans(ctx); err != nil {
+		t.Fatal(err)
+	}
+	got, err := store.Get(ctx, "orphan-done")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.State != models.StateProvisioned {
+		t.Fatalf("want provisioned for DONE orphan, got %s err=%s", got.State, got.Error)
 	}
 }
 

--- a/internal/discover/service.go
+++ b/internal/discover/service.go
@@ -187,6 +187,8 @@ func (s *Service) finalize(ctx context.Context, in models.RawAssetInput, result 
 		id, err := s.NetBox.UpsertDevice(ctx, models.DeviceIdentity{
 			Name:           result.Asset.Serial,
 			Serial:         result.Asset.Serial,
+			Vendor:         result.Asset.Vendor,
+			Model:          result.Asset.Model,
 			LifecycleState: models.StateDiscovered,
 			CredentialRef:  result.Asset.CredentialRef,
 			BMCIP:          result.Asset.BMCIP,

--- a/internal/observe/poll/poller.go
+++ b/internal/observe/poll/poller.go
@@ -149,13 +149,13 @@ func (p *Poller) PollOnce(ctx context.Context, t Target) (selWritten, sensorsWri
 	if maxSEL <= 0 {
 		maxSEL = DefaultSELMaxEntries
 	}
-	entries, err := bmc.ListSEL(ctx, t.SystemID, redfish.SELOptions{MaxEntries: maxSEL})
-	if err != nil {
-		return 0, 0, fmt.Errorf("poll: list sel: %w", err)
+	entries, selErr := bmc.ListSEL(ctx, t.SystemID, redfish.SELOptions{MaxEntries: maxSEL})
+	if selErr != nil {
+		entries = nil
 	}
-	samples, err := bmc.ListSensors(ctx, t.SystemID)
-	if err != nil {
-		return 0, 0, fmt.Errorf("poll: list sensors: %w", err)
+	samples, sensErr := bmc.ListSensors(ctx, t.SystemID)
+	if sensErr != nil {
+		samples = nil
 	}
 
 	p.mu.Lock()
@@ -240,6 +240,12 @@ func (p *Poller) PollOnce(ctx context.Context, t Target) (selWritten, sensorsWri
 		"sel_seen", len(entries),
 		"sensor_seen", len(samples),
 	)
+	if selErr != nil {
+		return selWritten, sensorsWritten, fmt.Errorf("poll: list sel: %w", selErr)
+	}
+	if sensErr != nil {
+		return selWritten, sensorsWritten, fmt.Errorf("poll: list sensors: %w", sensErr)
+	}
 	if failN > 0 {
 		return selWritten, sensorsWritten, fmt.Errorf("poll: %d item failure(s) after sel_new=%d sensors=%d: %w",
 			failN, selWritten, sensorsWritten, firstFail)

--- a/internal/observe/poll/poller.go
+++ b/internal/observe/poll/poller.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 	"sync"
 	"time"
 
@@ -14,10 +15,10 @@ import (
 	"github.com/mattcburns/shoal/internal/core/reconcile"
 )
 
-// Default idle vs watch-elevated intervals.
+// Default idle vs watch-elevated intervals (serve overrides from SHOAL_POLL_*).
 const (
-	DefaultIdleInterval  = 60 * time.Second
-	DefaultWatchInterval = 15 * time.Second
+	DefaultIdleInterval  = 5 * time.Minute
+	DefaultWatchInterval = 30 * time.Second
 	DefaultMaxConcurrent = 1
 	DefaultSELMaxEntries = 100
 )
@@ -112,15 +113,23 @@ func (p *Poller) Targets() []Target {
 	return out
 }
 
-// PollOnce runs a single SEL+sensor poll for one target (deduped SEL writes).
+// Result is the outcome of one PollOnce.
+type Result struct {
+	SELNew          int
+	SensorsWritten  int
+	FirmwareWritten int
+	PowerState      string
+}
+
+// PollOnce runs a single SEL+sensor+firmware+power poll for one target (deduped SEL writes).
 // Returns a non-nil error if Redfish fails or any normalize/write fails (counts
-// still reflect successful writes). Empty SEL/sensors with nil error is valid.
-func (p *Poller) PollOnce(ctx context.Context, t Target) (selWritten, sensorsWritten int, err error) {
+// still reflect successful writes). Empty SEL/sensors/firmware with nil error is valid.
+func (p *Poller) PollOnce(ctx context.Context, t Target) (Result, error) {
 	if p.Store == nil {
-		return 0, 0, fmt.Errorf("poll: telemetry store not configured")
+		return Result{}, fmt.Errorf("poll: telemetry store not configured")
 	}
 	if t.DeviceID == "" || t.BMC.BaseURL == "" {
-		return 0, 0, fmt.Errorf("poll: incomplete target")
+		return Result{}, fmt.Errorf("poll: incomplete target")
 	}
 	if p.MaxConcurrent <= 0 {
 		p.MaxConcurrent = DefaultMaxConcurrent
@@ -133,15 +142,15 @@ func (p *Poller) PollOnce(ctx context.Context, t Target) (selWritten, sensorsWri
 	case p.sem <- struct{}{}:
 		defer func() { <-p.sem }()
 	case <-ctx.Done():
-		return 0, 0, ctx.Err()
+		return Result{}, ctx.Err()
 	}
 
 	bmc, err := p.NewBMC(t.BMC)
 	if err != nil {
-		return 0, 0, fmt.Errorf("poll: bmc: %w", err)
+		return Result{}, fmt.Errorf("poll: bmc: %w", err)
 	}
 	if err := bmc.Open(ctx); err != nil {
-		return 0, 0, fmt.Errorf("poll: open: %w", err)
+		return Result{}, fmt.Errorf("poll: open: %w", err)
 	}
 	defer func() { _ = bmc.Close(context.Background()) }()
 
@@ -157,6 +166,11 @@ func (p *Poller) PollOnce(ctx context.Context, t Target) (selWritten, sensorsWri
 	if sensErr != nil {
 		samples = nil
 	}
+	fwItems, fwErr := bmc.ListFirmware(ctx)
+	if fwErr != nil {
+		fwItems = nil
+	}
+	sys, sysErr := bmc.GetSystem(ctx, t.SystemID)
 
 	p.mu.Lock()
 	if p.seenSEL[t.DeviceID] == nil {
@@ -167,6 +181,8 @@ func (p *Poller) PollOnce(ctx context.Context, t Target) (selWritten, sensorsWri
 
 	var failN int
 	var firstFail error
+	out := Result{}
+	now := time.Now().UTC()
 
 	for _, e := range entries {
 		key := e.ODataID
@@ -199,10 +215,9 @@ func (p *Poller) PollOnce(ctx context.Context, t Target) (selWritten, sensorsWri
 			p.Log.Warn("poll write event", "device_id", t.DeviceID, "err", err.Error())
 			continue
 		}
-		selWritten++
+		out.SELNew++
 	}
 
-	now := time.Now().UTC()
 	for _, s := range samples {
 		name := s.Name
 		if name == "" {
@@ -215,13 +230,17 @@ func (p *Poller) PollOnce(ctx context.Context, t Target) (selWritten, sensorsWri
 			}
 			continue
 		}
-		if err := p.Store.WriteSensor(ctx, telemetry.SensorReading{
+		row := telemetry.SensorReading{
 			DeviceID: t.DeviceID,
 			TS:       now,
 			Sensor:   name,
-			Value:    s.Reading,
 			Unit:     s.Units,
-		}); err != nil {
+			Note:     s.Note,
+		}
+		if s.HasReading {
+			row.Value = telemetry.SensorValue(s.Reading)
+		}
+		if err := p.Store.WriteSensor(ctx, row); err != nil {
 			failN++
 			if firstFail == nil {
 				firstFail = fmt.Errorf("write sensor: %w", err)
@@ -229,28 +248,85 @@ func (p *Poller) PollOnce(ctx context.Context, t Target) (selWritten, sensorsWri
 			p.Log.Warn("poll write sensor", "device_id", t.DeviceID, "err", err.Error())
 			continue
 		}
-		sensorsWritten++
+		out.SensorsWritten++
+	}
+
+	for _, fw := range fwItems {
+		id := strings.TrimSpace(fw.ID)
+		if id == "" {
+			id = strings.TrimSpace(fw.Name)
+		}
+		if id == "" {
+			failN++
+			if firstFail == nil {
+				firstFail = fmt.Errorf("firmware item missing id")
+			}
+			continue
+		}
+		row := telemetry.FirmwareComponent{
+			DeviceID:     t.DeviceID,
+			TS:           now,
+			ID:           id,
+			Name:         fw.Name,
+			Version:      fw.Version,
+			Manufacturer: fw.Manufacturer,
+			SoftwareID:   fw.SoftwareID,
+			Health:       fw.Health,
+			Updateable:   fw.Updateable,
+			ReleaseDate:  fw.ReleaseDate,
+		}
+		if err := p.Store.WriteFirmware(ctx, row); err != nil {
+			failN++
+			if firstFail == nil {
+				firstFail = fmt.Errorf("write firmware: %w", err)
+			}
+			p.Log.Warn("poll write firmware", "device_id", t.DeviceID, "err", err.Error())
+			continue
+		}
+		out.FirmwareWritten++
+	}
+
+	if sysErr == nil && strings.TrimSpace(sys.PowerState) != "" {
+		out.PowerState = sys.PowerState
+		if err := p.Store.WritePower(ctx, telemetry.PowerReading{
+			DeviceID: t.DeviceID, TS: now, PowerState: sys.PowerState,
+		}); err != nil {
+			failN++
+			if firstFail == nil {
+				firstFail = fmt.Errorf("write power: %w", err)
+			}
+			p.Log.Warn("poll write power", "device_id", t.DeviceID, "err", err.Error())
+		}
 	}
 
 	p.Log.Info("poll complete",
 		"device_id", t.DeviceID,
-		"sel_new", selWritten,
-		"sensors", sensorsWritten,
+		"sel_new", out.SELNew,
+		"sensors", out.SensorsWritten,
+		"firmware", out.FirmwareWritten,
+		"power_state", out.PowerState,
 		"failures", failN,
 		"sel_seen", len(entries),
 		"sensor_seen", len(samples),
+		"firmware_seen", len(fwItems),
 	)
 	if selErr != nil {
-		return selWritten, sensorsWritten, fmt.Errorf("poll: list sel: %w", selErr)
+		return out, fmt.Errorf("poll: list sel: %w", selErr)
 	}
 	if sensErr != nil {
-		return selWritten, sensorsWritten, fmt.Errorf("poll: list sensors: %w", sensErr)
+		return out, fmt.Errorf("poll: list sensors: %w", sensErr)
+	}
+	if fwErr != nil {
+		return out, fmt.Errorf("poll: list firmware: %w", fwErr)
+	}
+	if sysErr != nil {
+		return out, fmt.Errorf("poll: power state: %w", sysErr)
 	}
 	if failN > 0 {
-		return selWritten, sensorsWritten, fmt.Errorf("poll: %d item failure(s) after sel_new=%d sensors=%d: %w",
-			failN, selWritten, sensorsWritten, firstFail)
+		return out, fmt.Errorf("poll: %d item failure(s) after sel_new=%d sensors=%d firmware=%d: %w",
+			failN, out.SELNew, out.SensorsWritten, out.FirmwareWritten, firstFail)
 	}
-	return selWritten, sensorsWritten, nil
+	return out, nil
 }
 
 func (p *Poller) normalizeSEL(ctx context.Context, deviceID string, e redfish.SELEntry) (models.NormalizedEvent, error) {
@@ -299,7 +375,7 @@ func (p *Poller) Run(ctx context.Context) {
 			if t0, ok := last[t.DeviceID]; ok && time.Since(t0) < interval {
 				continue
 			}
-			if _, _, err := p.PollOnce(ctx, t); err != nil && ctx.Err() == nil {
+			if _, err := p.PollOnce(ctx, t); err != nil && ctx.Err() == nil {
 				p.Log.Warn("poll once failed", "device_id", t.DeviceID, "err", err.Error())
 			}
 			last[t.DeviceID] = time.Now()

--- a/internal/observe/poll/poller_test.go
+++ b/internal/observe/poll/poller_test.go
@@ -2,6 +2,8 @@ package poll_test
 
 import (
 	"context"
+	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -60,6 +62,38 @@ func TestPollOnceWritesSELAndSensors(t *testing.T) {
 	}
 	if evs[0].Component != "Temperature" {
 		t.Fatalf("component=%q", evs[0].Component)
+	}
+}
+
+func TestPollOnceWritesSELWhenSensorsFail(t *testing.T) {
+	store := telemetry.NewMemory()
+	fake := redfish.NewFake()
+	ts := time.Now().UTC()
+	fake.SEL = []redfish.SELEntry{
+		{ID: "1", Message: "chassis closed", Severity: "OK", Created: ts, ODataID: "/e/1"},
+	}
+	fake.ListSensorsErr = errors.New("context deadline exceeded")
+	p := poll.New(nil, store, func(redfish.Config) (redfish.BMC, error) { return fake, nil })
+
+	selN, sensN, err := p.PollOnce(context.Background(), poll.Target{
+		DeviceID: "dev-1",
+		BMC:      redfish.Config{BaseURL: "http://fake"},
+	})
+	if err == nil {
+		t.Fatal("expected sensor error")
+	}
+	if !strings.Contains(err.Error(), "list sensors") {
+		t.Fatalf("err=%v", err)
+	}
+	if selN != 1 {
+		t.Fatalf("sel written=%d want 1", selN)
+	}
+	if sensN != 0 {
+		t.Fatalf("sensors=%d", sensN)
+	}
+	evs, _ := store.ListEvents(context.Background(), "dev-1", time.Time{}, 10)
+	if len(evs) != 1 {
+		t.Fatalf("events=%d", len(evs))
 	}
 }
 

--- a/internal/observe/poll/poller_test.go
+++ b/internal/observe/poll/poller_test.go
@@ -30,28 +30,31 @@ func TestPollOnceWritesSELAndSensors(t *testing.T) {
 	// Deterministic path — no Core / no Fake AI.
 	p := poll.New(nil, store, func(redfish.Config) (redfish.BMC, error) { return fake, nil })
 
-	selN, sensN, err := p.PollOnce(context.Background(), poll.Target{
+	got, err := p.PollOnce(context.Background(), poll.Target{
 		DeviceID: "dev-1",
 		BMC:      redfish.Config{BaseURL: "http://fake"},
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if selN != 1 {
-		t.Fatalf("sel written=%d want 1 (dedup)", selN)
+	if got.SELNew != 1 {
+		t.Fatalf("sel written=%d want 1 (dedup)", got.SELNew)
 	}
-	if sensN != 1 {
-		t.Fatalf("sensors=%d", sensN)
+	if got.SensorsWritten != 1 {
+		t.Fatalf("sensors=%d", got.SensorsWritten)
 	}
-	selN, _, err = p.PollOnce(context.Background(), poll.Target{
+	if got.PowerState != "Off" {
+		t.Fatalf("power=%q", got.PowerState)
+	}
+	got, err = p.PollOnce(context.Background(), poll.Target{
 		DeviceID: "dev-1",
 		BMC:      redfish.Config{BaseURL: "http://fake"},
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if selN != 0 {
-		t.Fatalf("second poll sel=%d", selN)
+	if got.SELNew != 0 {
+		t.Fatalf("second poll sel=%d", got.SELNew)
 	}
 	evs, _ := store.ListEvents(context.Background(), "dev-1", time.Time{}, 10)
 	if len(evs) != 1 {
@@ -65,6 +68,34 @@ func TestPollOnceWritesSELAndSensors(t *testing.T) {
 	}
 }
 
+func TestPollOnceWritesFirmwareAndPower(t *testing.T) {
+	store := telemetry.NewMemory()
+	fake := redfish.NewFake()
+	fake.Systems[0].PowerState = "On"
+	fake.Firmware = []redfish.FirmwareComponent{
+		{ID: "Installed-0-BIOS", Name: "BIOS", Version: "1.8.0", Manufacturer: "Dell Inc."},
+		{ID: "Installed-1-iDRAC", Name: "iDRAC", Version: "7.30.10.50"},
+	}
+	p := poll.New(nil, store, func(redfish.Config) (redfish.BMC, error) { return fake, nil })
+	got, err := p.PollOnce(context.Background(), poll.Target{
+		DeviceID: "6", BMC: redfish.Config{BaseURL: "http://fake"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.FirmwareWritten != 2 || got.PowerState != "On" {
+		t.Fatalf("%+v", got)
+	}
+	fw, err := store.ListFirmware(context.Background(), "6", 20)
+	if err != nil || len(fw) != 2 {
+		t.Fatalf("firmware %v %+v", err, fw)
+	}
+	pw, err := store.LatestPower(context.Background(), "6")
+	if err != nil || pw.PowerState != "On" {
+		t.Fatalf("power %v %+v", err, pw)
+	}
+}
+
 func TestPollOnceWritesSELWhenSensorsFail(t *testing.T) {
 	store := telemetry.NewMemory()
 	fake := redfish.NewFake()
@@ -75,7 +106,7 @@ func TestPollOnceWritesSELWhenSensorsFail(t *testing.T) {
 	fake.ListSensorsErr = errors.New("context deadline exceeded")
 	p := poll.New(nil, store, func(redfish.Config) (redfish.BMC, error) { return fake, nil })
 
-	selN, sensN, err := p.PollOnce(context.Background(), poll.Target{
+	got, err := p.PollOnce(context.Background(), poll.Target{
 		DeviceID: "dev-1",
 		BMC:      redfish.Config{BaseURL: "http://fake"},
 	})
@@ -85,11 +116,11 @@ func TestPollOnceWritesSELWhenSensorsFail(t *testing.T) {
 	if !strings.Contains(err.Error(), "list sensors") {
 		t.Fatalf("err=%v", err)
 	}
-	if selN != 1 {
-		t.Fatalf("sel written=%d want 1", selN)
+	if got.SELNew != 1 {
+		t.Fatalf("sel written=%d want 1", got.SELNew)
 	}
-	if sensN != 0 {
-		t.Fatalf("sensors=%d", sensN)
+	if got.SensorsWritten != 0 {
+		t.Fatalf("sensors=%d", got.SensorsWritten)
 	}
 	evs, _ := store.ListEvents(context.Background(), "dev-1", time.Time{}, 10)
 	if len(evs) != 1 {
@@ -100,7 +131,7 @@ func TestPollOnceWritesSELWhenSensorsFail(t *testing.T) {
 func TestPollOnceSurfacesWriteFailures(t *testing.T) {
 	// nil store → hard error
 	p := poll.New(nil, nil, func(redfish.Config) (redfish.BMC, error) { return redfish.NewFake(), nil })
-	_, _, err := p.PollOnce(context.Background(), poll.Target{
+	_, err := p.PollOnce(context.Background(), poll.Target{
 		DeviceID: "d", BMC: redfish.Config{BaseURL: "http://x"},
 	})
 	if err == nil {

--- a/internal/observe/service.go
+++ b/internal/observe/service.go
@@ -63,6 +63,12 @@ func (s *Service) Status(ctx context.Context, deviceID string) (models.DeviceSta
 	}
 
 	if s.Telemetry != nil {
+		if pw, err := s.Telemetry.LatestPower(ctx, deviceID); err == nil && pw.PowerState != "" {
+			st.PowerState = pw.PowerState
+			if pw.TS.After(st.UpdatedAt) {
+				st.UpdatedAt = pw.TS
+			}
+		}
 		evs, err := s.Telemetry.ListEvents(ctx, deviceID, time.Time{}, 1)
 		if err != nil {
 			return st, fmt.Errorf("observe: list events: %w", err)
@@ -106,6 +112,17 @@ func (s *Service) ListEvents(ctx context.Context, deviceID string, since time.Ti
 		return nil, fmt.Errorf("observe: device_id required")
 	}
 	return s.Telemetry.ListEvents(ctx, deviceID, since, limit)
+}
+
+// ListFirmware returns the latest firmware inventory snapshot for a device.
+func (s *Service) ListFirmware(ctx context.Context, deviceID string, limit int) ([]telemetry.FirmwareComponent, error) {
+	if s.Telemetry == nil {
+		return nil, fmt.Errorf("observe: telemetry store not configured (set SHOAL_TELEMETRY_DATABASE_URL)")
+	}
+	if deviceID == "" {
+		return nil, fmt.Errorf("observe: device_id required")
+	}
+	return s.Telemetry.ListFirmware(ctx, deviceID, limit)
 }
 
 // ListSensors returns recent sensor readings for a device.

--- a/internal/observe/sol/parse.go
+++ b/internal/observe/sol/parse.go
@@ -2,6 +2,7 @@
 package sol
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 	"time"
@@ -112,4 +113,23 @@ func TerminalReasonFromMarker(m models.SOLMarker) string {
 		return "done_ok"
 	}
 	return "marker_error"
+}
+
+// FormatMarkerLine renders m as a SHOAL|… protocol line for durable job_log rows.
+// Empty timestamps use UTC now; nil percent is written as "-".
+func FormatMarkerLine(m models.SOLMarker) string {
+	ts := m.Timestamp.UTC()
+	if ts.IsZero() {
+		ts = time.Now().UTC()
+	}
+	pct := "-"
+	if m.Percent != nil {
+		pct = strconv.Itoa(*m.Percent)
+	}
+	ver := m.SchemaVer
+	if ver == 0 {
+		ver = SchemaVersion
+	}
+	return fmt.Sprintf("SHOAL|%d|%d|%s|%s|%s|%s|%s",
+		ver, m.Seq, ts.Format(time.RFC3339), m.Phase, pct, m.State, m.Detail)
 }

--- a/internal/observe/sol/parse_test.go
+++ b/internal/observe/sol/parse_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/mattcburns/shoal/internal/common/models"
 	"github.com/mattcburns/shoal/internal/observe/sol"
 )
 
@@ -94,6 +95,41 @@ func TestIsStageComplete(t *testing.T) {
 	if !ok || !sol.IsStageComplete(m) {
 		t.Fatal("DONE should be stage-complete")
 	}
+}
+
+func TestFormatMarkerLine(t *testing.T) {
+	p := 65
+	m := models.SOLMarker{
+		SchemaVer: 1,
+		Seq:       41,
+		Timestamp: mustTime(t, "2026-06-19T04:10:11Z"),
+		Phase:     "IMAGE_WRITE",
+		Percent:   &p,
+		State:     "OK",
+		Detail:    "writing rootfs",
+	}
+	got := sol.FormatMarkerLine(m)
+	want := "SHOAL|1|41|2026-06-19T04:10:11Z|IMAGE_WRITE|65|OK|writing rootfs"
+	if got != want {
+		t.Fatalf("got %q want %q", got, want)
+	}
+	// Round-trip through ParseLine.
+	parsed, ok := sol.ParseLine(got)
+	if !ok {
+		t.Fatal("parse failed")
+	}
+	if parsed.Phase != "IMAGE_WRITE" || parsed.Seq != 41 || parsed.Percent == nil || *parsed.Percent != 65 {
+		t.Fatalf("%+v", parsed)
+	}
+}
+
+func mustTime(t *testing.T, s string) time.Time {
+	t.Helper()
+	ts, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return ts
 }
 
 func intPtr(v int) *int { return &v }

--- a/internal/observe/sol/transport.go
+++ b/internal/observe/sol/transport.go
@@ -129,6 +129,10 @@ func (t *LibvirtTransport) Open(ctx context.Context, target string) (<-chan stri
 	ch := make(chan string, 32)
 	go func() {
 		defer close(ch)
+		defer func() {
+			// Scanner/PTY edge cases must not kill the process.
+			_ = recover()
+		}()
 		sc := bufio.NewScanner(f) // local f, not t.file
 		buf := make([]byte, 0, 64*1024)
 		sc.Buffer(buf, 1024*1024)

--- a/internal/observe/sol/watch.go
+++ b/internal/observe/sol/watch.go
@@ -169,6 +169,17 @@ func (w *WatchService) Unregister(_ context.Context, sessionID string) error {
 
 func (w *WatchService) run(ctx context.Context, aw *activeWatch, lines <-chan string, progress jobport.JobProgress) {
 	defer close(aw.done)
+	// Never let a watch-loop panic take down the whole process (Compose restart
+	// would orphan-reconcile and race HandleTerminal).
+	defer func() {
+		if r := recover(); r != nil {
+			w.log.Error("sol watch panic recovered",
+				"job_id", aw.session.JobID,
+				"session_id", aw.session.ID,
+				"recover", fmt.Sprint(r),
+			)
+		}
+	}()
 	stallDisabled := aw.session.StallDisabled
 	stall := aw.session.StallTimeout
 	var timer *time.Timer


### PR DESCRIPTION
## Summary

Operator path for mixed **lab sushy** + **physical BMC** demos on the existing NetBox plugin branch.

### Already on this PR (prior commits)
- Plugin v0.3 Status/Jobs/Events/Sensors + Start provision / Cancel
- Name/serial → NetBox pk remap; durable SOL `job_log`; `SHOAL_BMC_*` start defaults
- iDRAC LC log skip so Observe poll can finish; physical Dell classified as Server / PowerEdge

### This push (`9981812`)
- **Host power:** `POST /v1/devices/{id}/power` (Redfish Reset as requested, no On→ForceRestart rewrite) + NetBox Status controls
- **BMC credentials:** `GET`/`PUT /v1/devices/{id}/credentials` — password in Shoal secrets (`SHOAL_SECRETS_DIR`); NetBox keeps `credential_ref` only. Status GET passes `?credential_ref=` so Shoal does not call NetBox while a device page is rendering (was 16s stalls)
- **Poll BMC:** `POST /v1/devices/{id}/poll` writes SEL + sensors + firmware + power. `GET /v1/devices/{id}/firmware` + **Shoal Firmware** tab (gather-only; Dell `Current-*` dupes skipped)
- **Poll cadence:** `SHOAL_POLL_IDLE_INTERVAL` default `5m`, `SHOAL_POLL_WATCH_INTERVAL` default `30s` (env + Ansible). Auto-seed still job-only; on-demand poll `SetTarget`s the device
- **Sensors:** JSON null Reading stays null with a note (“No reading while host is off”), not fake zeros
- **BMC endpoint prefill:** real servers use `https://<bmc_ip>`; lab virtual BMC nodes keep shared sushy URL
- Plugin **v0.4**; docs: `AGENTS.md`, design §8.1, `docs/netbox-telemetry-ui-design.md`, `docs/lab-runbook.md`, plugin README

## Test plan
- [x] `gofmt`; `go test ./internal/api ./internal/cli ./internal/common/... ./internal/observe/...`
- [x] `go test ./...`
- [x] VM lab rebuild (`lab_up.yml --tags shoal,config,start --skip-tags sushy`)
- [x] Live iDRAC 7.30 / PowerEdge R750 C784MH3: poll wrote 21 firmware + 26 sensors + `power_state=Off`; credentials GET with hint ~1ms; Status sequential GETs ~35ms
- [x] Physical node classified Server / PowerEdge R750 (prior commit)
- [x] Browser: NetBox → device → Status (credentials/power), Sensors/Firmware Poll BMC, Start provision on a **lab** sushy node
- [ ] Real-BMC **provision** still blocked: no usable Redfish SOL, ISO URL not BMC-reachable, power-on not authorized. Spike remains lab sushy + libvirt SOL.

## Notes
- Passwords never returned in JSON or stored in NetBox.
- Start provision with empty user/pass still uses `SHOAL_BMC_*` (not the stored per-device secret). Power/poll already resolve stored then env.
- Compose privileged + libvirt mounts unchanged from earlier commits on this branch.
