### PR TITLE
feat(sol): Dell SSH attach when SerialConsole is empty

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,10 +45,23 @@ These encode the core design decisions. Violating one is a bug, even if tests pa
 5. **SOL is the primary provisioning feedback channel.** Progress comes from the
    `SHOAL|...` serial marker protocol. OCR is only for graphics-only failure
    screens (Phase 6; approach not yet decided), never the progress loop.
-6. **Redfish only via `internal/common/redfish` (gofish-backed).** gofish is the
-   chosen Redfish stack from day one. **gofish types must not leak** outside
-   `internal/common/redfish`. Reuse sessions (or basic auth in lab), cap
+6. **BMC control is Redfish-only via `internal/common/redfish` (gofish-backed).**
+   gofish is the chosen Redfish stack from day one. **gofish types must not leak**
+   outside `internal/common/redfish`. Reuse sessions (or basic auth in lab), cap
    per-BMC concurrency (~1–2), and back off on throttling (respect `Retry-After`).
+   Power, Virtual Media, boot override, SEL, sensors, inventory, and screenshots
+   **never** use IPMI (no `ipmitool chassis`, no IPMI media, no IPMI inventory).
+
+   **SOL is the scoped exception.** `BMC.OpenSOL` may leave HTTP, in this order:
+   (1) line-oriented Redfish/OEM WebSocket if it is actually SOL (not HTML5 KVM);
+   (2) SSH to the BMC + vendor attach command when SSH is enabled — including when
+   standard `ComputerSystem.SerialConsole` (gofish `HostSerialConsole`) is empty
+   but `NetworkProtocol` / Dell OEM serial-redirection attributes show serial is
+   on. **IPMI 2.0 SOL as last resort is specified in
+   `docs/sol-transports-design.md`; it is not implemented in this change.** Until
+   that follow-on lands, an IPMI-only BMC still returns `*SOLUnsupportedError`.
+   IPMI, when implemented, is a SOL payload, not a second BMC API. Call sites
+   still only see `OpenSOL`.
 7. **Artifact/ISO serving is plain HTTP on the management segment for MVP.** Do
    not add TLS to the ISO server (many BMCs reject self-signed certs); TLS is
    Phase 6. Phase 2 publishes ISOs to the lab ISO dir and serves them at
@@ -439,11 +452,15 @@ Live-server remaster (`SHOAL_UBUNTU_ISO`) is alternate/stretch. **7b/7c deferred
 - **SOL ownership:** Observe holds the single SOL session for a node during a
   job (register via `watchport`). Lab uses libvirt serial; real hardware uses
   the `redfish_sol` transport (`internal/observe/sol/redfish_transport.go` +
-  `internal/common/redfish/sol.go`) behind `sol.Transport`. **Redfish only —
-  never raw IPMI**, even for BMCs that only advertise IPMI SOL. `redfish_sol`
-  is unit-tested only (sushy-tools has no SOL); see
-  `docs/real-hardware-sol-runbook.md` before relying on it against real
-  hardware.
+  `internal/common/redfish/sol.go`) behind `sol.Transport`. BMC **control** stays
+  Redfish-only. `OpenSOL` may use line-oriented WebSocket or SSH attach (Dell
+  `console com2` / `connect` when SerialConsole is empty but SSH/serial OEM is
+  on). **IPMI 2.0 SOL last-resort client is not yet in the tree** — IPMI-only
+  BMCs still return `*SOLUnsupportedError` with a debug trail.
+  `WatchSession.Transport=ipmi_sol` remains an error (IPMI is not a watch
+  transport). Fake-SSH unit tests always run; sushy-tools has no SOL. Live
+  iDRAC attach is operator-gated (`go test -tags=live_sol`); see
+  `docs/real-hardware-sol-runbook.md` and `docs/sol-transports-design.md`.
 - Capture real Redfish responses into the **record/replay corpus**
   (`testdata/redfish/`) when you hit a new vendor/firmware shape, and add a
   fixture-based test. Pin gofish version in `go.mod`.

--- a/SHOAL_COMPREHENSIVE_DESIGN_AND_IMPLEMENTATION_PLAN.md
+++ b/SHOAL_COMPREHENSIVE_DESIGN_AND_IMPLEMENTATION_PLAN.md
@@ -1015,7 +1015,7 @@ type WatchSession struct {
     ID           string    `json:"id"`
     JobID        string    `json:"job_id"`
     DeviceID     string    `json:"device_id"`
-    Transport    string    `json:"transport"` // "libvirt" | "redfish_sol" | "ipmi_sol"
+    Transport    string    `json:"transport"` // "libvirt" | "redfish_sol"
     Target       string    `json:"target"`    // console path or BMC URI
     StartedAt    time.Time `json:"started_at"`
     StallTimeout time.Duration `json:"stall_timeout"` // e.g. 90s
@@ -1154,7 +1154,7 @@ Implementation notes:
 | `github.com/jackc/pgx/v5` | runtime (default) | Postgres driver for lab telemetry/jobs DB on `:5433` |
 | `modernc.org/sqlite` | runtime (optional demo) | Pure-Go SQLite if someone runs without Compose; not required for lab ACs |
 | `github.com/coder/websocket` | runtime (required) | Real Redfish SOL transport: native WebSocket SOL dial for recognized BMC vendors (`internal/common/redfish/sol.go`); gofish has no client-side streaming/WebSocket support. Context-native `Read`/`Close` fits the cancellation-bounded `sol.Transport` contract. |
-| `golang.org/x/crypto` (`ssh` subpackage) | runtime (required) | Real Redfish SOL transport: SSH fallback for `OpenSOL` when — and only when — Redfish's own capability metadata (`ComputerSystem.SerialConsole.SSH`) advertises SSH, using password auth against BMC credentials. Was already an indirect transitive dependency (pulled in by gofish/pgx); promoted to direct use in `internal/common/redfish/sol.go`. Never used for raw IPMI. |
+| `golang.org/x/crypto` (`ssh` subpackage) | runtime (required) | Real-hardware SOL: SSH attach for `OpenSOL` when Redfish SerialConsole advertises SSH **or** (Dell) NetworkProtocol/OEM serial-redirection is enabled. Password and keyboard-interactive auth against BMC credentials (iDRAC offers KI only). Already an indirect transitive dep (gofish/pgx); used in `internal/common/redfish/sol.go`. Never used for IPMI or BMC control. |
 | `honnef.co/go/tools/cmd/staticcheck` | toolchain | Static analysis beyond `go vet`; not linked into binary |
 
 **Toolchain install (AGENTS / CI):**
@@ -1700,7 +1700,7 @@ Golden Rules:
 3. Secrets never to LLM/log; `credential_ref` only
 4. NetBox identity + lifecycle only
 5. SOL markers primary progress; OCR diagnostic
-6. Redfish only via `internal/common/redfish` (**gofish-backed**; no gofish types outside that package)
+6. BMC control Redfish-only via `internal/common/redfish` (**gofish-backed**; no gofish types outside that package). SOL may leave HTTP (WS / SSH attach); IPMI 2.0 SOL last-resort client is a specified follow-on, not yet in tree. Never IPMI for power/media/SEL/sensors/inventory.
 7. Plain HTTP ISO on mgmt segment for MVP
 8. Structs + validate/decode pipeline for AI I/O
 9. Component boundaries §3–4; **no observe↔deploy imports** (use `jobport`/`watchport`)

--- a/SHOAL_COMPREHENSIVE_DESIGN_AND_IMPLEMENTATION_PLAN.md
+++ b/SHOAL_COMPREHENSIVE_DESIGN_AND_IMPLEMENTATION_PLAN.md
@@ -558,7 +558,7 @@ Fields/transitions **only Orchestrator commits**: `state` (`LifecycleState`), `a
 
 Explicit cancel: `PROVISIONING --cancel--> (cleanup) --> FAILED` (with `error=canceled`), then device may return to READY when re-enqueued. Do **not** invent a separate long-lived `CLEANUP` lifecycle enum for MVP; cleanup is a **mandatory finalizer** inside `HandleTerminal`, not a NetBox-facing state.
 
-**Transport**: real hardware uses Redfish `SerialConsole` / IPMI SOL; lab uses libvirt guest serial (Section 8).
+**Transport**: lab uses libvirt guest serial (Section 8). Real hardware uses `redfish_sol` → `BMC.OpenSOL` (line-oriented WS if actually SOL, else SSH attach — Dell `console com2` even when `SerialConsole` is empty). IPMI 2.0 SOL last-resort is specified (`docs/sol-transports-design.md`), not yet in tree.
 
 ```go
 // internal/observe/sol — parser returns models.SOLMarker (common), not deploy types

--- a/docs/lab-runbook.md
+++ b/docs/lab-runbook.md
@@ -877,7 +877,7 @@ list, job log lines from SOL markers, and NetBox `lifecycle_state` CF updates.
    |-------------|---------------------|
    | Device custom field `lifecycle_state` | `provisioning` → `provisioned` (or `failed`) |
    | **Shoal Status** | Lifecycle badge, last polled power, phase, animated progress while running; stages panel; job log (`SHOAL\|…` lines); **BMC credentials** (saved in Shoal secrets); **Host power** |
-   | **Shoal Status → Provision** | **Start provision** (demo write path): prefills lab BMC URL + marker ISO (real servers use `https://<bmc_ip>`). Empty user/pass uses `SHOAL_BMC_*` (not the stored per-device secret). Requires `dcim.change_device`. **Cancel** when a job is provisioning. Lab sushy + libvirt SOL is the path that completes; real BMC SOL + ISO reachability is still a gap. |
+   | **Shoal Status → Provision** | **Start provision** (demo write path): prefills lab BMC URL + marker ISO (real servers use `https://<bmc_ip>`). Empty user/pass uses `SHOAL_BMC_*` (not the stored per-device secret). Requires `dcim.change_device`. **Cancel** when a job is provisioning. Lab sushy + libvirt SOL completes today. Real BMC SOL attach works on the probed iDRAC with `SHOAL_SERIAL_TRANSPORT=redfish_sol` (see `docs/real-hardware-sol-runbook.md`); the remaining provision gap is an ISO URL the BMC can fetch. |
    | **Shoal Jobs** | Job row with state badge + progress + stages; log for active/latest job; cancel active |
    | **Shoal Events / Sensors / Firmware** | Often empty on nested sushy (valid). Real BMC: **Poll BMC** fills SEL, sensors (null readings keep a note), firmware inventory, and power. |
 

--- a/docs/real-hardware-sol-runbook.md
+++ b/docs/real-hardware-sol-runbook.md
@@ -179,7 +179,10 @@ Re-run (credentials from gitignored `.env`; never log the password):
 ```bash
 set -a && . ./.env && set +a
 SHOAL_BMC_URL=https://172.16.21.202 \
-  go test ./internal/common/redfish -tags=live_sol -run TestLiveOpenSOL -v -count=1 -timeout 60s
+  go test ./internal/common/redfish -tags=live_sol -run TestLiveOpenSOL$ -v -count=1 -timeout 60s
+# ForceRestart + ~90s POST capture (changes host power):
+SHOAL_BMC_URL=https://172.16.21.202 \
+  go test ./internal/common/redfish -tags=live_sol -run TestLiveOpenSOL_ResetAndRead -v -count=1 -timeout 4m
 ```
 
 CI must not use `-tags=live_sol`. IPMI UDP/623 remains filtered from this

--- a/docs/real-hardware-sol-runbook.md
+++ b/docs/real-hardware-sol-runbook.md
@@ -2,10 +2,10 @@
 
 `internal/common/redfish/sol.go` (`BMC.OpenSOL`) and the `redfish_sol` serial
 transport (`internal/observe/sol/redfish_transport.go`,
-`internal/observe/sol/factory.go`) are **unit-tested only** — sushy-tools
-(the lab BMC simulator) has no SOL support at all, so nothing in this repo's
-automated test suite proves this works against a real BMC. This doc is the
-checklist for the first time a human runs it against real hardware.
+`internal/observe/sol/factory.go`) are proven by fake-SSH unit tests; sushy-tools
+has no SOL, so lab CI cannot. A live attach against the lab iDRAC is recorded
+below (`-tags=live_sol`). Re-run that gated test when firmware or the attach
+path changes.
 
 Read this before pointing `redfish_sol` at a real BMC, and update it (or the
 candidate list in `sol.go`) with what you learn — the initial WebSocket
@@ -13,27 +13,37 @@ candidate URLs are **unverified guesses**, not documented vendor APIs.
 
 ## What's implemented, and how
 
-- **Redfish only.** No IPMI (`ipmitool`) is ever used, regardless of what a
-  BMC advertises. This is a hard project rule, not a v1 limitation.
-- **Discovery order** (`OpenSOL`): classify the BMC vendor from
-  `Manufacturer`/`Model`/manager hints (Dell, Supermicro recognized; same
-  `detectVendor` used by OEM screenshot capture) → try native WebSocket SOL
-  candidates for that vendor → if that's unsupported or fails, check whether
-  Redfish's own capability metadata
-  (`ComputerSystem.SerialConsole.SSH.ServiceEnabled` /
-  `Manager.SerialConsole`) advertises SSH, and if so, open an SSH session
-  (password auth, BMC credentials) using the `ConsoleEntryCommand` Redfish
-  itself provides when present → otherwise, `*redfish.SOLUnsupportedError`
-  with a full debug trail.
-- **Telnet is never attempted** (deferred; a Telnet-only BMC is reported as
-  unsupported, not implemented).
+- **BMC control is Redfish-only.** Power, Virtual Media, boot override, SEL,
+  sensors, inventory, and screenshots never use IPMI (`ipmitool chassis` etc.).
+- **SOL may leave HTTP** (`BMC.OpenSOL`, opt-in `redfish_sol`). Discovery
+  order: classify vendor → try native WebSocket SOL candidates, but **only keep
+  the socket if the first frame is line-oriented SOL text** (HTML/binary/silence
+  fall through; do not treat idle KVM as SOL) → SSH attach when eligible →
+  otherwise `*redfish.SOLUnsupportedError` with a debug trail.
+- **SSH eligibility:** any vendor if `ComputerSystem.SerialConsole.SSH` is
+  enabled, or manager `SerialConsole` lists `SSH`; **Dell only** if
+  `NetworkProtocol.SSH` is enabled or OEM serial-redirection attributes are
+  `Enabled` — even when standard SerialConsole is empty (live iDRAC 7.30 on a
+  PowerEdge R750, 2026-08-23). Attach commands: Redfish `ConsoleEntryCommand` if
+  set; else Dell `console com2`, then `connect`. Non-Dell without
+  `ConsoleEntryCommand` does **not** guess `console com2`. SSH auth is
+  password **and** keyboard-interactive (iDRAC advertises KI only, not
+  `password`).
+- **IPMI 2.0 SOL** is specified in [`docs/sol-transports-design.md`](./sol-transports-design.md)
+  as last resort and **is not implemented yet**. IPMI-only BMCs still return
+  `*SOLUnsupportedError`. `WatchSession.Transport=ipmi_sol` remains an error.
+  On this workstation, UDP/TCP 623 to the lab iDRAC is filtered; a future IPMI
+  client must timeout, not hang.
+- **Host Off:** SSH attach still returns a stream; silence until power-on is
+  Observe’s stall timer, not an OpenSOL error. This runbook does not send
+  power commands; the live probe below is attach-only.
+- **Telnet is never attempted** (deferred).
 - **WebSocket candidates are placeholders.** No vendor publishes a documented
   client-pull plain-text SOL-over-WebSocket endpoint. Real iDRAC/Supermicro
   console redirection is typically an HTML5/binary KVM protocol, not
   line-oriented SOL — the candidates in `solWSCandidates` (`sol.go`) are
-  best-effort guesses in the same spirit as the OEM screenshot-capture
-  candidate list, and are very likely to fail until someone finds the real
-  endpoint on real firmware (see "What to do when it fails" below).
+  best-effort guesses. Per-candidate dial ≤3s; 500ms sniff. Do not expand the
+  URL list until a real SOL URL is proven.
 
 ## Prerequisites
 
@@ -119,10 +129,11 @@ graphics-only failure screens, never the primary progress channel).
   gap, not an oversight; revisit if this transport sees production use.
 - **Telnet is not implemented** — a Telnet-only BMC is reported as
   unsupported, not a crash.
-- **Raw IPMI is never attempted**, even if a BMC only advertises IPMI SOL.
-  This is intentional and permanent (project rule: Redfish only).
-- **WebSocket candidate URLs are unverified** against any real vendor
-  firmware as of this PR — see "What to do when it fails" above.
+- **IPMI 2.0 SOL is specified, not implemented.** IPMI-only BMCs still return
+  `*SOLUnsupportedError`. `WatchSession.Transport=ipmi_sol` remains an error.
+- **WebSocket candidate URLs are not SOL on the probed iDRAC** (`/console`
+  HTTP 200, `/wsman/virtualconsole` 404). Do not expand the list until a real
+  vendor SOL URL is proven.
 - **BMC concurrent-session limits are not load-tested.** `OpenSOL` opens a
   short-lived discovery session (closed before returning) plus one
   long-lived WS/SSH connection per active watch — this is the minimum
@@ -143,3 +154,33 @@ unset SHOAL_SERIAL_TRANSPORT   # or export SHOAL_SERIAL_TRANSPORT=libvirt
 
 or omit `serial_transport` on the `StartJobRequest`. Nothing about the
 default `libvirt` path changes as part of this feature.
+
+## Field notes — Dell PowerEdge R750 / iDRAC 7.30.10.50 (2026-08-23)
+
+Live `OpenSOL` against `https://172.16.21.202` (`System.Embedded.1`),
+attach-only (no power/media/boot changes):
+
+| Probe | Result |
+|-------|--------|
+| Redfish `SerialConsole` | empty (`ConnectTypesSupported=[]`) |
+| `NetworkProtocol.SSH` | enabled, port 22 |
+| OEM `SerialRedirection.1.Enable` | Enabled |
+| `wss://…/console` | HTTP 200, not a WebSocket (101) — sniffed fail, fall through |
+| `wss://…/wsman/virtualconsole` | HTTP 404 |
+| SSH auth methods | `publickey,keyboard-interactive` (**not** `password`) |
+| Attach | `session.Start("console com2")` after KI auth → `Kind=ssh` `vendor=dell` |
+| First bytes (host already On) | ANSI reset/clear, then `Connected to Serial Device 2. To end type: ^\` |
+| After `Reset ForceRestart` (operator-authorized) | BIOS 1.15.2 POST on SOL: PCIe/USB/Video init, `PowerEdge R750`, F2/F10/F11/F12, Lifecycle Controller inventory, `Booting from Ubuntu` → `Boot Failed: Ubuntu` → PXE IPv4 on NIC Slot 5 Port 1 |
+
+`TestLiveOpenSOL_ResetAndRead` (`-tags=live_sol`) attaches first, then `On` or `ForceRestart`, and captures ~90s of console. It sends no Virtual Media / boot override. The host may be left in PXE if the disk boot option failed — that is BIOS policy, not Shoal media.
+
+Re-run (credentials from gitignored `.env`; never log the password):
+
+```bash
+set -a && . ./.env && set +a
+SHOAL_BMC_URL=https://172.16.21.202 \
+  go test ./internal/common/redfish -tags=live_sol -run TestLiveOpenSOL -v -count=1 -timeout 60s
+```
+
+CI must not use `-tags=live_sol`. IPMI UDP/623 remains filtered from this
+workstation; do not treat that as an attach failure.

--- a/docs/sol-transports-design.md
+++ b/docs/sol-transports-design.md
@@ -2,9 +2,9 @@
 
 **Author:** TBD  
 **Date:** 2026-08-23  
-**Status:** Draft (rev 4 — operator decisions 2026-08-23)  
+**Status:** PR1 implemented (`feature/sol-transports` / live iDRAC attach). PR2 (stdlib IPMI SOL) not started. Rev 5.  
 **Companion to:** `SHOAL_COMPREHENSIVE_DESIGN_AND_IMPLEMENTATION_PLAN.md` v2.0.9, `docs/real-hardware-sol-runbook.md`, `AGENTS.md` Golden Rule 6  
-**Not a rewrite of those documents.** This records field findings from a live Dell iDRAC and the rule/interface changes needed so `BMC.OpenSOL` can actually attach on real hardware.
+**Not a rewrite of those documents.** This records field findings from a live Dell iDRAC and the rule/interface changes needed so `BMC.OpenSOL` can actually attach on real hardware. Sections below that say “today” / “current implementation” describe the **pre-PR1** tree; see the runbook for what shipped.
 
 **Rev 2 notes:** IPMI v2.0 byte-accurate tables (RAKP 1–4 unencrypted; Get Channel Auth Caps `[0x0E, 0x84]`; SIDc vs SIDm; Table 15-2 bits; HMAC fixture vectors); Dell-only SSH command guessing; WS sniff must not drop SOL or hang ahead of SSH; PR1 rule text does not claim an IPMI client that is not in the tree.
 
@@ -12,11 +12,13 @@
 
 **Rev 4 notes (operator decisions):** (1) No live attach, power-on, SSH, or IPMI against `172.16.21.202` until the operator says so — PR1/PR2 are fake-SSH / fake-RMCP only. (2) Cipher suite **17** (RAKP-HMAC-SHA256 + HMAC-SHA256-128 + AES-CBC-128) is **in PR2**: try suite 3 first, then 17 if Open Session rejects 3; no other shopping. Stdlib `crypto/sha256` only.
 
+**Rev 5 notes:** Operator authorized live attach and `ForceRestart`. PR1 SSH path proven on iDRAC 7.30.10.50 (`Kind=ssh`, `console com2`, keyboard-interactive; WS `/console` is not SOL). Constraint (1) is lifted for this box; IPMI/UDP 623 still filtered. Field log: `docs/real-hardware-sol-runbook.md`.
+
 ---
 
 ## Overview
 
-Shoal’s real-hardware serial transport (`SHOAL_SERIAL_TRANSPORT=redfish_sol` → `redfish.BMC.OpenSOL`) cannot attach to a representative Dell 15G iDRAC. Redfish `SerialConsole` on that box is empty, the existing WebSocket candidates are unverified KVM-ish guesses, and Golden Rule 6 currently forbids IPMI even as a SOL payload. The operator path that *does* work on this iDRAC is SSH + `console com2` (BMC bridges IPMI SOL internally). SuperMicro-class BMCs typically have no SSH serial CLI at all and need IPMI 2.0 SOL on UDP/623.
+Shoal’s real-hardware serial transport (`SHOAL_SERIAL_TRANSPORT=redfish_sol` → `redfish.BMC.OpenSOL`) **could not** attach to a representative Dell 15G iDRAC before PR1. Redfish `SerialConsole` on that box is empty, the WebSocket candidates are not SOL (HTTP 200 / 404), and Golden Rule 6 previously forbade IPMI even as a SOL payload. The operator path that works on this iDRAC is SSH + `console com2` (BMC bridges IPMI SOL internally) — **implemented and live-proven in PR1**. SuperMicro-class BMCs typically have no SSH serial CLI at all and need IPMI 2.0 SOL on UDP/623 (PR2).
 
 This design splits Golden Rule 6: **BMC control stays Redfish-only**; **SOL may leave HTTP** in a fixed order (line-oriented WS, then vendor SSH attach, then a stdlib-only IPMI 2.0 SOL client as last resort). No new Go modules. No `ipmitool`. Call sites still only see `BMC.OpenSOL`. Lab default remains `libvirt`.
 

--- a/extras/netbox-plugin-shoal/README.md
+++ b/extras/netbox-plugin-shoal/README.md
@@ -57,7 +57,10 @@ secrets backend (`credential_ref` only). Empty user/pass on **power/poll** uses
 stored secrets, then `SHOAL_BMC_*`. **Start provision** still fills empty
 user/pass from `SHOAL_BMC_*` only. Real servers (role ≠ `virtual-bmc-node`)
 prefill `https://<bmc_ip>`; lab virtual BMC nodes keep
-`SHOAL_DEFAULT_BMC_ENDPOINT` (shared sushy).
+`SHOAL_DEFAULT_BMC_ENDPOINT` (shared sushy). Lab Start provision completes
+over sushy + libvirt SOL. A real iDRAC needs `SHOAL_SERIAL_TRANSPORT=redfish_sol`
+on the Shoal process (SOL attach is proven; the BMC still must be able to
+fetch the ISO URL — see `docs/real-hardware-sol-runbook.md`).
 
 ## Development
 

--- a/internal/common/redfish/bmc.go
+++ b/internal/common/redfish/bmc.go
@@ -44,14 +44,14 @@ type BMC interface {
 	// On failure, returned Screenshot.Debug (and error text) include probe steps without secrets.
 	CaptureScreenshot(ctx context.Context, systemID string, kind ScreenshotKind) (Screenshot, error)
 	// OpenSOL opens a serial-over-LAN byte stream for systemID. It tries native
-	// Redfish WebSocket SOL for recognized vendors (Dell, Supermicro) first, then
-	// falls back to SSH only when Redfish's own capability metadata
-	// (ComputerSystem.HostSerialConsole.SSH / Manager.SerialConsole) advertises SSH
-	// as enabled. Never uses raw IPMI, regardless of what a BMC advertises. If a BMC
-	// advertises only IPMI/Oem/Telnet connect types with no working native WS and no
-	// advertised SSH, OpenSOL returns *SOLUnsupportedError. ctx cancellation aborts
-	// discovery/dial; this is the first BMC method that owns a long-lived connection
-	// rather than one round trip, so callers must cancel ctx to release it.
+	// Redfish WebSocket SOL for recognized vendors (Dell, Supermicro) first, but
+	// only keeps a socket that sniffs as line-oriented SOL (not HTML5 KVM). Then
+	// SSH attach when eligible (Redfish SerialConsole.SSH, manager SSH connect
+	// type, or Dell NetworkProtocol/OEM serial-redirection even if SerialConsole
+	// is empty). IPMI 2.0 SOL last resort is specified, not implemented: IPMI-only
+	// BMCs return *SOLUnsupportedError. ctx cancellation aborts discovery/dial;
+	// this is the first BMC method that owns a long-lived connection rather than
+	// one round trip, so callers must cancel ctx to release it.
 	OpenSOL(ctx context.Context, systemID string) (SOLStream, error)
 }
 
@@ -64,8 +64,9 @@ type SOLConnectKind string
 const (
 	// SOLConnectWebSocket is a native Redfish/OEM WebSocket SOL stream.
 	SOLConnectWebSocket SOLConnectKind = "websocket"
-	// SOLConnectSSH is an SSH session opened only because Redfish's own
-	// capability metadata advertised SSH as the BMC's serial console transport.
+	// SOLConnectSSH is an SSH session opened because OpenSOL selected the SSH
+	// backend (Redfish SerialConsole.SSH, manager SSH connect type, or Dell
+	// NetworkProtocol/OEM serial-redirection).
 	SOLConnectSSH SOLConnectKind = "ssh"
 )
 

--- a/internal/common/redfish/sol.go
+++ b/internal/common/redfish/sol.go
@@ -1,19 +1,18 @@
 package redfish
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"fmt"
 	"io"
-	"net"
 	"net/http"
 	"net/url"
-	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	gofishredfish "github.com/stmcginnis/gofish/redfish"
-	"golang.org/x/crypto/ssh"
 
 	"github.com/coder/websocket"
 )
@@ -22,12 +21,11 @@ import (
 //
 // Discovery order: classify the BMC vendor (reused from screenshot.go), try
 // native Redfish/OEM WebSocket SOL candidates for recognized vendors (Dell,
-// Supermicro — unverified placeholder endpoints; see docs/real-hardware-sol-runbook.md),
-// then — only if Redfish's own capability metadata
-// (ComputerSystem.SerialConsole.SSH / Manager.SerialConsole) advertises SSH —
-// fall back to an SSH session using the ComputerSystem-provided
-// ConsoleEntryCommand when present. Raw IPMI is never attempted, and a
-// Telnet-only BMC is treated as unsupported (deferred, not implemented).
+// Supermicro) but only keep a socket that sniffs as line-oriented SOL text,
+// then SSH when eligible (Redfish SerialConsole.SSH, manager SSH connect type,
+// or Dell NetworkProtocol/OEM serial-redirection even if SerialConsole is
+// empty). IPMI 2.0 SOL last resort is specified, not implemented. Telnet-only
+// BMCs are unsupported (deferred).
 func (c *client) OpenSOL(ctx context.Context, systemID string) (SOLStream, error) {
 	var dbg []CaptureDebugStep
 	add := func(step CaptureDebugStep) {
@@ -82,8 +80,16 @@ func (c *client) OpenSOL(ctx context.Context, systemID string) (SOLStream, error
 		}
 	}
 
-	if sys.SerialConsole.SSH.ServiceEnabled {
-		if stream, sshErr := c.trySSHSOL(ctx, sys, vendor, add); sshErr == nil {
+	hint := c.sshEligible(sys, managers, vendor, add)
+	if hint.eligible {
+		ps := strings.TrimSpace(string(sys.PowerState))
+		if ps == "" || strings.EqualFold(ps, "Off") {
+			add(CaptureDebugStep{
+				Phase: "probe", Vendor: string(vendor), OK: true,
+				Message: fmt.Sprintf("PowerState=%s; SOL attach expected silent until power-on", ps),
+			})
+		}
+		if stream, sshErr := c.trySSHSOL(ctx, vendor, hint, add); sshErr == nil {
 			stream.Debug = dbg
 			return stream, nil
 		} else {
@@ -93,7 +99,7 @@ func (c *client) OpenSOL(ctx context.Context, systemID string) (SOLStream, error
 
 	add(CaptureDebugStep{
 		Phase: "probe", Vendor: string(vendor), OK: false,
-		Message: fmt.Sprintf("no supported SOL path (native WS unsupported/failed, Redfish did not advertise SSH); observed connect types: %v", observed),
+		Message: fmt.Sprintf("no supported SOL path (native WS unsupported/failed, SSH ineligible or failed); observed connect types: %v", observed),
 	})
 	return SOLStream{}, &SOLUnsupportedError{Vendor: vendor, ConnectTypes: observed, Debug: dbg}
 }
@@ -155,10 +161,12 @@ func (c *client) tryWebSocketSOL(ctx context.Context, vendor VendorID, managers 
 	for _, candURL := range candidates {
 		start := time.Now()
 		add(CaptureDebugStep{Phase: "request", Vendor: string(vendor), Method: http.MethodGet, URL: candURL, Message: "websocket SOL dial (unverified candidate)"})
-		conn, resp, dialErr := websocket.Dial(ctx, candURL, &websocket.DialOptions{
+		dialCtx, cancelDial := context.WithTimeout(ctx, 3*time.Second)
+		conn, resp, dialErr := websocket.Dial(dialCtx, candURL, &websocket.DialOptions{
 			HTTPClient: httpClient,
 			HTTPHeader: header,
 		})
+		cancelDial()
 		elapsed := time.Since(start).Milliseconds()
 		if dialErr != nil {
 			status := 0
@@ -172,9 +180,29 @@ func (c *client) tryWebSocketSOL(ctx context.Context, vendor VendorID, managers 
 			lastErr = dialErr
 			continue
 		}
-		add(CaptureDebugStep{Phase: "request", Vendor: string(vendor), Method: http.MethodGet, URL: candURL, OK: true, Message: "websocket connected", ElapsedMS: elapsed})
+		sniffCtx, cancelSniff := context.WithTimeout(ctx, 500*time.Millisecond)
+		msgType, frame, sniffErr := conn.Read(sniffCtx)
+		cancelSniff()
+		if sniffErr != nil || msgType != websocket.MessageText || !looksLikeSOLText(frame) {
+			why := "sniff timeout/silence"
+			if sniffErr == nil && msgType != websocket.MessageText {
+				why = "binary websocket frame"
+			} else if sniffErr == nil {
+				why = "html or non-SOL text"
+			}
+			add(CaptureDebugStep{
+				Phase: "parse", Vendor: string(vendor), URL: candURL, OK: false,
+				Message:   "websocket not line-oriented SOL (" + why + "); falling through",
+				ElapsedMS: time.Since(start).Milliseconds(),
+			})
+			_ = conn.Close(websocket.StatusNormalClosure, "")
+			lastErr = fmt.Errorf("websocket sol sniff: %s", why)
+			continue
+		}
+		add(CaptureDebugStep{Phase: "request", Vendor: string(vendor), Method: http.MethodGet, URL: candURL, OK: true, Message: "websocket connected (SOL text)", ElapsedMS: elapsed})
+		rest := websocket.NetConn(context.Background(), conn, websocket.MessageText)
 		return SOLStream{
-			ReadCloser: websocket.NetConn(context.Background(), conn, websocket.MessageText),
+			ReadCloser: &wsSOLCloser{r: io.MultiReader(bytes.NewReader(frame), rest), c: rest},
 			Vendor:     vendor,
 			Kind:       SOLConnectWebSocket,
 		}, nil
@@ -228,111 +256,39 @@ func solWSCandidates(vendor VendorID, base string, managers []*gofishredfish.Man
 	return out
 }
 
-// --- SSH fallback (Redfish-advertised only; never raw IPMI, never guessed) ---
-
-func (c *client) trySSHSOL(ctx context.Context, sys *gofishredfish.ComputerSystem, vendor VendorID, add func(CaptureDebugStep)) (SOLStream, error) {
-	proto := sys.SerialConsole.SSH
-	host, err := sshHost(c.cfg.BaseURL)
-	if err != nil {
-		add(CaptureDebugStep{Phase: "probe", Vendor: string(vendor), OK: false, Message: "resolve BMC host: " + err.Error()})
-		return SOLStream{}, err
-	}
-	port := proto.Port
-	if port <= 0 {
-		port = 22
-	}
-	addr := net.JoinHostPort(host, strconv.Itoa(port))
-
-	add(CaptureDebugStep{
-		Phase: "request", Vendor: string(vendor), Method: "SSH", URL: addr,
-		Message: fmt.Sprintf("dial SSH SOL (Redfish-advertised; console_entry_command=%q)", proto.ConsoleEntryCommand),
-	})
-
-	sshCfg := &ssh.ClientConfig{
-		User: c.cfg.Username,
-		Auth: []ssh.AuthMethod{ssh.Password(c.cfg.Password)},
-		// BMC SSH host keys are not pinned by operators today; this is a
-		// documented limitation (see docs/real-hardware-sol-runbook.md), not an
-		// oversight — Redfish itself is what authorized using SSH here.
-		HostKeyCallback: ssh.InsecureIgnoreHostKey(), //nolint:gosec
-		Timeout:         10 * time.Second,
-	}
-
-	dialer := &net.Dialer{Timeout: sshCfg.Timeout}
-	conn, err := dialer.DialContext(ctx, "tcp", addr)
-	if err != nil {
-		add(CaptureDebugStep{Phase: "request", Vendor: string(vendor), Method: "SSH", URL: addr, OK: false, Message: err.Error()})
-		return SOLStream{}, fmt.Errorf("redfish: ssh sol dial: %w", err)
-	}
-	sshConn, chans, reqs, err := ssh.NewClientConn(conn, addr, sshCfg)
-	if err != nil {
-		_ = conn.Close()
-		add(CaptureDebugStep{Phase: "request", Vendor: string(vendor), Method: "SSH", URL: addr, OK: false, Message: err.Error()})
-		return SOLStream{}, fmt.Errorf("redfish: ssh sol handshake: %w", err)
-	}
-	cl := ssh.NewClient(sshConn, chans, reqs)
-	session, err := cl.NewSession()
-	if err != nil {
-		_ = cl.Close()
-		add(CaptureDebugStep{Phase: "request", Vendor: string(vendor), Method: "SSH", URL: addr, OK: false, Message: err.Error()})
-		return SOLStream{}, fmt.Errorf("redfish: ssh sol session: %w", err)
-	}
-	if err := session.RequestPty("vt100", 24, 80, ssh.TerminalModes{}); err != nil {
-		_ = session.Close()
-		_ = cl.Close()
-		add(CaptureDebugStep{Phase: "request", Vendor: string(vendor), Method: "SSH", URL: addr, OK: false, Message: "request pty: " + err.Error()})
-		return SOLStream{}, fmt.Errorf("redfish: ssh sol pty: %w", err)
-	}
-	stdout, err := session.StdoutPipe()
-	if err != nil {
-		_ = session.Close()
-		_ = cl.Close()
-		return SOLStream{}, fmt.Errorf("redfish: ssh sol stdout: %w", err)
-	}
-
-	if cmd := strings.TrimSpace(proto.ConsoleEntryCommand); cmd != "" {
-		err = session.Start(cmd)
-	} else {
-		err = session.Shell()
-	}
-	if err != nil {
-		_ = session.Close()
-		_ = cl.Close()
-		add(CaptureDebugStep{Phase: "request", Vendor: string(vendor), Method: "SSH", URL: addr, OK: false, Message: "start console: " + err.Error()})
-		return SOLStream{}, fmt.Errorf("redfish: ssh sol start: %w", err)
-	}
-	add(CaptureDebugStep{Phase: "request", Vendor: string(vendor), Method: "SSH", URL: addr, OK: true, Message: "ssh sol session started"})
-
-	return SOLStream{
-		ReadCloser: &sshSOLReadCloser{stdout: stdout, session: session, client: cl},
-		Vendor:     vendor,
-		Kind:       SOLConnectSSH,
-	}, nil
+type wsSOLCloser struct {
+	r io.Reader
+	c io.Closer
 }
 
-func sshHost(base string) (string, error) {
-	u, err := url.Parse(base)
-	if err != nil {
-		return "", fmt.Errorf("parse BaseURL: %w", err)
+func (w *wsSOLCloser) Read(p []byte) (int, error) { return w.r.Read(p) }
+func (w *wsSOLCloser) Close() error               { return w.c.Close() }
+
+func looksLikeSOLText(b []byte) bool {
+	if len(b) == 0 {
+		return false
 	}
-	host := u.Hostname()
-	if host == "" {
-		return "", fmt.Errorf("BaseURL %q has no host", base)
+	s := strings.ToLower(string(b))
+	if strings.Contains(s, "<!doctype") || strings.Contains(s, "<html") {
+		return false
 	}
-	return host, nil
-}
-
-// sshSOLReadCloser adapts an ssh.Session's stdout + owning session/client into
-// a single io.ReadCloser so Close() releases the whole SSH connection.
-type sshSOLReadCloser struct {
-	stdout  io.Reader
-	session *ssh.Session
-	client  *ssh.Client
-}
-
-func (r *sshSOLReadCloser) Read(p []byte) (int, error) { return r.stdout.Read(p) }
-
-func (r *sshSOLReadCloser) Close() error {
-	_ = r.session.Close()
-	return r.client.Close()
+	if bytes.Contains(b, []byte("SHOAL|")) {
+		return true
+	}
+	printable := 0
+	for i := 0; i < len(b); {
+		r, size := utf8.DecodeRune(b[i:])
+		i += size
+		if r == utf8.RuneError && size == 1 {
+			continue
+		}
+		if r == '\n' || r == '\r' || r == '\t' || (r >= 32 && r < 127) {
+			printable++
+		}
+	}
+	runes := utf8.RuneCount(b)
+	if runes == 0 {
+		return false
+	}
+	return printable*10 >= runes*8
 }

--- a/internal/common/redfish/sol_live_test.go
+++ b/internal/common/redfish/sol_live_test.go
@@ -1,0 +1,258 @@
+//go:build live_sol
+
+package redfish_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+	"unicode/utf8"
+
+	"github.com/mattcburns/shoal/internal/common/redfish"
+)
+
+// Live attach against a real BMC (operator-gated).
+//
+//	set -a && . ./.env && set +a
+//	SHOAL_BMC_URL=https://172.16.21.202 \
+//	  go test ./internal/common/redfish -tags=live_sol -run 'TestLiveOpenSOL' -v -count=1 -timeout 4m
+//
+// TestLiveOpenSOL is attach-only (no power). TestLiveOpenSOL_ResetAndRead
+// attaches first, then On / ForceRestart, and records console text.
+
+func TestLiveOpenSOL(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	defer cancel()
+	bmc, sys := liveBMC(t, ctx)
+	defer func() { _ = bmc.Close(context.Background()) }()
+	stream := liveOpenSOL(t, ctx, bmc, sys.ID)
+	defer closeStream(t, stream)
+
+	buf, err := readSOLFor(stream, 3*time.Second)
+	if err != nil && !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("stream read: %v", err)
+	}
+	if len(buf) == 0 {
+		t.Logf("no bytes in 3s (expected when PowerState=Off)")
+		return
+	}
+	t.Logf("read n=%d preview=%q", len(buf), sanitizeConsole(buf, 200))
+}
+
+func TestLiveOpenSOL_ResetAndRead(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+	bmc, sys := liveBMC(t, ctx)
+	defer func() { _ = bmc.Close(context.Background()) }()
+	stream := liveOpenSOL(t, ctx, bmc, sys.ID)
+
+	var (
+		mu   sync.Mutex
+		got  bytes.Buffer
+		rerr error
+	)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		buf := make([]byte, 4096)
+		for {
+			n, err := stream.Read(buf)
+			if n > 0 {
+				mu.Lock()
+				if got.Len() < 256<<10 {
+					_, _ = got.Write(buf[:n])
+				}
+				mu.Unlock()
+			}
+			if err != nil {
+				if !errors.Is(err, io.EOF) {
+					rerr = err
+				}
+				return
+			}
+		}
+	}()
+
+	resetType := "ForceRestart"
+	if !strings.EqualFold(sys.PowerState, "On") {
+		resetType = "On"
+	}
+	t.Logf("Reset %s (was PowerState=%s)", resetType, sys.PowerState)
+	if err := bmc.Reset(ctx, sys.ID, resetType); err != nil {
+		t.Fatalf("Reset %s: %v", resetType, err)
+	}
+
+	deadline := time.Now().Add(90 * time.Second)
+	var last int
+	for time.Now().Before(deadline) {
+		time.Sleep(5 * time.Second)
+		mu.Lock()
+		n := got.Len()
+		mu.Unlock()
+		if n != last {
+			t.Logf("sol bytes so far: %d", n)
+			last = n
+		}
+	}
+	closeStream(t, stream)
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Log("reader still blocked after Close")
+	}
+	mu.Lock()
+	capture := got.Bytes()
+	mu.Unlock()
+	t.Logf("capture n=%d read_err=%v printable=\n%s", len(capture), rerr, sanitizeConsole(capture, 4000))
+	if len(bytes.TrimSpace(stripANSI(capture))) < 8 {
+		t.Fatalf("expected console text after %s, got %d bytes (%q)", resetType, len(capture), sanitizeConsole(capture, 120))
+	}
+}
+
+func liveBMC(t *testing.T, ctx context.Context) (redfish.BMC, redfish.SystemInfo) {
+	t.Helper()
+	base := os.Getenv("SHOAL_BMC_URL")
+	user := os.Getenv("SHOAL_BMC_USERNAME")
+	pass := os.Getenv("SHOAL_BMC_PASSWORD")
+	if base == "" || user == "" || pass == "" {
+		t.Skip("SHOAL_BMC_URL / SHOAL_BMC_USERNAME / SHOAL_BMC_PASSWORD required")
+	}
+	tlsMode := os.Getenv("SHOAL_REDFISH_TLS_MODE")
+	if tlsMode == "" {
+		tlsMode = "insecure"
+	}
+	authMode := os.Getenv("SHOAL_REDFISH_AUTH_MODE")
+	if authMode == "" {
+		authMode = "basic"
+	}
+	bmc, err := redfish.NewBMC(redfish.Config{
+		BaseURL:       base,
+		Username:      user,
+		Password:      pass,
+		AuthMode:      authMode,
+		TLSMode:       tlsMode,
+		MaxConcurrent: 1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := bmc.Open(ctx); err != nil {
+		t.Fatalf("open bmc: %v", err)
+	}
+	systems, err := bmc.ListSystems(ctx)
+	if err != nil || len(systems) == 0 {
+		t.Fatalf("systems: %v n=%d", err, len(systems))
+	}
+	sys := systems[0]
+	t.Logf("system id=%s name=%s manufacturer=%s model=%s power=%s",
+		sys.ID, sys.Name, sys.Manufacturer, sys.Model, sys.PowerState)
+	return bmc, sys
+}
+
+func liveOpenSOL(t *testing.T, ctx context.Context, bmc redfish.BMC, systemID string) redfish.SOLStream {
+	t.Helper()
+	stream, err := bmc.OpenSOL(ctx, systemID)
+	if err != nil {
+		var unsupported *redfish.SOLUnsupportedError
+		if errors.As(err, &unsupported) {
+			t.Logf("OpenSOL unsupported vendor=%s connect_types=%v", unsupported.Vendor, unsupported.ConnectTypes)
+			logDebug(t, unsupported.Debug)
+		}
+		t.Fatalf("OpenSOL: %v", err)
+	}
+	t.Logf("OpenSOL ok kind=%s vendor=%s", stream.Kind, stream.Vendor)
+	logDebug(t, stream.Debug)
+	return stream
+}
+
+func closeStream(t *testing.T, stream redfish.SOLStream) {
+	t.Helper()
+	if stream.ReadCloser == nil {
+		return
+	}
+	if err := stream.Close(); err != nil {
+		t.Logf("stream close: %v", err)
+	}
+}
+
+func readSOLFor(r io.Reader, d time.Duration) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), d)
+	defer cancel()
+	type nerr struct {
+		buf []byte
+		err error
+	}
+	ch := make(chan nerr, 1)
+	go func() {
+		buf := make([]byte, 4096)
+		n, err := r.Read(buf)
+		ch <- nerr{buf: buf[:n], err: err}
+	}()
+	select {
+	case <-ctx.Done():
+		return nil, context.DeadlineExceeded
+	case got := <-ch:
+		if got.err != nil && got.err != io.EOF && len(got.buf) == 0 {
+			return got.buf, got.err
+		}
+		return got.buf, nil
+	}
+}
+
+func stripANSI(b []byte) []byte {
+	var out []byte
+	for i := 0; i < len(b); {
+		if b[i] == 0x1b && i+1 < len(b) && b[i+1] == '[' {
+			i += 2
+			for i < len(b) && (b[i] < 0x40 || b[i] > 0x7e) {
+				i++
+			}
+			if i < len(b) {
+				i++
+			}
+			continue
+		}
+		out = append(out, b[i])
+		i++
+	}
+	return out
+}
+
+func sanitizeConsole(b []byte, max int) string {
+	var bld strings.Builder
+	for i := 0; i < len(b); {
+		r, size := utf8.DecodeRune(b[i:])
+		i += size
+		if r == utf8.RuneError && size == 1 {
+			continue
+		}
+		if r == '\n' || r == '\r' || r == '\t' || (r >= 32 && r < 127) {
+			bld.WriteRune(r)
+		}
+	}
+	s := strings.TrimSpace(bld.String())
+	lower := strings.ToLower(s)
+	for _, bad := range []string{"password", "passwd", "secret", "token"} {
+		if strings.Contains(lower, bad) {
+			return "[redacted: body contained sensitive key]"
+		}
+	}
+	if max > 0 && len(s) > max {
+		s = s[:max] + "…"
+	}
+	return s
+}
+
+func logDebug(t *testing.T, steps []redfish.CaptureDebugStep) {
+	t.Helper()
+	for i, s := range steps {
+		t.Logf("  %d. [%s] ok=%v vendor=%s %s %s status=%d msg=%q elapsed=%dms",
+			i+1, s.Phase, s.OK, s.Vendor, s.Method, s.URL, s.StatusCode, s.Message, s.ElapsedMS)
+	}
+}

--- a/internal/common/redfish/sol_ssh.go
+++ b/internal/common/redfish/sol_ssh.go
@@ -1,0 +1,329 @@
+package redfish
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	gofishredfish "github.com/stmcginnis/gofish/redfish"
+	"golang.org/x/crypto/ssh"
+)
+
+type sshHint struct {
+	eligible bool
+	port     int
+	entryCmd string
+	reason   string
+}
+
+func (c *client) sshEligible(sys *gofishredfish.ComputerSystem, managers []*gofishredfish.Manager, vendor VendorID, add func(CaptureDebugStep)) sshHint {
+	h := sshHint{port: 22, entryCmd: strings.TrimSpace(sys.SerialConsole.SSH.ConsoleEntryCommand)}
+	if p := sys.SerialConsole.SSH.Port; p > 0 {
+		h.port = p
+	}
+
+	if sys.SerialConsole.SSH.ServiceEnabled {
+		h.eligible = true
+		h.reason = "system SerialConsole.SSH.ServiceEnabled"
+	}
+	for _, m := range managers {
+		if m == nil {
+			continue
+		}
+		if m.SerialConsole.ServiceEnabled {
+			for _, ct := range m.SerialConsole.ConnectTypesSupported {
+				if strings.EqualFold(string(ct), string(gofishredfish.SSHSerialConnectTypesSupported)) {
+					h.eligible = true
+					if h.reason == "" {
+						h.reason = "manager SerialConsole ConnectTypesSupported=SSH"
+					}
+				}
+			}
+		}
+	}
+	if vendor == VendorDell {
+		if port, ok := c.dellNetworkProtocolSSH(managers, add); ok {
+			h.eligible = true
+			if h.reason == "" {
+				h.reason = "Dell NetworkProtocol.SSH.ProtocolEnabled"
+			}
+			if h.port == 22 && port > 0 {
+				h.port = port
+			}
+		}
+		if c.dellSerialOEMEnabled(managers, add) {
+			h.eligible = true
+			if h.reason == "" {
+				h.reason = "Dell OEM serial-redirection attributes Enabled"
+			}
+		}
+	}
+	if h.entryCmd != "" && !h.eligible {
+		h.eligible = true
+		h.reason = "ConsoleEntryCommand present"
+	}
+	if h.eligible {
+		add(CaptureDebugStep{Phase: "probe", Vendor: string(vendor), OK: true, Message: "ssh eligible: " + h.reason + fmt.Sprintf(" port=%d", h.port)})
+	} else {
+		add(CaptureDebugStep{Phase: "probe", Vendor: string(vendor), OK: false, Message: "ssh ineligible"})
+	}
+	return h
+}
+
+func (c *client) dellNetworkProtocolSSH(managers []*gofishredfish.Manager, add func(CaptureDebugStep)) (port int, ok bool) {
+	for _, m := range managers {
+		if m == nil {
+			continue
+		}
+		np, err := m.NetworkProtocol()
+		if err != nil || np == nil {
+			add(CaptureDebugStep{Phase: "probe", Vendor: string(VendorDell), OK: false, Message: "NetworkProtocol: not enabled (" + errString(err) + ")"})
+			continue
+		}
+		if np.SSH.ProtocolEnabled {
+			p := int(np.SSH.Port)
+			add(CaptureDebugStep{Phase: "probe", Vendor: string(VendorDell), OK: true, Message: fmt.Sprintf("NetworkProtocol.SSH enabled port=%d", p)})
+			return p, true
+		}
+	}
+	return 0, false
+}
+
+func (c *client) dellSerialOEMEnabled(managers []*gofishredfish.Manager, add func(CaptureDebugStep)) bool {
+	api, err := c.apiClient()
+	if err != nil {
+		return false
+	}
+	keys := []string{"serialredirection.1.enable", "ipmisol.1.enable", "ssh.1.enable"}
+	for _, m := range managers {
+		if m == nil {
+			continue
+		}
+		base := strings.TrimSuffix(m.ODataID, "/")
+		urls := []string{
+			base + "/Oem/Dell/DellAttributes/iDRAC.Embedded.1",
+			base + "/Attributes",
+		}
+		for _, u := range urls {
+			resp, gerr := api.Get(u)
+			if gerr != nil {
+				add(CaptureDebugStep{Phase: "probe", Vendor: string(VendorDell), URL: u, OK: false, Message: "oem attributes: " + gerr.Error()})
+				continue
+			}
+			body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+			_ = resp.Body.Close()
+			if resp.StatusCode == 404 {
+				add(CaptureDebugStep{Phase: "probe", Vendor: string(VendorDell), URL: u, StatusCode: 404, OK: false, Message: "oem attributes 404"})
+				continue
+			}
+			if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+				add(CaptureDebugStep{Phase: "probe", Vendor: string(VendorDell), URL: u, StatusCode: resp.StatusCode, OK: false, Message: "oem attributes HTTP"})
+				continue
+			}
+			var payload struct {
+				Attributes map[string]any `json:"Attributes"`
+			}
+			if json.Unmarshal(body, &payload) != nil || payload.Attributes == nil {
+				continue
+			}
+			for k, v := range payload.Attributes {
+				lk := strings.ToLower(k)
+				for _, want := range keys {
+					if lk == want && strings.EqualFold(fmt.Sprint(v), "Enabled") {
+						add(CaptureDebugStep{Phase: "probe", Vendor: string(VendorDell), URL: u, OK: true, Message: "oem " + k + "=Enabled"})
+						return true
+					}
+				}
+			}
+		}
+	}
+	return false
+}
+
+func errString(err error) string {
+	if err == nil {
+		return "empty"
+	}
+	return err.Error()
+}
+
+func (c *client) trySSHSOL(ctx context.Context, vendor VendorID, hint sshHint, add func(CaptureDebugStep)) (SOLStream, error) {
+	host, err := sshHost(c.cfg.BaseURL)
+	if err != nil {
+		add(CaptureDebugStep{Phase: "probe", Vendor: string(vendor), OK: false, Message: "resolve BMC host: " + err.Error()})
+		return SOLStream{}, err
+	}
+	port := hint.port
+	if port <= 0 {
+		port = 22
+	}
+	addr := net.JoinHostPort(host, strconv.Itoa(port))
+
+	add(CaptureDebugStep{
+		Phase: "request", Vendor: string(vendor), Method: "SSH", URL: addr,
+		Message: fmt.Sprintf("dial SSH SOL (%s; console_entry_command=%q)", hint.reason, hint.entryCmd),
+	})
+
+	password := c.cfg.Password
+	sshCfg := &ssh.ClientConfig{
+		User: c.cfg.Username,
+		Auth: []ssh.AuthMethod{
+			ssh.Password(password),
+			// iDRAC (and many BMCs) advertise keyboard-interactive, not password.
+			ssh.KeyboardInteractive(func(_, _ string, questions []string, _ []bool) ([]string, error) {
+				answers := make([]string, len(questions))
+				for i := range questions {
+					answers[i] = password
+				}
+				return answers, nil
+			}),
+		},
+		// BMC SSH host keys are not pinned by operators today; this is a
+		// documented limitation (see docs/real-hardware-sol-runbook.md), not an
+		// oversight — Redfish itself is what authorized using SSH here.
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(), //nolint:gosec
+		Timeout:         10 * time.Second,
+	}
+
+	dialer := &net.Dialer{Timeout: sshCfg.Timeout}
+	conn, err := dialer.DialContext(ctx, "tcp", addr)
+	if err != nil {
+		add(CaptureDebugStep{Phase: "request", Vendor: string(vendor), Method: "SSH", URL: addr, OK: false, Message: err.Error()})
+		return SOLStream{}, fmt.Errorf("redfish: ssh sol dial: %w", err)
+	}
+	sshConn, chans, reqs, err := ssh.NewClientConn(conn, addr, sshCfg)
+	if err != nil {
+		_ = conn.Close()
+		add(CaptureDebugStep{Phase: "request", Vendor: string(vendor), Method: "SSH", URL: addr, OK: false, Message: err.Error()})
+		return SOLStream{}, fmt.Errorf("redfish: ssh sol handshake: %w", err)
+	}
+	cl := ssh.NewClient(sshConn, chans, reqs)
+
+	openSess := func() (*ssh.Session, io.Reader, io.WriteCloser, error) {
+		session, serr := cl.NewSession()
+		if serr != nil {
+			return nil, nil, nil, serr
+		}
+		if perr := session.RequestPty("vt100", 24, 80, ssh.TerminalModes{}); perr != nil {
+			_ = session.Close()
+			return nil, nil, nil, fmt.Errorf("pty: %w", perr)
+		}
+		stdout, oerr := session.StdoutPipe()
+		if oerr != nil {
+			_ = session.Close()
+			return nil, nil, nil, oerr
+		}
+		if stderr, eerr := session.StderrPipe(); eerr == nil {
+			go func() { _, _ = io.Copy(io.Discard, stderr) }()
+		}
+		stdin, ierr := session.StdinPipe()
+		if ierr != nil {
+			_ = session.Close()
+			return nil, nil, nil, ierr
+		}
+		return session, stdout, stdin, nil
+	}
+
+	startCmd := func(cmd string) (*ssh.Session, io.Reader, io.WriteCloser, error) {
+		session, stdout, stdin, oerr := openSess()
+		if oerr != nil {
+			return nil, nil, nil, oerr
+		}
+		if serr := session.Start(cmd); serr != nil {
+			_ = session.Close()
+			return nil, nil, nil, serr
+		}
+		return session, stdout, stdin, nil
+	}
+
+	var (
+		session *ssh.Session
+		stdout  io.Reader
+		stdin   io.WriteCloser
+	)
+
+	if cmd := strings.TrimSpace(hint.entryCmd); cmd != "" {
+		session, stdout, stdin, err = startCmd(cmd)
+	} else if vendor == VendorDell {
+		session, stdout, stdin, err = startCmd("console com2")
+		if err != nil {
+			if session != nil {
+				_ = session.Close()
+			}
+			add(CaptureDebugStep{Phase: "probe", Vendor: string(vendor), Method: "SSH", URL: addr, OK: false, Message: "console com2 rejected; trying connect"})
+			session, stdout, stdin, err = startCmd("connect")
+		}
+		if err != nil {
+			if session != nil {
+				_ = session.Close()
+			}
+			add(CaptureDebugStep{Phase: "probe", Vendor: string(vendor), Method: "SSH", URL: addr, OK: false, Message: "connect failed; trying shell + write"})
+			session, stdout, stdin, err = openSess()
+			if err == nil {
+				err = session.Shell()
+			}
+			if err == nil && stdin != nil {
+				_, _ = io.WriteString(stdin, "console com2\r\nconnect\r\n")
+			}
+		}
+	} else {
+		_ = cl.Close()
+		add(CaptureDebugStep{Phase: "probe", Vendor: string(vendor), OK: false, Message: "ssh: no ConsoleEntryCommand; vendor attach not implemented"})
+		return SOLStream{}, fmt.Errorf("redfish: ssh sol: no ConsoleEntryCommand; vendor attach not implemented")
+	}
+	if err != nil {
+		if session != nil {
+			_ = session.Close()
+		}
+		_ = cl.Close()
+		add(CaptureDebugStep{Phase: "request", Vendor: string(vendor), Method: "SSH", URL: addr, OK: false, Message: "start console: " + err.Error()})
+		return SOLStream{}, fmt.Errorf("redfish: ssh sol start: %w", err)
+	}
+	add(CaptureDebugStep{Phase: "request", Vendor: string(vendor), Method: "SSH", URL: addr, OK: true, Message: "ssh sol session started"})
+
+	return SOLStream{
+		ReadCloser: &sshSOLReadCloser{stdout: stdout, stdin: stdin, session: session, client: cl},
+		Vendor:     vendor,
+		Kind:       SOLConnectSSH,
+	}, nil
+}
+
+func sshHost(base string) (string, error) {
+	u, err := url.Parse(base)
+	if err != nil {
+		return "", fmt.Errorf("parse BaseURL: %w", err)
+	}
+	host := u.Hostname()
+	if host == "" {
+		return "", fmt.Errorf("BaseURL %q has no host", base)
+	}
+	return host, nil
+}
+
+// sshSOLReadCloser adapts an ssh.Session's stdout + owning session/client into
+// a single io.ReadCloser so Close() detaches Dell SOL then releases SSH.
+type sshSOLReadCloser struct {
+	stdout  io.Reader
+	stdin   io.WriteCloser
+	session *ssh.Session
+	client  *ssh.Client
+}
+
+func (r *sshSOLReadCloser) Read(p []byte) (int, error) { return r.stdout.Read(p) }
+
+func (r *sshSOLReadCloser) Close() error {
+	if r.stdin != nil {
+		_, _ = r.stdin.Write([]byte("\r\x1c."))
+		time.Sleep(50 * time.Millisecond)
+		_, _ = r.stdin.Write([]byte("\x1d."))
+		_ = r.stdin.Close()
+	}
+	_ = r.session.Close()
+	return r.client.Close()
+}

--- a/internal/common/redfish/sol_test.go
+++ b/internal/common/redfish/sol_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 
 	"golang.org/x/crypto/ssh"
@@ -21,9 +22,13 @@ import (
 // --- fake Redfish HTTP server (drives real gofish parsing, not a mock of *client) ---
 
 type fakeSOLServerOpts struct {
-	systemJSON  string // body for /redfish/v1/Systems/1
-	managerJSON string // body for /redfish/v1/Managers/1
-	wsPaths     []string
+	systemJSON          string // body for /redfish/v1/Systems/1
+	managerJSON         string // body for /redfish/v1/Managers/1
+	networkProtocolJSON string // body for /redfish/v1/Managers/1/NetworkProtocol
+	oemAttributesJSON   string // body for Dell OEM Attributes
+	wsPaths             []string
+	wsPayload           []byte                // default: SHOAL|…ws-hello
+	wsMessageType       websocket.MessageType // 0 → text
 }
 
 func newFakeSOLServer(t *testing.T, opts fakeSOLServerOpts) *httptest.Server {
@@ -70,14 +75,41 @@ func newFakeSOLServer(t *testing.T, opts fakeSOLServerOpts) *httptest.Server {
 		}
 		_, _ = io.WriteString(w, body)
 	})
+	mux.HandleFunc("/redfish/v1/Managers/1/NetworkProtocol", func(w http.ResponseWriter, r *http.Request) {
+		if opts.networkProtocolJSON == "" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, opts.networkProtocolJSON)
+	})
+	oemHandler := func(w http.ResponseWriter, r *http.Request) {
+		if opts.oemAttributesJSON == "" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, opts.oemAttributesJSON)
+	}
+	mux.HandleFunc("/redfish/v1/Managers/1/Oem/Dell/DellAttributes/iDRAC.Embedded.1", oemHandler)
+	mux.HandleFunc("/redfish/v1/Managers/1/Attributes", oemHandler)
+	wsType := opts.wsMessageType
+	if wsType == 0 {
+		wsType = websocket.MessageText
+	}
+	wsPayload := opts.wsPayload
+	if wsPayload == nil {
+		wsPayload = []byte("SHOAL|1|1|2026-07-19T00:00:00Z|BOOT|1|OK|ws-hello\n")
+	}
 	for _, p := range opts.wsPaths {
-		mux.HandleFunc(p, func(w http.ResponseWriter, r *http.Request) {
+		path := p
+		mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
 			conn, err := websocket.Accept(w, r, nil)
 			if err != nil {
 				return
 			}
 			defer conn.Close(websocket.StatusNormalClosure, "")
-			_ = conn.Write(r.Context(), websocket.MessageText, []byte("SHOAL|1|1|2026-07-19T00:00:00Z|BOOT|1|OK|ws-hello\n"))
+			_ = conn.Write(r.Context(), wsType, wsPayload)
 			// Keep reading so the client's close-handshake frame is answered
 			// promptly instead of forcing the client to wait out its close timeout.
 			for {
@@ -115,7 +147,7 @@ const systemJSONNoConsole = `{
 	"PowerState": "On"
 }`
 
-func systemJSONWithHostSerialConsole(ssh, telnet, ipmi bool, sshPort int) string {
+func systemJSONWithHostSerialConsole(ssh, telnet, ipmi bool, sshPort int, entryCmd string) string {
 	b := func(v bool) string {
 		if v {
 			return "true"
@@ -131,11 +163,44 @@ func systemJSONWithHostSerialConsole(ssh, telnet, ipmi bool, sshPort int) string
 		"PowerState": "On",
 		"SerialConsole": {
 			"MaxConcurrentSessions": 1,
-			"SSH": {"ServiceEnabled": %s, "Port": %d},
+			"SSH": {"ServiceEnabled": %s, "Port": %d, "ConsoleEntryCommand": %q},
 			"Telnet": {"ServiceEnabled": %s, "Port": 23},
 			"IPMI": {"ServiceEnabled": %s, "Port": 623}
 		}
-	}`, b(ssh), sshPort, b(telnet), b(ipmi))
+	}`, b(ssh), sshPort, entryCmd, b(telnet), b(ipmi))
+}
+
+func managerJSONWithNetworkProtocol() string {
+	return `{
+		"@odata.id": "/redfish/v1/Managers/1",
+		"Id": "1",
+		"Name": "Manager",
+		"NetworkProtocol": {"@odata.id": "/redfish/v1/Managers/1/NetworkProtocol"}
+	}`
+}
+
+func networkProtocolJSON(sshEnabled bool, sshPort int) string {
+	b := "false"
+	if sshEnabled {
+		b = "true"
+	}
+	return fmt.Sprintf(`{
+		"@odata.id": "/redfish/v1/Managers/1/NetworkProtocol",
+		"Id": "NetworkProtocol",
+		"Name": "Manager Network Protocol",
+		"SSH": {"ProtocolEnabled": %s, "Port": %d}
+	}`, b, sshPort)
+}
+
+func systemJSONDell(powerState string) string {
+	return fmt.Sprintf(`{
+		"@odata.id": "/redfish/v1/Systems/1",
+		"Id": "1",
+		"Name": "System.1",
+		"Manufacturer": "Dell Inc.",
+		"Model": "PowerEdge R750",
+		"PowerState": %q
+	}`, powerState)
 }
 
 const systemJSONDellNoConsole = `{
@@ -147,9 +212,73 @@ const systemJSONDellNoConsole = `{
 	"PowerState": "On"
 }`
 
-// --- fake SSH server (proves the Redfish-advertised SSH fallback end to end) ---
+// --- fake SSH server (proves Redfish-advertised and Dell NetworkProtocol attach) ---
 
-func startFakeSSHServer(t *testing.T, user, pass string, lines []string) int {
+type fakeSSHRecorder struct {
+	mu     sync.Mutex
+	Execs  []string
+	Shells int
+	Stdin  []byte
+}
+
+func (r *fakeSSHRecorder) addExec(cmd string) {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	r.Execs = append(r.Execs, cmd)
+	r.mu.Unlock()
+}
+
+func (r *fakeSSHRecorder) addShell() {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	r.Shells++
+	r.mu.Unlock()
+}
+
+func (r *fakeSSHRecorder) addStdin(p []byte) {
+	if r == nil || len(p) == 0 {
+		return
+	}
+	r.mu.Lock()
+	r.Stdin = append(r.Stdin, p...)
+	r.mu.Unlock()
+}
+
+func (r *fakeSSHRecorder) execs() []string {
+	if r == nil {
+		return nil
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]string, len(r.Execs))
+	copy(out, r.Execs)
+	return out
+}
+
+func (r *fakeSSHRecorder) stdin() string {
+	if r == nil {
+		return ""
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return string(r.Stdin)
+}
+
+type fakeSSHOptions struct {
+	user, pass     string
+	lines          []string
+	rejectExecOnce string // Reply(false) the first time this exec command is seen
+	keepOpen       bool   // do not close the channel after writing lines (Close/stdin tests)
+	// keyboardInteractive: advertise only keyboard-interactive (iDRAC shape).
+	keyboardInteractive bool
+	rec                 *fakeSSHRecorder
+}
+
+func startFakeSSHServer(t *testing.T, opts fakeSSHOptions) int {
 	t.Helper()
 	_, priv, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
@@ -159,13 +288,25 @@ func startFakeSSHServer(t *testing.T, user, pass string, lines []string) int {
 	if err != nil {
 		t.Fatal(err)
 	}
-	cfg := &ssh.ServerConfig{
-		PasswordCallback: func(conn ssh.ConnMetadata, password []byte) (*ssh.Permissions, error) {
-			if conn.User() == user && string(password) == pass {
+	cfg := &ssh.ServerConfig{}
+	if opts.keyboardInteractive {
+		cfg.KeyboardInteractiveCallback = func(conn ssh.ConnMetadata, client ssh.KeyboardInteractiveChallenge) (*ssh.Permissions, error) {
+			ans, err := client("", "", []string{"Password: "}, []bool{false})
+			if err != nil {
+				return nil, err
+			}
+			if conn.User() == opts.user && len(ans) > 0 && ans[0] == opts.pass {
 				return nil, nil
 			}
 			return nil, fmt.Errorf("fake ssh: bad credentials")
-		},
+		}
+	} else {
+		cfg.PasswordCallback = func(conn ssh.ConnMetadata, password []byte) (*ssh.Permissions, error) {
+			if conn.User() == opts.user && string(password) == opts.pass {
+				return nil, nil
+			}
+			return nil, fmt.Errorf("fake ssh: bad credentials")
+		}
 	}
 	cfg.AddHostKey(signer)
 
@@ -175,20 +316,22 @@ func startFakeSSHServer(t *testing.T, user, pass string, lines []string) int {
 	}
 	t.Cleanup(func() { _ = ln.Close() })
 
+	var rejectOnce sync.Once
+
 	go func() {
 		for {
 			nConn, err := ln.Accept()
 			if err != nil {
 				return
 			}
-			go serveFakeSSHConn(nConn, cfg, lines)
+			go serveFakeSSHConn(nConn, cfg, opts, &rejectOnce)
 		}
 	}()
 
 	return ln.Addr().(*net.TCPAddr).Port
 }
 
-func serveFakeSSHConn(nConn net.Conn, cfg *ssh.ServerConfig, lines []string) {
+func serveFakeSSHConn(nConn net.Conn, cfg *ssh.ServerConfig, opts fakeSSHOptions, rejectOnce *sync.Once) {
 	sConn, chans, reqs, err := ssh.NewServerConn(nConn, cfg)
 	if err != nil {
 		return
@@ -205,18 +348,47 @@ func serveFakeSSHConn(nConn net.Conn, cfg *ssh.ServerConfig, lines []string) {
 			continue
 		}
 		go func(in <-chan *ssh.Request, ch ssh.Channel) {
+			go func() {
+				buf := make([]byte, 256)
+				for {
+					n, rerr := ch.Read(buf)
+					if n > 0 {
+						opts.rec.addStdin(buf[:n])
+					}
+					if rerr != nil {
+						return
+					}
+				}
+			}()
+			started := false
 			for req := range in {
 				switch req.Type {
 				case "pty-req":
 					_ = req.Reply(true, nil)
-				case "shell", "exec":
-					_ = req.Reply(true, nil)
-					go func() {
-						for _, l := range lines {
-							_, _ = io.WriteString(ch, l+"\n")
+				case "exec":
+					var msg struct{ Command string }
+					_ = ssh.Unmarshal(req.Payload, &msg)
+					opts.rec.addExec(msg.Command)
+					reject := false
+					if opts.rejectExecOnce != "" && msg.Command == opts.rejectExecOnce {
+						rejectOnce.Do(func() { reject = true })
+						if reject {
+							_ = req.Reply(false, nil)
+							continue
 						}
-						_ = ch.Close()
-					}()
+					}
+					_ = req.Reply(true, nil)
+					if !started {
+						started = true
+						go writeFakeSSHLines(ch, opts.lines, opts.keepOpen)
+					}
+				case "shell":
+					opts.rec.addShell()
+					_ = req.Reply(true, nil)
+					if !started {
+						started = true
+						go writeFakeSSHLines(ch, opts.lines, opts.keepOpen)
+					}
 				default:
 					_ = req.Reply(false, nil)
 				}
@@ -225,14 +397,26 @@ func serveFakeSSHConn(nConn net.Conn, cfg *ssh.ServerConfig, lines []string) {
 	}
 }
 
+func writeFakeSSHLines(ch ssh.Channel, lines []string, keepOpen bool) {
+	for _, l := range lines {
+		_, _ = io.WriteString(ch, l+"\n")
+	}
+	if !keepOpen {
+		_ = ch.Close()
+	}
+}
+
 // --- tests ---
 
 func TestOpenSOL_SSHAdvertised_Success(t *testing.T) {
 	sshLines := []string{"SHOAL|1|1|2026-07-19T00:00:00Z|BOOT|1|OK|ssh-hello"}
-	sshPort := startFakeSSHServer(t, "admin", "password", sshLines)
+	rec := &fakeSSHRecorder{}
+	sshPort := startFakeSSHServer(t, fakeSSHOptions{
+		user: "admin", pass: "password", lines: sshLines, rec: rec,
+	})
 
 	srv := newFakeSOLServer(t, fakeSOLServerOpts{
-		systemJSON: systemJSONWithHostSerialConsole(true, false, false, sshPort),
+		systemJSON: systemJSONWithHostSerialConsole(true, false, false, sshPort, "sol-attach"),
 	})
 	c := openFakeClient(t, srv.URL)
 
@@ -251,11 +435,14 @@ func TestOpenSOL_SSHAdvertised_Success(t *testing.T) {
 	if !strings.Contains(got, "ssh-hello") {
 		t.Fatalf("stream content = %q, want it to contain %q", got, "ssh-hello")
 	}
+	if got := rec.execs(); len(got) != 1 || got[0] != "sol-attach" {
+		t.Fatalf("execs = %v, want [sol-attach]", got)
+	}
 }
 
 func TestOpenSOL_IPMIOnly_Unsupported(t *testing.T) {
 	srv := newFakeSOLServer(t, fakeSOLServerOpts{
-		systemJSON: systemJSONWithHostSerialConsole(false, false, true, 623),
+		systemJSON: systemJSONWithHostSerialConsole(false, false, true, 623, ""),
 	})
 	c := openFakeClient(t, srv.URL)
 
@@ -280,7 +467,7 @@ func TestOpenSOL_IPMIOnly_Unsupported(t *testing.T) {
 
 func TestOpenSOL_TelnetOnly_Unsupported(t *testing.T) {
 	srv := newFakeSOLServer(t, fakeSOLServerOpts{
-		systemJSON: systemJSONWithHostSerialConsole(false, true, false, 23),
+		systemJSON: systemJSONWithHostSerialConsole(false, true, false, 23, ""),
 	})
 	c := openFakeClient(t, srv.URL)
 
@@ -355,7 +542,7 @@ func TestOpenSOL_WebSocketCandidatesFail_Unsupported(t *testing.T) {
 
 func TestOpenSOL_DebugTrailRedactsSecrets(t *testing.T) {
 	srv := newFakeSOLServer(t, fakeSOLServerOpts{
-		systemJSON: systemJSONWithHostSerialConsole(false, false, true, 623),
+		systemJSON: systemJSONWithHostSerialConsole(false, false, true, 623, ""),
 	})
 	c := openFakeClient(t, srv.URL)
 
@@ -372,5 +559,295 @@ func TestOpenSOL_DebugTrailRedactsSecrets(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "IPMI") {
 		t.Fatalf("error text = %q, want it to mention observed IPMI connect type", err.Error())
+	}
+}
+
+func TestOpenSOL_DellEmptySerialConsole_SSHAttach(t *testing.T) {
+	sshLines := []string{"SHOAL|1|1|2026-07-19T00:00:00Z|BOOT|1|OK|dell-com2"}
+	rec := &fakeSSHRecorder{}
+	sshPort := startFakeSSHServer(t, fakeSSHOptions{
+		user: "admin", pass: "password", lines: sshLines, rec: rec,
+	})
+	srv := newFakeSOLServer(t, fakeSOLServerOpts{
+		systemJSON:          systemJSONDell("On"),
+		managerJSON:         managerJSONWithNetworkProtocol(),
+		networkProtocolJSON: networkProtocolJSON(true, sshPort),
+	})
+	c := openFakeClient(t, srv.URL)
+
+	stream, err := c.OpenSOL(context.Background(), "1")
+	if err != nil {
+		t.Fatalf("OpenSOL: %v", err)
+	}
+	defer stream.Close()
+	if stream.Kind != SOLConnectSSH {
+		t.Fatalf("kind = %q, want ssh", stream.Kind)
+	}
+	if stream.Vendor != VendorDell {
+		t.Fatalf("vendor = %q, want dell", stream.Vendor)
+	}
+	buf := make([]byte, 4096)
+	n, _ := io.ReadFull(stream, buf[:len(sshLines[0])+1])
+	if !strings.Contains(string(buf[:n]), "dell-com2") {
+		t.Fatalf("stream content = %q, want dell-com2", buf[:n])
+	}
+	if got := rec.execs(); len(got) != 1 || got[0] != "console com2" {
+		t.Fatalf("execs = %v, want [console com2]", got)
+	}
+}
+
+func TestOpenSOL_DellSSH_KeyboardInteractive(t *testing.T) {
+	sshLines := []string{"SHOAL|1|1|2026-07-19T00:00:00Z|BOOT|1|OK|ki-hello"}
+	rec := &fakeSSHRecorder{}
+	sshPort := startFakeSSHServer(t, fakeSSHOptions{
+		user: "admin", pass: "password", lines: sshLines, rec: rec,
+		keyboardInteractive: true,
+	})
+	srv := newFakeSOLServer(t, fakeSOLServerOpts{
+		systemJSON:          systemJSONDell("On"),
+		managerJSON:         managerJSONWithNetworkProtocol(),
+		networkProtocolJSON: networkProtocolJSON(true, sshPort),
+	})
+	c := openFakeClient(t, srv.URL)
+
+	stream, err := c.OpenSOL(context.Background(), "1")
+	if err != nil {
+		t.Fatalf("OpenSOL: %v", err)
+	}
+	defer stream.Close()
+	if stream.Kind != SOLConnectSSH {
+		t.Fatalf("kind = %q, want ssh", stream.Kind)
+	}
+	buf := make([]byte, 4096)
+	n, _ := io.ReadFull(stream, buf[:len(sshLines[0])+1])
+	if !strings.Contains(string(buf[:n]), "ki-hello") {
+		t.Fatalf("stream content = %q, want ki-hello", buf[:n])
+	}
+}
+
+func TestOpenSOL_DellSSH_ConnectFallback(t *testing.T) {
+	sshLines := []string{"SHOAL|1|1|2026-07-19T00:00:00Z|BOOT|1|OK|via-connect"}
+	rec := &fakeSSHRecorder{}
+	sshPort := startFakeSSHServer(t, fakeSSHOptions{
+		user: "admin", pass: "password", lines: sshLines, rec: rec,
+		rejectExecOnce: "console com2",
+	})
+	srv := newFakeSOLServer(t, fakeSOLServerOpts{
+		systemJSON:          systemJSONDell("On"),
+		managerJSON:         managerJSONWithNetworkProtocol(),
+		networkProtocolJSON: networkProtocolJSON(true, sshPort),
+	})
+	c := openFakeClient(t, srv.URL)
+
+	stream, err := c.OpenSOL(context.Background(), "1")
+	if err != nil {
+		t.Fatalf("OpenSOL: %v", err)
+	}
+	defer stream.Close()
+	if stream.Kind != SOLConnectSSH {
+		t.Fatalf("kind = %q, want ssh", stream.Kind)
+	}
+	buf := make([]byte, 4096)
+	n, _ := io.ReadFull(stream, buf[:len(sshLines[0])+1])
+	if !strings.Contains(string(buf[:n]), "via-connect") {
+		t.Fatalf("stream content = %q, want via-connect", buf[:n])
+	}
+	if got := rec.execs(); len(got) != 2 || got[0] != "console com2" || got[1] != "connect" {
+		t.Fatalf("execs = %v, want [console com2 connect]", got)
+	}
+}
+
+func TestOpenSOL_HostOff_QuietStreamNotError(t *testing.T) {
+	rec := &fakeSSHRecorder{}
+	sshPort := startFakeSSHServer(t, fakeSSHOptions{
+		user: "admin", pass: "password", keepOpen: true, rec: rec,
+	})
+	srv := newFakeSOLServer(t, fakeSOLServerOpts{
+		systemJSON:          systemJSONDell("Off"),
+		managerJSON:         managerJSONWithNetworkProtocol(),
+		networkProtocolJSON: networkProtocolJSON(true, sshPort),
+	})
+	c := openFakeClient(t, srv.URL)
+
+	stream, err := c.OpenSOL(context.Background(), "1")
+	if err != nil {
+		t.Fatalf("OpenSOL with PowerState=Off: %v", err)
+	}
+	defer stream.Close()
+	if stream.Kind != SOLConnectSSH {
+		t.Fatalf("kind = %q, want ssh", stream.Kind)
+	}
+	found := false
+	for _, step := range stream.Debug {
+		if strings.Contains(step.Message, "PowerState=Off") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("debug trail missing PowerState=Off quiet-stream note: %+v", stream.Debug)
+	}
+	if got := rec.execs(); len(got) != 1 || got[0] != "console com2" {
+		t.Fatalf("execs = %v, want [console com2]", got)
+	}
+}
+
+func TestOpenSOL_WSHTMLOrBinary_FallsThroughToSSH(t *testing.T) {
+	sshLines := []string{"SHOAL|1|1|2026-07-19T00:00:00Z|BOOT|1|OK|after-kvm"}
+	rec := &fakeSSHRecorder{}
+	sshPort := startFakeSSHServer(t, fakeSSHOptions{
+		user: "admin", pass: "password", lines: sshLines, rec: rec,
+	})
+	srv := newFakeSOLServer(t, fakeSOLServerOpts{
+		systemJSON:          systemJSONDell("On"),
+		managerJSON:         managerJSONWithNetworkProtocol(),
+		networkProtocolJSON: networkProtocolJSON(true, sshPort),
+		wsPaths:             []string{"/console"},
+		wsPayload:           []byte("<!DOCTYPE html><html><body>kvm</body></html>"),
+	})
+	c := openFakeClient(t, srv.URL)
+
+	stream, err := c.OpenSOL(context.Background(), "1")
+	if err != nil {
+		t.Fatalf("OpenSOL: %v", err)
+	}
+	defer stream.Close()
+	if stream.Kind != SOLConnectSSH {
+		t.Fatalf("kind = %q, want ssh (HTML websocket must fall through), got %q", stream.Kind, stream.Kind)
+	}
+	buf := make([]byte, 4096)
+	n, _ := io.ReadFull(stream, buf[:len(sshLines[0])+1])
+	if !strings.Contains(string(buf[:n]), "after-kvm") {
+		t.Fatalf("first SOL line = %q, want it from SSH (after-kvm), not WS HTML", buf[:n])
+	}
+}
+
+func TestOpenSOL_WSBinary_FallsThroughToSSH(t *testing.T) {
+	sshLines := []string{"SHOAL|1|1|2026-07-19T00:00:00Z|BOOT|1|OK|after-binary"}
+	rec := &fakeSSHRecorder{}
+	sshPort := startFakeSSHServer(t, fakeSSHOptions{
+		user: "admin", pass: "password", lines: sshLines, rec: rec,
+	})
+	srv := newFakeSOLServer(t, fakeSOLServerOpts{
+		systemJSON:          systemJSONDell("On"),
+		managerJSON:         managerJSONWithNetworkProtocol(),
+		networkProtocolJSON: networkProtocolJSON(true, sshPort),
+		wsPaths:             []string{"/console"},
+		wsMessageType:       websocket.MessageBinary,
+		wsPayload:           []byte{0x00, 0x01, 0xff, 0x80, 0x00},
+	})
+	c := openFakeClient(t, srv.URL)
+
+	stream, err := c.OpenSOL(context.Background(), "1")
+	if err != nil {
+		t.Fatalf("OpenSOL: %v", err)
+	}
+	defer stream.Close()
+	if stream.Kind != SOLConnectSSH {
+		t.Fatalf("kind = %q, want ssh (binary websocket must fall through)", stream.Kind)
+	}
+	buf := make([]byte, 4096)
+	n, _ := io.ReadFull(stream, buf[:len(sshLines[0])+1])
+	if !strings.Contains(string(buf[:n]), "after-binary") {
+		t.Fatalf("stream = %q, want after-binary from SSH", buf[:n])
+	}
+}
+
+func TestOpenSOL_WSTextSOL_PrependsFirstFrame(t *testing.T) {
+	srv := newFakeSOLServer(t, fakeSOLServerOpts{
+		systemJSON: systemJSONDellNoConsole,
+		wsPaths:    []string{"/console"},
+	})
+	c := openFakeClient(t, srv.URL)
+
+	stream, err := c.OpenSOL(context.Background(), "1")
+	if err != nil {
+		t.Fatalf("OpenSOL: %v", err)
+	}
+	defer stream.Close()
+	if stream.Kind != SOLConnectWebSocket {
+		t.Fatalf("kind = %q, want websocket", stream.Kind)
+	}
+	buf := make([]byte, 256)
+	n, err := stream.Read(buf)
+	if err != nil && n == 0 {
+		t.Fatalf("read: %v", err)
+	}
+	if !strings.Contains(string(buf[:n]), "ws-hello") {
+		t.Fatalf("stream content = %q, want prepended sniff frame with ws-hello", string(buf[:n]))
+	}
+}
+
+func TestOpenSOL_NonDellNetworkProtocolOnly_NoConsoleCom2(t *testing.T) {
+	rec := &fakeSSHRecorder{}
+	sshPort := startFakeSSHServer(t, fakeSSHOptions{
+		user: "admin", pass: "password",
+		lines: []string{"should-not-see"},
+		rec:   rec,
+	})
+	srv := newFakeSOLServer(t, fakeSOLServerOpts{
+		systemJSON: `{
+			"@odata.id": "/redfish/v1/Systems/1",
+			"Id": "1",
+			"Name": "System.1",
+			"Manufacturer": "Super Micro Computer",
+			"Model": "X11",
+			"PowerState": "On"
+		}`,
+		managerJSON:         managerJSONWithNetworkProtocol(),
+		networkProtocolJSON: networkProtocolJSON(true, sshPort),
+	})
+	c := openFakeClient(t, srv.URL)
+
+	_, err := c.OpenSOL(context.Background(), "1")
+	var unsupported *SOLUnsupportedError
+	if !errors.As(err, &unsupported) {
+		t.Fatalf("expected *SOLUnsupportedError, got %T: %v", err, err)
+	}
+	if unsupported.Vendor != VendorSupermicro {
+		t.Fatalf("vendor = %q, want supermicro", unsupported.Vendor)
+	}
+	ineligible := false
+	for _, step := range unsupported.Debug {
+		if strings.Contains(step.Message, "ssh ineligible") {
+			ineligible = true
+		}
+		if strings.Contains(step.Message, "console com2") {
+			t.Fatalf("non-Dell must not guess console com2: %+v", step)
+		}
+	}
+	if !ineligible {
+		t.Fatalf("debug trail should record ssh ineligible; got %+v", unsupported.Debug)
+	}
+	if got := rec.execs(); len(got) != 0 {
+		t.Fatalf("execs = %v, want none (must not Start console com2)", got)
+	}
+}
+
+func TestOpenSOL_DellSSH_CloseWritesDetach(t *testing.T) {
+	rec := &fakeSSHRecorder{}
+	sshPort := startFakeSSHServer(t, fakeSSHOptions{
+		user: "admin", pass: "password",
+		lines:    []string{"attached"},
+		keepOpen: true,
+		rec:      rec,
+	})
+	srv := newFakeSOLServer(t, fakeSOLServerOpts{
+		systemJSON:          systemJSONDell("On"),
+		managerJSON:         managerJSONWithNetworkProtocol(),
+		networkProtocolJSON: networkProtocolJSON(true, sshPort),
+	})
+	c := openFakeClient(t, srv.URL)
+
+	stream, err := c.OpenSOL(context.Background(), "1")
+	if err != nil {
+		t.Fatalf("OpenSOL: %v", err)
+	}
+	if err := stream.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	got := rec.stdin()
+	if !strings.Contains(got, "\r\x1c.") {
+		t.Fatalf("Close stdin = %q, want it to contain Dell detach \\r\\x1c.", got)
 	}
 }

--- a/internal/observe/sol/factory.go
+++ b/internal/observe/sol/factory.go
@@ -20,8 +20,9 @@ type RedfishSOLConfig struct {
 }
 
 // NewCombinedTransportFactory dispatches on session.Transport:
-//   - "redfish_sol": native Redfish SOL (WebSocket, or SSH iff Redfish's own
-//     capability metadata advertised it). Never IPMI.
+//   - "redfish_sol": BMC.OpenSOL (line-oriented WS, then SSH attach). IPMI SOL
+//     last-resort is not implemented yet; OpenSOL returns unsupported for
+//     IPMI-only BMCs. Never a watch transport named ipmi_sol.
 //   - "libvirt", "": existing SSH/local libvirt tailing (delegates to
 //     NewTransportFactory(sshCfg)).
 //   - anything else (including the legacy "ipmi_sol"): a transport whose

--- a/internal/observe/sol/redfish_transport.go
+++ b/internal/observe/sol/redfish_transport.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	"log/slog"
 	"sync"
 
 	"github.com/mattcburns/shoal/internal/common/redfish"
@@ -81,6 +82,7 @@ func (t *RedfishTransport) Open(ctx context.Context, target string) (<-chan stri
 		_ = bmc.Close(context.Background())
 		return nil, fmt.Errorf("sol: redfish transport: open sol: %w", err)
 	}
+	slog.Info("sol watch attached", "sol_kind", string(stream.Kind), "vendor", string(stream.Vendor))
 
 	t.bmc = bmc
 	t.stream = stream


### PR DESCRIPTION
PR1 of the real-hardware SOL work (`docs/sol-transports-design.md` rev 4).

## What changed

Splits Golden Rule 6: **BMC control stays Redfish-only**; `BMC.OpenSOL` may leave HTTP.

`OpenSOL` discovery order:
1. Line-oriented WebSocket only if the first frame sniffs as SOL text (HTML/binary/silence fall through; first SOL frame is prepended).
2. SSH when eligible — including Dell with **empty** `SerialConsole` if `NetworkProtocol.SSH` or OEM serial-redirection is on.
3. IPMI 2.0 SOL last resort is **specified, not implemented**. IPMI-only BMCs still return `*SOLUnsupportedError`. `WatchSession.Transport=ipmi_sol` remains an error.

Dell attach: `console com2` → `connect`. Auth is password **and** keyboard-interactive (this iDRAC advertises KI only). Close writes Dell detach `\\r\\x1c.`.

Lab default `libvirt` is unchanged. `go.mod` unchanged.

## Tests

- Fake-SSH / fake-Redfish unit tests (empty SerialConsole, connect fallback, Host Off, KI auth, WS HTML/binary fallthrough, Close detach, IPMI-only still unsupported).
- `gofmt` / `go vet` / `staticcheck` / `go test ./...`
- Operator-gated live attach (`-tags=live_sol`, not CI) against iDRAC 7.30.10.50 / PowerEdge R750 `172.16.21.202`: `Kind=ssh`, POST over SOL after ForceRestart (BIOS 1.15.2, Ubuntu boot failed, PXE).

See `docs/real-hardware-sol-runbook.md` field notes.

## Out of scope (follow-on)

- PR2: stdlib IPMI 2.0 SOL (`internal/common/redfish/internal/ipmi`, cipher suite 3 then 17)
- HPE `vsp`/`textcons`, ATEN SMASH-CLP
- ISO reachability / a full provision job against this BMC