### PR TITLE
feat(sol): stdlib IPMI 2.0 SOL last-resort backend

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,11 +57,10 @@ These encode the core design decisions. Violating one is a bug, even if tests pa
    (2) SSH to the BMC + vendor attach command when SSH is enabled — including when
    standard `ComputerSystem.SerialConsole` (gofish `HostSerialConsole`) is empty
    but `NetworkProtocol` / Dell OEM serial-redirection attributes show serial is
-   on. **IPMI 2.0 SOL as last resort is specified in
-   `docs/sol-transports-design.md`; it is not implemented in this change.** Until
-   that follow-on lands, an IPMI-only BMC still returns `*SOLUnsupportedError`.
-   IPMI, when implemented, is a SOL payload, not a second BMC API. Call sites
-   still only see `OpenSOL`.
+   on; (3) IPMI 2.0 SOL (LAN plus, stdlib client in
+   `internal/common/redfish/internal/ipmi`) as **last resort** when no SSH serial
+   path exists. IPMI is a SOL payload, not a second BMC API. Call sites still
+   only see `OpenSOL`. IPMI types must not leak into Deploy/Observe.
 7. **Artifact/ISO serving is plain HTTP on the management segment for MVP.** Do
    not add TLS to the ISO server (many BMCs reject self-signed certs); TLS is
    Phase 6. Phase 2 publishes ISOs to the lab ISO dir and serves them at
@@ -455,11 +454,10 @@ Live-server remaster (`SHOAL_UBUNTU_ISO`) is alternate/stretch. **7b/7c deferred
   `internal/common/redfish/sol.go`) behind `sol.Transport`. BMC **control** stays
   Redfish-only. `OpenSOL` may use line-oriented WebSocket or SSH attach (Dell
   `console com2` / `connect` when SerialConsole is empty but SSH/serial OEM is
-  on). **IPMI 2.0 SOL last-resort client is not yet in the tree** — IPMI-only
-  BMCs still return `*SOLUnsupportedError` with a debug trail.
+  on). IPMI 2.0 SOL is last-resort inside `OpenSOL` (cipher suite 3 then 17);
   `WatchSession.Transport=ipmi_sol` remains an error (IPMI is not a watch
-  transport). Fake-SSH unit tests always run; sushy-tools has no SOL. Live
-  iDRAC attach is operator-gated (`go test -tags=live_sol`); see
+  transport). Fake-SSH and fake-RMCP unit tests always run; sushy-tools has no
+  SOL. Live iDRAC attach is operator-gated (`go test -tags=live_sol`); see
   `docs/real-hardware-sol-runbook.md` and `docs/sol-transports-design.md`.
 - Capture real Redfish responses into the **record/replay corpus**
   (`testdata/redfish/`) when you hit a new vendor/firmware shape, and add a

--- a/SHOAL_COMPREHENSIVE_DESIGN_AND_IMPLEMENTATION_PLAN.md
+++ b/SHOAL_COMPREHENSIVE_DESIGN_AND_IMPLEMENTATION_PLAN.md
@@ -558,7 +558,7 @@ Fields/transitions **only Orchestrator commits**: `state` (`LifecycleState`), `a
 
 Explicit cancel: `PROVISIONING --cancel--> (cleanup) --> FAILED` (with `error=canceled`), then device may return to READY when re-enqueued. Do **not** invent a separate long-lived `CLEANUP` lifecycle enum for MVP; cleanup is a **mandatory finalizer** inside `HandleTerminal`, not a NetBox-facing state.
 
-**Transport**: lab uses libvirt guest serial (Section 8). Real hardware uses `redfish_sol` → `BMC.OpenSOL` (line-oriented WS if actually SOL, else SSH attach — Dell `console com2` even when `SerialConsole` is empty). IPMI 2.0 SOL last-resort is specified (`docs/sol-transports-design.md`), not yet in tree.
+**Transport**: lab uses libvirt guest serial (Section 8). Real hardware uses `redfish_sol` → `BMC.OpenSOL` (line-oriented WS if actually SOL, else SSH attach — Dell `console com2` even when `SerialConsole` is empty — else IPMI 2.0 SOL last resort, stdlib client, cipher suite 3 then 17).
 
 ```go
 // internal/observe/sol — parser returns models.SOLMarker (common), not deploy types
@@ -1154,7 +1154,7 @@ Implementation notes:
 | `github.com/jackc/pgx/v5` | runtime (default) | Postgres driver for lab telemetry/jobs DB on `:5433` |
 | `modernc.org/sqlite` | runtime (optional demo) | Pure-Go SQLite if someone runs without Compose; not required for lab ACs |
 | `github.com/coder/websocket` | runtime (required) | Real Redfish SOL transport: native WebSocket SOL dial for recognized BMC vendors (`internal/common/redfish/sol.go`); gofish has no client-side streaming/WebSocket support. Context-native `Read`/`Close` fits the cancellation-bounded `sol.Transport` contract. |
-| `golang.org/x/crypto` (`ssh` subpackage) | runtime (required) | Real-hardware SOL: SSH attach for `OpenSOL` when Redfish SerialConsole advertises SSH **or** (Dell) NetworkProtocol/OEM serial-redirection is enabled. Password and keyboard-interactive auth against BMC credentials (iDRAC offers KI only). Already an indirect transitive dep (gofish/pgx); used in `internal/common/redfish/sol.go`. Never used for IPMI or BMC control. |
+| `golang.org/x/crypto` (`ssh` subpackage) | runtime (required) | Real-hardware SOL: SSH attach for `OpenSOL` when Redfish SerialConsole advertises SSH **or** (Dell) NetworkProtocol/OEM serial-redirection is enabled. Password and keyboard-interactive auth against BMC credentials (iDRAC offers KI only). Already an indirect transitive dep (gofish/pgx); used in `internal/common/redfish/sol.go`. Never used for IPMI or BMC control. IPMI 2.0 SOL is stdlib-only (`net`, `crypto/sha1`, `crypto/sha256`, `crypto/aes`, …) in `internal/common/redfish/internal/ipmi` — **no new module**. |
 | `honnef.co/go/tools/cmd/staticcheck` | toolchain | Static analysis beyond `go vet`; not linked into binary |
 
 **Toolchain install (AGENTS / CI):**
@@ -1700,7 +1700,7 @@ Golden Rules:
 3. Secrets never to LLM/log; `credential_ref` only
 4. NetBox identity + lifecycle only
 5. SOL markers primary progress; OCR diagnostic
-6. BMC control Redfish-only via `internal/common/redfish` (**gofish-backed**; no gofish types outside that package). SOL may leave HTTP (WS / SSH attach); IPMI 2.0 SOL last-resort client is a specified follow-on, not yet in tree. Never IPMI for power/media/SEL/sensors/inventory.
+6. BMC control Redfish-only via `internal/common/redfish` (**gofish-backed**; no gofish types outside that package). SOL may leave HTTP (WS / SSH attach / IPMI 2.0 SOL last-resort in `internal/common/redfish/internal/ipmi`). Never IPMI for power/media/SEL/sensors/inventory.
 7. Plain HTTP ISO on mgmt segment for MVP
 8. Structs + validate/decode pipeline for AI I/O
 9. Component boundaries §3–4; **no observe↔deploy imports** (use `jobport`/`watchport`)

--- a/docs/real-hardware-sol-runbook.md
+++ b/docs/real-hardware-sol-runbook.md
@@ -19,7 +19,8 @@ candidate URLs are **unverified guesses**, not documented vendor APIs.
   order: classify vendor → try native WebSocket SOL candidates, but **only keep
   the socket if the first frame is line-oriented SOL text** (HTML/binary/silence
   fall through; do not treat idle KVM as SOL) → SSH attach when eligible →
-  otherwise `*redfish.SOLUnsupportedError` with a debug trail.
+  IPMI 2.0 SOL last resort → otherwise `*redfish.SOLUnsupportedError` with a
+  debug trail.
 - **SSH eligibility:** any vendor if `ComputerSystem.SerialConsole.SSH` is
   enabled, or manager `SerialConsole` lists `SSH`; **Dell only** if
   `NetworkProtocol.SSH` is enabled or OEM serial-redirection attributes are
@@ -29,11 +30,10 @@ candidate URLs are **unverified guesses**, not documented vendor APIs.
   `ConsoleEntryCommand` does **not** guess `console com2`. SSH auth is
   password **and** keyboard-interactive (iDRAC advertises KI only, not
   `password`).
-- **IPMI 2.0 SOL** is specified in [`docs/sol-transports-design.md`](./sol-transports-design.md)
-  as last resort and **is not implemented yet**. IPMI-only BMCs still return
-  `*SOLUnsupportedError`. `WatchSession.Transport=ipmi_sol` remains an error.
-  On this workstation, UDP/TCP 623 to the lab iDRAC is filtered; a future IPMI
-  client must timeout, not hang.
+- **IPMI 2.0 SOL** is last resort inside `OpenSOL` (stdlib client, cipher suite
+  3 then 17). `WatchSession.Transport=ipmi_sol` remains an error. UDP timeout on
+  Get Channel Auth Caps is recorded in the debug trail and does **not** try
+  suite 17. On this workstation, UDP/TCP 623 to the lab iDRAC is filtered.
 - **Host Off:** SSH attach still returns a stream; silence until power-on is
   Observe’s stall timer, not an OpenSOL error. This runbook does not send
   power commands; the live probe below is attach-only.
@@ -129,8 +129,8 @@ graphics-only failure screens, never the primary progress channel).
   gap, not an oversight; revisit if this transport sees production use.
 - **Telnet is not implemented** — a Telnet-only BMC is reported as
   unsupported, not a crash.
-- **IPMI 2.0 SOL is specified, not implemented.** IPMI-only BMCs still return
-  `*SOLUnsupportedError`. `WatchSession.Transport=ipmi_sol` remains an error.
+- **IPMI 2.0 SOL is last-resort inside OpenSOL.** `ipmi_sol` is not a watch
+  transport. UDP/623 filtered from this workstation times out; do not hang.
 - **WebSocket candidate URLs are not SOL on the probed iDRAC** (`/console`
   HTTP 200, `/wsman/virtualconsole` 404). Do not expand the list until a real
   vendor SOL URL is proven.

--- a/docs/sol-transports-design.md
+++ b/docs/sol-transports-design.md
@@ -2,7 +2,7 @@
 
 **Author:** TBD  
 **Date:** 2026-08-23  
-**Status:** PR1 implemented (`feature/sol-transports` / live iDRAC attach). PR2 (stdlib IPMI SOL) not started. Rev 5.  
+**Status:** PR1 implemented (live iDRAC SSH attach). PR2 stdlib IPMI SOL implemented (`internal/common/redfish/internal/ipmi`). Rev 6.  
 **Companion to:** `SHOAL_COMPREHENSIVE_DESIGN_AND_IMPLEMENTATION_PLAN.md` v2.0.9, `docs/real-hardware-sol-runbook.md`, `AGENTS.md` Golden Rule 6  
 **Not a rewrite of those documents.** This records field findings from a live Dell iDRAC and the rule/interface changes needed so `BMC.OpenSOL` can actually attach on real hardware. Sections below that say “today” / “current implementation” describe the **pre-PR1** tree; see the runbook for what shipped.
 

--- a/internal/common/redfish/bmc.go
+++ b/internal/common/redfish/bmc.go
@@ -48,10 +48,10 @@ type BMC interface {
 	// only keeps a socket that sniffs as line-oriented SOL (not HTML5 KVM). Then
 	// SSH attach when eligible (Redfish SerialConsole.SSH, manager SSH connect
 	// type, or Dell NetworkProtocol/OEM serial-redirection even if SerialConsole
-	// is empty). IPMI 2.0 SOL last resort is specified, not implemented: IPMI-only
-	// BMCs return *SOLUnsupportedError. ctx cancellation aborts discovery/dial;
-	// this is the first BMC method that owns a long-lived connection rather than
-	// one round trip, so callers must cancel ctx to release it.
+	// is empty), then IPMI 2.0 SOL as last resort (stdlib client; not a second
+	// BMC API). ctx cancellation aborts discovery/dial; this is the first BMC
+	// method that owns a long-lived connection rather than one round trip, so
+	// callers must cancel ctx to release it.
 	OpenSOL(ctx context.Context, systemID string) (SOLStream, error)
 }
 
@@ -68,6 +68,8 @@ const (
 	// backend (Redfish SerialConsole.SSH, manager SSH connect type, or Dell
 	// NetworkProtocol/OEM serial-redirection).
 	SOLConnectSSH SOLConnectKind = "ssh"
+	// SOLConnectIPMI is IPMI 2.0 SOL (RMCP+) used as last resort inside OpenSOL.
+	SOLConnectIPMI SOLConnectKind = "ipmi"
 )
 
 // SOLStream is an open SOL byte stream plus how it was obtained. Callers read
@@ -81,10 +83,9 @@ type SOLStream struct {
 	Debug []CaptureDebugStep
 }
 
-// SOLUnsupportedError is returned when a BMC has no usable Redfish-discovered
-// SOL path: no native WebSocket candidate worked and Redfish's own metadata
-// did not advertise SSH (Telnet-only and IPMI/Oem-only BMCs land here too —
-// Telnet is deferred and raw IPMI is never attempted).
+// SOLUnsupportedError is returned when no OpenSOL backend attached: WebSocket
+// was not line-oriented SOL, SSH was ineligible or failed, and IPMI 2.0 SOL
+// timed out or failed. Telnet is deferred. IPMI is a SOL payload only.
 type SOLUnsupportedError struct {
 	Vendor       VendorID
 	ConnectTypes []string // observed enabled serial-console protocols, e.g. "IPMI", "Telnet"

--- a/internal/common/redfish/internal/ipmi/crypto.go
+++ b/internal/common/redfish/internal/ipmi/crypto.go
@@ -1,0 +1,73 @@
+package ipmi
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/hmac"
+	"crypto/rand"
+	"fmt"
+)
+
+func encryptPayload(key, plain []byte) ([]byte, error) {
+	iv := make([]byte, aes.BlockSize)
+	if _, err := rand.Read(iv); err != nil {
+		return nil, fmt.Errorf("ipmi: iv: %w", err)
+	}
+	padded := confidentialityPad(plain)
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("ipmi: aes: %w", err)
+	}
+	if len(padded)%aes.BlockSize != 0 {
+		return nil, fmt.Errorf("ipmi: confidentiality pad not block-aligned")
+	}
+	ct := make([]byte, len(padded))
+	cipher.NewCBCEncrypter(block, iv).CryptBlocks(ct, padded)
+	out := make([]byte, 0, len(iv)+len(ct))
+	out = append(out, iv...)
+	out = append(out, ct...)
+	return out, nil
+}
+
+func decryptPayload(key, ivct []byte) ([]byte, error) {
+	if len(ivct) < aes.BlockSize*2 || len(ivct)%aes.BlockSize != 0 {
+		return nil, fmt.Errorf("ipmi: short ciphertext")
+	}
+	iv, ct := ivct[:aes.BlockSize], ivct[aes.BlockSize:]
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("ipmi: aes: %w", err)
+	}
+	plain := make([]byte, len(ct))
+	cipher.NewCBCDecrypter(block, iv).CryptBlocks(plain, ct)
+	return stripConfidentialityPad(plain)
+}
+
+// Table 13-20: pad bytes 0x01…0xN, pad length, Next Header 0x07, so
+// (len(payload)+1+1+N) % 16 == 0.
+func confidentialityPad(payload []byte) []byte {
+	n := (aes.BlockSize - ((len(payload) + 2) % aes.BlockSize)) % aes.BlockSize
+	out := make([]byte, 0, len(payload)+n+2)
+	out = append(out, payload...)
+	for i := 1; i <= n; i++ {
+		out = append(out, byte(i))
+	}
+	out = append(out, byte(n), nextHeaderIPMI)
+	return out
+}
+
+func stripConfidentialityPad(plain []byte) ([]byte, error) {
+	if len(plain) < 2 {
+		return nil, fmt.Errorf("ipmi: confidentiality trailer truncated")
+	}
+	if plain[len(plain)-1] != nextHeaderIPMI {
+		return nil, fmt.Errorf("ipmi: confidentiality next-header")
+	}
+	padLen := int(plain[len(plain)-2])
+	if padLen < 0 || padLen > aes.BlockSize || len(plain) < padLen+2 {
+		return nil, fmt.Errorf("ipmi: confidentiality pad length")
+	}
+	return plain[:len(plain)-2-padLen], nil
+}
+
+func macEqual(a, b []byte) bool { return hmac.Equal(a, b) }

--- a/internal/common/redfish/internal/ipmi/dial.go
+++ b/internal/common/redfish/internal/ipmi/dial.go
@@ -1,0 +1,399 @@
+package ipmi
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"net"
+	"time"
+)
+
+// Config is the only IPMI surface OpenSOL needs. No chassis, power, or SEL.
+// Never fmt %+v this struct (it contains Password).
+type Config struct {
+	Host     string
+	Port     int
+	Username string
+	Password string
+	Timeout  time.Duration
+}
+
+func (c Config) timeout() time.Duration {
+	if c.Timeout > 0 {
+		return c.Timeout
+	}
+	return 2 * time.Second
+}
+
+func (c Config) port() int {
+	if c.Port > 0 {
+		return c.Port
+	}
+	return 623
+}
+
+// DialSOL opens a bidirectional SOL byte stream (payload type 1) over
+// RMCP+ cipher suite 3, then suite 17 if Open Session rejects 3.
+// ctx cancel / Close deactivates payload and closes the RMCP+ session.
+func DialSOL(ctx context.Context, cfg Config) (io.ReadWriteCloser, error) {
+	if cfg.Host == "" {
+		return nil, fmt.Errorf("ipmi: empty host")
+	}
+	addr := net.JoinHostPort(cfg.Host, fmt.Sprintf("%d", cfg.port()))
+	d := net.Dialer{}
+	c, err := d.DialContext(ctx, "udp", addr)
+	if err != nil {
+		return nil, fmt.Errorf("ipmi: udp dial: %w", err)
+	}
+	udp, ok := c.(*net.UDPConn)
+	if !ok {
+		_ = c.Close()
+		return nil, fmt.Errorf("ipmi: not a udp conn")
+	}
+	s := &sess{cfg: cfg, conn: udp}
+	if err := s.handshake(ctx); err != nil {
+		_ = udp.Close()
+		return nil, err
+	}
+	return newSOL(ctx, s), nil
+}
+
+type sess struct {
+	cfg          Config
+	conn         *net.UDPConn
+	keys         sessionKeys
+	sidc, sidm   uint32
+	seqOut       uint32
+	rqSeq        byte
+	tag          byte
+	suite        cipherSuite
+	solSeq       byte
+	lastBMCSeq   byte
+	lastAccepted byte
+}
+
+func (s *sess) nextTag() byte {
+	s.tag++
+	return s.tag
+}
+
+func (s *sess) nextRQ() byte {
+	s.rqSeq = (s.rqSeq + 1) & 0x3F
+	return s.rqSeq
+}
+
+func (s *sess) write(ctx context.Context, pkt []byte) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	_ = s.conn.SetWriteDeadline(time.Now().Add(s.cfg.timeout()))
+	_, err := s.conn.Write(pkt)
+	return err
+}
+
+func (s *sess) readUDP(ctx context.Context) ([]byte, error) {
+	buf := make([]byte, 4096)
+	_ = s.conn.SetReadDeadline(time.Now().Add(s.cfg.timeout()))
+	n, err := s.conn.Read(buf)
+	if err != nil {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		return nil, err
+	}
+	return buf[:n], nil
+}
+
+func (s *sess) handshake(ctx context.Context) error {
+	if err := s.getChannelAuth(ctx); err != nil {
+		return err
+	}
+	suite := suite3
+	if err := s.openSession(ctx, suite); err != nil {
+		if isOpenReject(err) {
+			suite = suite17
+			if err2 := s.openSession(ctx, suite); err2 != nil {
+				return err2
+			}
+		} else {
+			return err
+		}
+	}
+	s.suite = suite
+	return s.rakpAndActivate(ctx)
+}
+
+type openReject struct{ status byte }
+
+func (e openReject) Error() string {
+	return fmt.Sprintf("ipmi: cipher suite rejected status=0x%02x", e.status)
+}
+
+func isOpenReject(err error) bool {
+	_, ok := err.(openReject)
+	return ok
+}
+
+func (s *sess) getChannelAuth(ctx context.Context) error {
+	req := packLANRequest(netFnApp, cmdGetAuth, s.nextRQ(), []byte{0x0E, 0x84})
+	pkt := packSessionless(req)
+	var last error
+	for try := 0; try < 3; try++ {
+		if err := s.write(ctx, pkt); err != nil {
+			return fmt.Errorf("ipmi: get channel auth: %w", err)
+		}
+		raw, err := s.readUDP(ctx)
+		if err != nil {
+			last = err
+			if ne, ok := err.(net.Error); ok && ne.Timeout() {
+				continue
+			}
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			continue
+		}
+		msg, err := parseSessionless(raw)
+		if err != nil {
+			last = err
+			continue
+		}
+		_, cc, data, err := parseLANResponse(msg)
+		if err != nil {
+			last = err
+			continue
+		}
+		if cc != ccOK {
+			return fmt.Errorf("ipmi: get channel auth cc=0x%02x", cc)
+		}
+		if len(data) < 4 {
+			return fmt.Errorf("ipmi: get channel auth short data")
+		}
+		if data[1]&0x80 == 0 {
+			return fmt.Errorf("ipmi: no RMCP+ (ext caps bit7=0)")
+		}
+		if data[3]&0x02 == 0 {
+			return fmt.Errorf("ipmi: no RMCP+ (ext caps bit1=0)")
+		}
+		return nil
+	}
+	if last != nil {
+		if ne, ok := last.(net.Error); ok && ne.Timeout() {
+			return fmt.Errorf("ipmi: udp 623 timeout on Get Channel Auth Caps")
+		}
+	}
+	return fmt.Errorf("ipmi: udp 623 timeout on Get Channel Auth Caps")
+}
+
+func (s *sess) openSession(ctx context.Context, suite cipherSuite) error {
+	if s.sidc == 0 {
+		var b [4]byte
+		if _, err := rand.Read(b[:]); err != nil {
+			return err
+		}
+		s.sidc = binary.LittleEndian.Uint32(b[:])
+		if s.sidc == 0 {
+			s.sidc = 1
+		}
+	} else {
+		// new SIDc allowed on suite 17 retry
+		var b [4]byte
+		_, _ = rand.Read(b[:])
+		s.sidc = binary.LittleEndian.Uint32(b[:])
+		if s.sidc == 0 {
+			s.sidc = 1
+		}
+	}
+	tag := s.nextTag()
+	payload := packOpenSession(tag, s.sidc, suite)
+	pkt, err := packRMCPPlus(payloadOpenReq, 0, 0, payload, nil)
+	if err != nil {
+		return err
+	}
+	if err := s.write(ctx, pkt); err != nil {
+		return fmt.Errorf("ipmi: open session: %w", err)
+	}
+	raw, err := s.readUDP(ctx)
+	if err != nil {
+		return fmt.Errorf("ipmi: open session: %w", err)
+	}
+	plus, err := parseRMCPPlus(raw, nil)
+	if err != nil {
+		return err
+	}
+	if plus.payloadType&0x3F != payloadOpenResp {
+		return fmt.Errorf("ipmi: expected open session response")
+	}
+	p := plus.payload
+	if len(p) < 12 {
+		return fmt.Errorf("ipmi: short open session response")
+	}
+	status := p[1]
+	if status != 0 {
+		return openReject{status: status}
+	}
+	s.sidm = binary.LittleEndian.Uint32(p[8:12])
+	s.suite = suite
+	return nil
+}
+
+func packOpenSession(tag byte, sidc uint32, suite cipherSuite) []byte {
+	b := make([]byte, 32)
+	b[0] = tag
+	b[1] = 0x04
+	copy(b[4:8], le32(sidc))
+	b[8] = 0x00
+	b[10], b[11] = 0x00, 0x08
+	b[12] = suite.authAlg()
+	b[16] = 0x01
+	b[18], b[19] = 0x00, 0x08
+	b[20] = suite.integAlg()
+	b[24] = 0x02
+	b[26], b[27] = 0x00, 0x08
+	b[28] = 0x01
+	return b
+}
+
+func (s *sess) rakpAndActivate(ctx context.Context) error {
+	rc := make([]byte, 16)
+	if _, err := rand.Read(rc); err != nil {
+		return err
+	}
+	user := []byte(s.cfg.Username)
+	if len(user) > 16 {
+		user = user[:16]
+	}
+	ulen := byte(len(user))
+	role := roleAdminNameOnly
+	tag := s.nextTag()
+	rakp1 := packRAKP1(tag, s.sidm, rc, role, ulen, user)
+	pkt, err := packRMCPPlus(payloadRAKP1, 0, 0, rakp1, nil)
+	if err != nil {
+		return err
+	}
+	if err := s.write(ctx, pkt); err != nil {
+		return fmt.Errorf("ipmi: rakp1: %w", err)
+	}
+	raw, err := s.readUDP(ctx)
+	if err != nil {
+		return fmt.Errorf("ipmi: rakp2: %w", err)
+	}
+	plus, err := parseRMCPPlus(raw, nil)
+	if err != nil {
+		return err
+	}
+	if plus.payloadType&0x3F != payloadRAKP2 {
+		return fmt.Errorf("ipmi: expected rakp2")
+	}
+	p := plus.payload
+	keccLen := s.suite.hmacSize()
+	if len(p) < 40+keccLen {
+		return fmt.Errorf("ipmi: short rakp2")
+	}
+	if p[1] != 0 {
+		return fmt.Errorf("ipmi: rakp2 status=0x%02x", p[1])
+	}
+	rm := p[8:24]
+	guid := append([]byte{}, p[24:40]...)
+	gotKECC := p[40 : 40+keccLen]
+	s.keys = deriveKeys(s.suite, s.cfg.Password, rc, rm, role, ulen, user)
+	want := s.keys.kecc2(s.sidc, s.sidm, rc, rm, guid, role, ulen, user)
+	if !macEqual(gotKECC, want) {
+		return fmt.Errorf("ipmi: rakp2 kecc mismatch")
+	}
+
+	kecc3 := s.keys.kecc3(rm, s.sidc, role, ulen, user)
+	rakp3 := make([]byte, 0, 8+len(kecc3))
+	rakp3 = append(rakp3, s.nextTag(), 0x00, 0x00, 0x00)
+	rakp3 = append(rakp3, le32(s.sidm)...)
+	rakp3 = append(rakp3, kecc3...)
+	pkt, err = packRMCPPlus(payloadRAKP3, 0, 0, rakp3, nil)
+	if err != nil {
+		return err
+	}
+	if err := s.write(ctx, pkt); err != nil {
+		return fmt.Errorf("ipmi: rakp3: %w", err)
+	}
+	raw, err = s.readUDP(ctx)
+	if err != nil {
+		return fmt.Errorf("ipmi: rakp4: %w", err)
+	}
+	plus, err = parseRMCPPlus(raw, nil)
+	if err != nil {
+		return err
+	}
+	if plus.payloadType&0x3F != payloadRAKP4 {
+		return fmt.Errorf("ipmi: expected rakp4")
+	}
+	p = plus.payload
+	icvN := s.suite.authCodeSize()
+	if len(p) < 8+icvN {
+		return fmt.Errorf("ipmi: short rakp4")
+	}
+	if p[1] != 0 {
+		return fmt.Errorf("ipmi: rakp4 status=0x%02x", p[1])
+	}
+	if !macEqual(p[8:8+icvN], s.keys.icv(rm, s.sidc, guid)) {
+		return fmt.Errorf("ipmi: rakp4 icv mismatch")
+	}
+
+	s.seqOut = 1
+	if _, err := s.ipmiCmd(ctx, cmdSetPriv, []byte{0x04}); err != nil {
+		return fmt.Errorf("ipmi: set privilege: %w", err)
+	}
+	if _, err := s.ipmiCmd(ctx, cmdAct, []byte{0x01, 0x01, 0xC0, 0x00, 0x00, 0x00}); err != nil {
+		return fmt.Errorf("ipmi: activate payload: %w", err)
+	}
+	return nil
+}
+
+func (s *sess) ipmiCmd(ctx context.Context, cmd byte, data []byte) ([]byte, error) {
+	msg := packLANRequest(netFnApp, cmd, s.nextRQ(), data)
+	pt := byte(payloadIPMI | payloadEnc | payloadAuth)
+	pkt, err := packRMCPPlus(pt, s.sidm, s.seqOut, msg, &s.keys)
+	if err != nil {
+		return nil, err
+	}
+	s.seqOut++
+	if err := s.write(ctx, pkt); err != nil {
+		return nil, err
+	}
+	raw, err := s.readUDP(ctx)
+	if err != nil {
+		return nil, err
+	}
+	plus, err := parseRMCPPlus(raw, &s.keys)
+	if err != nil {
+		return nil, err
+	}
+	if plus.payloadType&0x3F != payloadIPMI {
+		return nil, fmt.Errorf("ipmi: expected IPMI payload, got 0x%02x", plus.payloadType)
+	}
+	_, cc, resp, err := parseLANResponse(plus.payload)
+	if err != nil {
+		return nil, err
+	}
+	if cc != ccOK {
+		return nil, fmt.Errorf("ipmi: cmd 0x%02x cc=0x%02x", cmd, cc)
+	}
+	return resp, nil
+}
+
+func (s *sess) sendSOL(ctx context.Context, seq, ack, accepted, op byte, chars []byte) error {
+	body := []byte{seq & 0x0F, ack & 0x0F, accepted, op}
+	body = append(body, chars...)
+	pt := byte(payloadSOL | payloadEnc | payloadAuth)
+	pkt, err := packRMCPPlus(pt, s.sidm, s.seqOut, body, &s.keys)
+	if err != nil {
+		return err
+	}
+	s.seqOut++
+	return s.write(ctx, pkt)
+}
+
+func (s *sess) deactivate(ctx context.Context) {
+	_, _ = s.ipmiCmd(ctx, cmdDeact, []byte{0x01, 0x01, 0x00, 0x00, 0x00, 0x00})
+	_, _ = s.ipmiCmd(ctx, cmdClose, le32(s.sidm))
+}

--- a/internal/common/redfish/internal/ipmi/dial_test.go
+++ b/internal/common/redfish/internal/ipmi/dial_test.go
@@ -1,0 +1,133 @@
+package ipmi
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net"
+	"testing"
+	"time"
+)
+
+func TestDialSOL_EchoSuite3(t *testing.T) {
+	bmc, err := StartTestBMC(TestBMCOptions{Username: "admin", Password: "password"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer bmc.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	rw, err := DialSOL(ctx, Config{
+		Host: "127.0.0.1", Port: bmc.Addr.Port,
+		Username: "admin", Password: "password",
+		Timeout: 500 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("DialSOL: %v", err)
+	}
+	defer rw.Close()
+
+	msg := []byte("hello-sol")
+	if _, err := rw.Write(msg); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	got := readN(t, rw, len(msg), 2*time.Second)
+	if !bytes.Equal(got, msg) {
+		t.Fatalf("echo = %q, want %q", got, msg)
+	}
+}
+
+func TestDialSOL_Suite17AfterSuite3Reject(t *testing.T) {
+	bmc, err := StartTestBMC(TestBMCOptions{Username: "admin", Password: "password", RejectSuite3: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer bmc.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	rw, err := DialSOL(ctx, Config{
+		Host: "127.0.0.1", Port: bmc.Addr.Port,
+		Username: "admin", Password: "password",
+		Timeout: 500 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("DialSOL suite17: %v", err)
+	}
+	defer rw.Close()
+	if _, err := rw.Write([]byte("x")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	got := readN(t, rw, 1, 2*time.Second)
+	if string(got) != "x" {
+		t.Fatalf("echo = %q", got)
+	}
+}
+
+func TestDialSOL_UDPTimeoutNoSuite17(t *testing.T) {
+	ln, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+	port := ln.LocalAddr().(*net.UDPAddr).Port
+
+	start := time.Now()
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	_, err = DialSOL(ctx, Config{
+		Host: "127.0.0.1", Port: port,
+		Username: "admin", Password: "password",
+		Timeout: 50 * time.Millisecond,
+	})
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatal("expected timeout")
+	}
+	if elapsed > 800*time.Millisecond {
+		t.Fatalf("timeout took %s, want <800ms (must not shop cipher 17 after UDP timeout)", elapsed)
+	}
+	if !bytes.Contains([]byte(err.Error()), []byte("udp 623 timeout")) {
+		t.Fatalf("error = %q, want udp 623 timeout", err)
+	}
+}
+
+func readN(t *testing.T, r io.Reader, n int, d time.Duration) []byte {
+	t.Helper()
+	done := make(chan struct {
+		b []byte
+		e error
+	}, 1)
+	go func() {
+		got := make([]byte, 0, n)
+		tmp := make([]byte, n)
+		for len(got) < n {
+			k, err := r.Read(tmp)
+			if k > 0 {
+				got = append(got, tmp[:k]...)
+			}
+			if err != nil {
+				done <- struct {
+					b []byte
+					e error
+				}{got, err}
+				return
+			}
+		}
+		done <- struct {
+			b []byte
+			e error
+		}{got[:n], nil}
+	}()
+	select {
+	case <-time.After(d):
+		t.Fatalf("read timed out waiting for %d bytes", n)
+		return nil
+	case res := <-done:
+		if res.e != nil && res.e != io.EOF && len(res.b) < n {
+			t.Fatalf("read: %v", res.e)
+		}
+		return res.b
+	}
+}

--- a/internal/common/redfish/internal/ipmi/fake.go
+++ b/internal/common/redfish/internal/ipmi/fake.go
@@ -1,0 +1,356 @@
+package ipmi
+
+import (
+	"crypto/hmac"
+	"crypto/sha1"
+	"crypto/sha256"
+	"encoding/binary"
+	"net"
+	"sync"
+)
+
+// TestBMC is an in-process RMCP+/SOL responder for DialSOL unit tests.
+// Production code never calls this. HMAC for RAKP 2 is computed here with
+// concatenations written out locally (not DialSOL's kecc2Input).
+type TestBMC struct {
+	Addr *net.UDPAddr
+	conn *net.UDPConn
+	opts TestBMCOptions
+
+	mu     sync.Mutex
+	closed bool
+}
+
+type TestBMCOptions struct {
+	Username, Password string
+	RejectSuite3       bool
+	Greet              []byte // optional unsolicited SOL bytes after Activate Payload
+}
+
+func StartTestBMC(opts TestBMCOptions) (*TestBMC, error) {
+	if opts.Username == "" {
+		opts.Username = "admin"
+	}
+	if opts.Password == "" {
+		opts.Password = "password"
+	}
+	conn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
+	if err != nil {
+		return nil, err
+	}
+	f := &TestBMC{Addr: conn.LocalAddr().(*net.UDPAddr), conn: conn, opts: opts}
+	go f.serve()
+	return f, nil
+}
+
+func (f *TestBMC) Close() error {
+	f.mu.Lock()
+	f.closed = true
+	f.mu.Unlock()
+	return f.conn.Close()
+}
+
+type fakePeer struct {
+	sidc, sidm   uint32
+	suite        cipherSuite
+	keys         sessionKeys
+	rc, rm, guid []byte
+	seqOut       uint32
+	solSeq       byte
+	ready        bool
+}
+
+func (f *TestBMC) serve() {
+	peer := &fakePeer{sidm: 0x01020304, seqOut: 1}
+	peer.rm = bytesOf(0x11, 16)
+	peer.guid = bytesOf(0xA1, 16)
+	buf := make([]byte, 4096)
+	for {
+		n, addr, err := f.conn.ReadFromUDP(buf)
+		if err != nil {
+			return
+		}
+		pkt := append([]byte{}, buf[:n]...)
+		f.handle(addr, pkt, peer)
+	}
+}
+
+func bytesOf(start byte, n int) []byte {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = start + byte(i)
+	}
+	return b
+}
+
+func (f *TestBMC) handle(addr *net.UDPAddr, pkt []byte, peer *fakePeer) {
+	if len(pkt) < 14 {
+		return
+	}
+	if pkt[4] == authNone {
+		f.handleSessionless(addr, pkt)
+		return
+	}
+	var keys *sessionKeys
+	if peer.ready {
+		keys = &peer.keys
+	}
+	plus, err := parseRMCPPlus(pkt, keys)
+	if err != nil {
+		return
+	}
+	switch plus.payloadType & 0x3F {
+	case payloadOpenReq:
+		f.handleOpen(addr, plus.payload, peer)
+	case payloadRAKP1:
+		f.handleRAKP1(addr, plus.payload, peer)
+	case payloadRAKP3:
+		f.handleRAKP3(addr, plus.payload, peer)
+	case payloadIPMI:
+		f.handleIPMI(addr, plus.payload, peer)
+	case payloadSOL:
+		f.handleSOL(addr, plus.payload, peer)
+	}
+}
+
+func (f *TestBMC) handleSessionless(addr *net.UDPAddr, pkt []byte) {
+	msg, err := parseSessionless(pkt)
+	if err != nil || len(msg) < 8 {
+		return
+	}
+	cmd := msg[5]
+	if cmd != cmdGetAuth {
+		return
+	}
+	data := msg[6 : len(msg)-1]
+	if len(data) < 2 || data[0] != 0x0E || data[1] != 0x84 {
+		return
+	}
+	rqseq := msg[4]
+	respData := []byte{0x01, 0x80, 0x00, 0x02} // channel, ext support, enable, RMCP+
+	resp := packLANResponse(cmd, rqseq, ccOK, respData)
+	_, _ = f.conn.WriteToUDP(packSessionless(resp), addr)
+}
+
+func packLANResponse(cmd, rqseqlun, cc byte, data []byte) []byte {
+	netfnlun := byte((netFnApp + 1) << 2)
+	msg := []byte{rqSWID, netfnlun, 0, rsBMC, rqseqlun, cmd, cc}
+	msg = append(msg, data...)
+	msg[2] = checksum(msg[:2])
+	msg = append(msg, checksum(msg[3:]))
+	return msg
+}
+
+func (f *TestBMC) replyPlus(addr *net.UDPAddr, pt byte, sid, seq uint32, payload []byte, keys *sessionKeys) {
+	pkt, err := packRMCPPlus(pt, sid, seq, payload, keys)
+	if err != nil {
+		return
+	}
+	_, _ = f.conn.WriteToUDP(pkt, addr)
+}
+
+func (f *TestBMC) handleOpen(addr *net.UDPAddr, p []byte, peer *fakePeer) {
+	if len(p) < 32 {
+		return
+	}
+	tag := p[0]
+	sidc := binary.LittleEndian.Uint32(p[4:8])
+	authAlg := p[12]
+	integAlg := p[20]
+	status := byte(0)
+	var suite cipherSuite
+	switch {
+	case authAlg == 0x01 && integAlg == 0x01:
+		if f.opts.RejectSuite3 {
+			status = 0x01
+		} else {
+			suite = suite3
+		}
+	case authAlg == 0x03 && integAlg == 0x04:
+		suite = suite17
+	default:
+		status = 0x01
+	}
+	resp := make([]byte, 36)
+	resp[0] = tag
+	resp[1] = status
+	resp[2] = 0x04
+	copy(resp[4:8], le32(sidc))
+	copy(resp[8:12], le32(peer.sidm))
+	resp[12] = 0x00
+	resp[14], resp[15] = 0x00, 0x08
+	resp[16] = authAlg
+	resp[20] = 0x01
+	resp[22], resp[23] = 0x00, 0x08
+	resp[24] = integAlg
+	resp[28] = 0x02
+	resp[30], resp[31] = 0x00, 0x08
+	resp[32] = 0x01
+	if status == 0 {
+		peer.sidc = sidc
+		peer.suite = suite
+	}
+	f.replyPlus(addr, payloadOpenResp, 0, 0, resp, nil)
+}
+
+func (f *TestBMC) handleRAKP1(addr *net.UDPAddr, p []byte, peer *fakePeer) {
+	if len(p) < 29 {
+		return
+	}
+	tag := p[0]
+	peer.rc = append([]byte{}, p[8:24]...)
+	role := p[24]
+	ulen := p[27]
+	if int(28+ulen) > len(p) {
+		return
+	}
+	user := p[28 : 28+ulen]
+	kecc := fakeKECC2(peer.suite, f.opts.Password, peer.sidc, peer.sidm, peer.rc, peer.rm, peer.guid, role, ulen, user)
+	resp := make([]byte, 0, 40+len(kecc))
+	resp = append(resp, tag, 0x00, 0x00, 0x00)
+	resp = append(resp, le32(peer.sidc)...)
+	resp = append(resp, peer.rm...)
+	resp = append(resp, peer.guid...)
+	resp = append(resp, kecc...)
+	peer.keys = fakeDerive(peer.suite, f.opts.Password, peer.rc, peer.rm, role, ulen, user)
+	f.replyPlus(addr, payloadRAKP2, 0, 0, resp, nil)
+}
+
+func (f *TestBMC) handleRAKP3(addr *net.UDPAddr, p []byte, peer *fakePeer) {
+	if len(p) < 8 {
+		return
+	}
+	tag := p[0]
+	icv := fakeICV(peer.suite, peer.keys.sik, peer.rm, peer.sidc, peer.guid)
+	resp := make([]byte, 0, 8+len(icv))
+	resp = append(resp, tag, 0x00, 0x00, 0x00)
+	resp = append(resp, le32(peer.sidc)...)
+	resp = append(resp, icv...)
+	peer.ready = true
+	f.replyPlus(addr, payloadRAKP4, 0, 0, resp, nil)
+}
+
+func (f *TestBMC) handleIPMI(addr *net.UDPAddr, msg []byte, peer *fakePeer) {
+	if len(msg) < 8 {
+		return
+	}
+	cmd := msg[5]
+	rqseq := msg[4]
+	var data []byte
+	switch cmd {
+	case cmdSetPriv:
+		data = nil
+	case cmdAct:
+		data = []byte{0, 0, 0, 0, 0xff, 0x00, 0xff, 0x00, 0, 0, 0xff, 0xff}
+	case cmdDeact, cmdClose:
+		data = nil
+	default:
+		resp := packLANResponse(cmd, rqseq, 0xC1, nil)
+		f.replyPlus(addr, payloadIPMI|payloadEnc|payloadAuth, peer.sidc, peer.seqOut, resp, &peer.keys)
+		peer.seqOut++
+		return
+	}
+	resp := packLANResponse(cmd, rqseq, ccOK, data)
+	f.replyPlus(addr, payloadIPMI|payloadEnc|payloadAuth, peer.sidc, peer.seqOut, resp, &peer.keys)
+	peer.seqOut++
+	if cmd == cmdAct && len(f.opts.Greet) > 0 {
+		peer.solSeq = 1
+		out := []byte{peer.solSeq, 0, byte(len(f.opts.Greet)), 0}
+		out = append(out, f.opts.Greet...)
+		f.replyPlus(addr, payloadSOL|payloadEnc|payloadAuth, peer.sidc, peer.seqOut, out, &peer.keys)
+		peer.seqOut++
+	}
+}
+
+func (f *TestBMC) handleSOL(addr *net.UDPAddr, body []byte, peer *fakePeer) {
+	if len(body) < 4 {
+		return
+	}
+	seq := body[0] & 0x0F
+	chars := body[4:]
+	if seq == 0 || len(chars) == 0 {
+		return
+	}
+	peer.solSeq++
+	if peer.solSeq == 0 || peer.solSeq > 15 {
+		peer.solSeq = 1
+	}
+	out := []byte{peer.solSeq, seq, byte(len(chars)), 0}
+	out = append(out, chars...)
+	f.replyPlus(addr, payloadSOL|payloadEnc|payloadAuth, peer.sidc, peer.seqOut, out, &peer.keys)
+	peer.seqOut++
+}
+
+// Independent concatenations (do not call kecc2Input / deriveKeys).
+func fakeKECC2(suite cipherSuite, password string, sidc, sidm uint32, rc, rm, guid []byte, role, ulen byte, user []byte) []byte {
+	kuid := make([]byte, 20)
+	copy(kuid, password)
+	var in []byte
+	in = append(in, le32(sidc)...)
+	in = append(in, le32(sidm)...)
+	in = append(in, rc...)
+	in = append(in, rm...)
+	in = append(in, guid...)
+	in = append(in, role, ulen)
+	in = append(in, user...)
+	return fakeHMAC(suite, kuid, in)
+}
+
+func fakeDerive(suite cipherSuite, password string, rc, rm []byte, role, ulen byte, user []byte) sessionKeys {
+	kuid := make([]byte, 20)
+	copy(kuid, password)
+	var sikIn []byte
+	sikIn = append(sikIn, rc...)
+	sikIn = append(sikIn, rm...)
+	sikIn = append(sikIn, role, ulen)
+	sikIn = append(sikIn, user...)
+	sik := fakeHMAC(suite, kuid, sikIn)
+	n := sha1.Size
+	if suite == suite17 {
+		n = sha256.Size
+	}
+	c1 := bytesRepeat(0x01, n)
+	c2 := bytesRepeat(0x02, n)
+	return sessionKeys{
+		suite: suite,
+		kuid:  kuid,
+		sik:   sik,
+		k1:    fakeHMAC(suite, sik, c1),
+		k2:    fakeHMAC(suite, sik, c2),
+	}
+}
+
+func fakeICV(suite cipherSuite, sik, rm []byte, sidc uint32, guid []byte) []byte {
+	var in []byte
+	in = append(in, rm...)
+	in = append(in, le32(sidc)...)
+	in = append(in, guid...)
+	sum := fakeHMAC(suite, sik, in)
+	n := 12
+	if suite == suite17 {
+		n = 16
+	}
+	return sum[:n]
+}
+
+func fakeHMAC(suite cipherSuite, key, data []byte) []byte {
+	var h interface {
+		Write([]byte) (int, error)
+		Sum([]byte) []byte
+	}
+	if suite == suite17 {
+		h = hmac.New(sha256.New, key)
+	} else {
+		h = hmac.New(sha1.New, key)
+	}
+	_, _ = h.Write(data)
+	return h.Sum(nil)
+}
+
+func bytesRepeat(v byte, n int) []byte {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = v
+	}
+	return b
+}

--- a/internal/common/redfish/internal/ipmi/lan.go
+++ b/internal/common/redfish/internal/ipmi/lan.go
@@ -1,0 +1,43 @@
+package ipmi
+
+import "fmt"
+
+const (
+	rsBMC      = 0x20
+	rqSWID     = 0x81
+	netFnApp   = 0x06
+	cmdGetAuth = 0x38
+	cmdSetPriv = 0x3B
+	cmdClose   = 0x3C
+	cmdAct     = 0x48
+	cmdDeact   = 0x49
+	ccOK       = 0x00
+)
+
+func checksum(b []byte) byte {
+	var s byte
+	for _, v := range b {
+		s += v
+	}
+	return -s
+}
+
+func packLANRequest(netFn, cmd, rqSeq byte, data []byte) []byte {
+	netfnlun := netFn << 2
+	rqseqlun := rqSeq << 2
+	msg := []byte{rsBMC, netfnlun, 0, rqSWID, rqseqlun, cmd}
+	msg = append(msg, data...)
+	msg[2] = checksum(msg[:2])
+	msg = append(msg, checksum(msg[3:]))
+	return msg
+}
+
+func parseLANResponse(msg []byte) (cmd, cc byte, data []byte, err error) {
+	if len(msg) < 8 {
+		return 0, 0, nil, fmt.Errorf("ipmi: short LAN response")
+	}
+	cmd = msg[5]
+	cc = msg[6]
+	data = msg[7 : len(msg)-1]
+	return cmd, cc, data, nil
+}

--- a/internal/common/redfish/internal/ipmi/rakp.go
+++ b/internal/common/redfish/internal/ipmi/rakp.go
@@ -1,0 +1,164 @@
+package ipmi
+
+import (
+	"crypto/hmac"
+	"crypto/sha1"
+	"crypto/sha256"
+	"encoding/binary"
+	"hash"
+)
+
+// cipherSuite is IPMI Table 22-19 ID 3 or 17 only.
+type cipherSuite int
+
+const (
+	suite3  cipherSuite = 3
+	suite17 cipherSuite = 17
+)
+
+const (
+	roleAdminNameOnly byte = 0x14 // Table 13-11: Admin + name-only lookup
+	kuidLen           int  = 20
+)
+
+func padKUID(password string) []byte {
+	k := make([]byte, kuidLen)
+	copy(k, []byte(password))
+	return k
+}
+
+func (s cipherSuite) hmacSize() int {
+	if s == suite17 {
+		return sha256.Size
+	}
+	return sha1.Size
+}
+
+func (s cipherSuite) authCodeSize() int {
+	if s == suite17 {
+		return 16 // HMAC-SHA256-128
+	}
+	return 12 // HMAC-SHA1-96
+}
+
+func (s cipherSuite) newHMAC(key []byte) hash.Hash {
+	if s == suite17 {
+		return hmac.New(sha256.New, key)
+	}
+	return hmac.New(sha1.New, key)
+}
+
+func (s cipherSuite) hmacSum(key, data []byte) []byte {
+	h := s.newHMAC(key)
+	_, _ = h.Write(data)
+	return h.Sum(nil)
+}
+
+func (s cipherSuite) constBlock(v byte) []byte {
+	n := s.hmacSize()
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = v
+	}
+	return b
+}
+
+func (s cipherSuite) authAlg() byte {
+	if s == suite17 {
+		return 0x03 // RAKP-HMAC-SHA256
+	}
+	return 0x01 // RAKP-HMAC-SHA1
+}
+
+func (s cipherSuite) integAlg() byte {
+	if s == suite17 {
+		return 0x04 // HMAC-SHA256-128
+	}
+	return 0x01 // HMAC-SHA1-96
+}
+
+func le32(v uint32) []byte {
+	b := make([]byte, 4)
+	binary.LittleEndian.PutUint32(b, v)
+	return b
+}
+
+func kecc2Input(sidc, sidm uint32, rc, rm, guid []byte, role, ulen byte, user []byte) []byte {
+	out := make([]byte, 0, 4+4+16+16+16+1+1+len(user))
+	out = append(out, le32(sidc)...)
+	out = append(out, le32(sidm)...)
+	out = append(out, rc...)
+	out = append(out, rm...)
+	out = append(out, guid...)
+	out = append(out, role, ulen)
+	out = append(out, user...)
+	return out
+}
+
+func sikInput(rc, rm []byte, role, ulen byte, user []byte) []byte {
+	out := make([]byte, 0, 16+16+1+1+len(user))
+	out = append(out, rc...)
+	out = append(out, rm...)
+	out = append(out, role, ulen)
+	out = append(out, user...)
+	return out
+}
+
+func kecc3Input(rm []byte, sidc uint32, role, ulen byte, user []byte) []byte {
+	out := make([]byte, 0, 16+4+1+1+len(user))
+	out = append(out, rm...)
+	out = append(out, le32(sidc)...)
+	out = append(out, role, ulen)
+	out = append(out, user...)
+	return out
+}
+
+func icvInput(rm []byte, sidc uint32, guid []byte) []byte {
+	out := make([]byte, 0, 16+4+16)
+	out = append(out, rm...)
+	out = append(out, le32(sidc)...)
+	out = append(out, guid...)
+	return out
+}
+
+type sessionKeys struct {
+	suite cipherSuite
+	kuid  []byte
+	sik   []byte
+	k1    []byte
+	k2    []byte
+}
+
+func deriveKeys(suite cipherSuite, password string, rc, rm []byte, role, ulen byte, user []byte) sessionKeys {
+	kuid := padKUID(password)
+	sik := suite.hmacSum(kuid, sikInput(rc, rm, role, ulen, user))
+	k1 := suite.hmacSum(sik, suite.constBlock(0x01))
+	k2 := suite.hmacSum(sik, suite.constBlock(0x02))
+	return sessionKeys{suite: suite, kuid: kuid, sik: sik, k1: k1, k2: k2}
+}
+
+func (k sessionKeys) aesKey() []byte { return k.k2[:16] }
+
+func (k sessionKeys) kecc2(sidc, sidm uint32, rc, rm, guid []byte, role, ulen byte, user []byte) []byte {
+	return k.suite.hmacSum(k.kuid, kecc2Input(sidc, sidm, rc, rm, guid, role, ulen, user))
+}
+
+func (k sessionKeys) kecc3(rm []byte, sidc uint32, role, ulen byte, user []byte) []byte {
+	return k.suite.hmacSum(k.kuid, kecc3Input(rm, sidc, role, ulen, user))
+}
+
+func (k sessionKeys) icv(rm []byte, sidc uint32, guid []byte) []byte {
+	sum := k.suite.hmacSum(k.sik, icvInput(rm, sidc, guid))
+	return sum[:k.suite.authCodeSize()]
+}
+
+// packRAKP1 is Table 13-11 (SID=0 session). Role 0x14, two reserved bytes, ULen at offset 27.
+func packRAKP1(tag byte, sidm uint32, rc []byte, role, ulen byte, user []byte) []byte {
+	out := make([]byte, 0, 28+len(user))
+	out = append(out, tag, 0, 0, 0)
+	out = append(out, le32(sidm)...)
+	out = append(out, rc...)
+	out = append(out, role, 0, 0, ulen)
+	out = append(out, user...)
+	return out
+}

--- a/internal/common/redfish/internal/ipmi/rakp_test.go
+++ b/internal/common/redfish/internal/ipmi/rakp_test.go
@@ -1,0 +1,133 @@
+package ipmi
+
+import (
+	"bytes"
+	"encoding/hex"
+	"testing"
+)
+
+func mustHex(t *testing.T, s string) []byte {
+	t.Helper()
+	s = compactHex(s)
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
+}
+
+func compactHex(s string) string {
+	out := make([]byte, 0, len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c != ' ' && c != '\n' && c != '\t' {
+			out = append(out, c)
+		}
+	}
+	return string(out)
+}
+
+var fixture = struct {
+	password     string
+	sidc         uint32
+	sidm         uint32
+	rc, rm, guid []byte
+	role         byte
+	user         []byte
+}{
+	password: "TestPass",
+	sidc:     0xA0A2A3A4,
+	sidm:     0x01234567,
+	role:     roleAdminNameOnly,
+	user:     []byte("admin"),
+}
+
+func initFixture(t *testing.T) {
+	t.Helper()
+	fixture.rc = mustHex(t, "01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F 10")
+	fixture.rm = mustHex(t, "11 12 13 14 15 16 17 18 19 1A 1B 1C 1D 1E 1F 20")
+	fixture.guid = mustHex(t, "A1 A2 A3 A4 A5 A6 A7 A8 A9 AA AB AC AD AE AF B0")
+}
+
+func TestRAKPVectors_Suite3_SpecConcat(t *testing.T) {
+	initFixture(t)
+	f := fixture
+	ulen := byte(len(f.user))
+	keys := deriveKeys(suite3, f.password, f.rc, f.rm, f.role, ulen, f.user)
+
+	wantKUID := mustHex(t, "54 65 73 74 50 61 73 73 00 00 00 00 00 00 00 00 00 00 00 00")
+	if !bytes.Equal(keys.kuid, wantKUID) {
+		t.Fatalf("K_UID=\n%s\nwant\n%s", hex.Dump(keys.kuid), hex.Dump(wantKUID))
+	}
+
+	kecc2 := keys.kecc2(f.sidc, f.sidm, f.rc, f.rm, f.guid, f.role, ulen, f.user)
+	want := map[string][]byte{
+		"KECC2": kecc2,
+		"SIK":   keys.sik,
+		"K1":    keys.k1,
+		"K2":    keys.k2,
+		"KECC3": keys.kecc3(f.rm, f.sidc, f.role, ulen, f.user),
+		"ICV":   keys.icv(f.rm, f.sidc, f.guid),
+	}
+	expect := map[string][]byte{
+		"KECC2": mustHex(t, "54 4B 64 66 E8 50 C4 58 68 36 4B 78 D5 54 49 94 DA 87 F2 6F"),
+		"SIK":   mustHex(t, "3B 19 7D 0D 52 54 32 0A 4C 95 41 A4 D0 FD FF 96 DC FB A4 66"),
+		"K1":    mustHex(t, "A5 21 F2 FD 18 6A 52 0B 69 BB BE 4A BF 08 88 D7 07 CA 1B D5"),
+		"K2":    mustHex(t, "37 B1 6B 63 17 04 EB 2E 8F 07 DC E9 0A D8 33 26 33 0F 02 1F"),
+		"KECC3": mustHex(t, "3E FC 2F F3 C6 0F E8 D1 BF 8D BC E2 A8 89 BA 13 4B BC 1B 12"),
+		"ICV":   mustHex(t, "11 B3 EF E0 68 BA 03 20 21 C7 CE 98"),
+	}
+	for name, got := range want {
+		if !bytes.Equal(got, expect[name]) {
+			t.Errorf("%s=\n%s\nwant\n%s", name, hex.Dump(got), hex.Dump(expect[name]))
+		}
+	}
+
+	wire := packRAKP1(0, f.sidm, f.rc, f.role, ulen, f.user)
+	wantWire := mustHex(t, "00 00 00 00 67 45 23 01 01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F 10 14 00 00 05 61 64 6D 69 6E")
+	if !bytes.Equal(wire, wantWire) {
+		t.Fatalf("RAKP1 wire=\n%s\nwant\n%s", hex.Dump(wire), hex.Dump(wantWire))
+	}
+	if wire[24] != 0x14 || wire[27] != 0x05 {
+		t.Fatalf("RAKP1 role/ulen offsets: [24]=%02x [27]=%02x", wire[24], wire[27])
+	}
+}
+
+func TestRAKPVectors_Suite17_SpecConcat(t *testing.T) {
+	initFixture(t)
+	f := fixture
+	ulen := byte(len(f.user))
+	keys := deriveKeys(suite17, f.password, f.rc, f.rm, f.role, ulen, f.user)
+
+	want := map[string][]byte{
+		"KECC2": keys.kecc2(f.sidc, f.sidm, f.rc, f.rm, f.guid, f.role, ulen, f.user),
+		"SIK":   keys.sik,
+		"K1":    keys.k1,
+		"K2":    keys.k2,
+		"KECC3": keys.kecc3(f.rm, f.sidc, f.role, ulen, f.user),
+		"ICV":   keys.icv(f.rm, f.sidc, f.guid),
+	}
+	expect := map[string][]byte{
+		"KECC2": mustHex(t, "3E 4F EE 78 D3 3E F5 CB DA 8A C4 7C 22 24 30 05 20 A4 6D 0B C0 F1 C8 F2 4A 6D 18 0E E5 D7 9D 6B"),
+		"SIK":   mustHex(t, "A6 5F 45 EC 03 B1 5E 8F FC 02 A1 B6 96 5B 35 D5 25 0C A3 F5 03 F3 87 1D 4C 87 07 52 D8 94 25 7C"),
+		"K1":    mustHex(t, "04 DB 8E 56 06 A1 85 A5 94 56 BD 35 42 9C 1C 0D 28 40 34 6F A9 2B ED 0E 29 7E D8 02 45 F3 E9 0A"),
+		"K2":    mustHex(t, "5A 1E 6F C5 7F E6 39 71 95 B8 51 20 75 96 A8 7E 2D 59 16 AE 4A 0D 37 66 44 76 CF F6 63 B6 94 8B"),
+		"KECC3": mustHex(t, "AC 03 00 4E 0B CF F6 CF D6 2A CC EE 91 15 4E E1 22 83 16 37 D2 53 7D B6 8D C5 FA 51 C4 2C 78 96"),
+		"ICV":   mustHex(t, "78 85 08 20 28 E4 00 E3 CF 5B 93 F2 6A 99 76 4E"),
+	}
+	for name, got := range want {
+		if !bytes.Equal(got, expect[name]) {
+			t.Errorf("%s=\n%s\nwant\n%s", name, hex.Dump(got), hex.Dump(expect[name]))
+		}
+	}
+	aes := keys.aesKey()
+	wantAES := mustHex(t, "5A 1E 6F C5 7F E6 39 71 95 B8 51 20 75 96 A8 7E")
+	if !bytes.Equal(aes, wantAES) {
+		t.Fatalf("AES key=\n%s\nwant\n%s", hex.Dump(aes), hex.Dump(wantAES))
+	}
+	wire := packRAKP1(0, f.sidm, f.rc, f.role, ulen, f.user)
+	wantWire := mustHex(t, "00 00 00 00 67 45 23 01 01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F 10 14 00 00 05 61 64 6D 69 6E")
+	if !bytes.Equal(wire, wantWire) {
+		t.Fatalf("RAKP1 wire (suite 17 same pack)=\n%s\nwant\n%s", hex.Dump(wire), hex.Dump(wantWire))
+	}
+}

--- a/internal/common/redfish/internal/ipmi/rmcp.go
+++ b/internal/common/redfish/internal/ipmi/rmcp.go
@@ -1,0 +1,171 @@
+package ipmi
+
+import (
+	"encoding/binary"
+	"fmt"
+)
+
+const (
+	rmcpVersion     = 0x06
+	rmcpSeqNoACK    = 0xFF
+	rmcpClassIPMI   = 0x07
+	authNone        = 0x00
+	authRMCPPlus    = 0x06
+	payloadIPMI     = 0x00
+	payloadSOL      = 0x01
+	payloadOpenReq  = 0x10
+	payloadOpenResp = 0x11
+	payloadRAKP1    = 0x12
+	payloadRAKP2    = 0x13
+	payloadRAKP3    = 0x14
+	payloadRAKP4    = 0x15
+	payloadEnc      = 0x80
+	payloadAuth     = 0x40
+	nextHeaderIPMI  = 0x07
+)
+
+func packRMCP(class byte, rest []byte) []byte {
+	out := make([]byte, 0, 4+len(rest))
+	out = append(out, rmcpVersion, 0x00, rmcpSeqNoACK, class)
+	out = append(out, rest...)
+	return out
+}
+
+func packSessionless(ipmiMsg []byte) []byte {
+	rest := make([]byte, 0, 10+len(ipmiMsg))
+	rest = append(rest, authNone)
+	rest = append(rest, 0, 0, 0, 0) // seq
+	rest = append(rest, 0, 0, 0, 0) // sid
+	rest = append(rest, byte(len(ipmiMsg)))
+	rest = append(rest, ipmiMsg...)
+	return packRMCP(rmcpClassIPMI, rest)
+}
+
+func parseSessionless(pkt []byte) ([]byte, error) {
+	if len(pkt) < 4+10 {
+		return nil, fmt.Errorf("ipmi: short session-less packet")
+	}
+	if pkt[0] != rmcpVersion || pkt[3]&0x0F != rmcpClassIPMI {
+		return nil, fmt.Errorf("ipmi: not an IPMI RMCP packet")
+	}
+	body := pkt[4:]
+	if body[0] != authNone {
+		return nil, fmt.Errorf("ipmi: unexpected auth type 0x%02x", body[0])
+	}
+	n := int(body[9])
+	if len(body) < 10+n {
+		return nil, fmt.Errorf("ipmi: truncated session-less payload")
+	}
+	return body[10 : 10+n], nil
+}
+
+func packRMCPPlus(payloadType byte, sessionID, seq uint32, payload []byte, keys *sessionKeys) ([]byte, error) {
+	encrypted := payloadType&payloadEnc != 0
+	authenticated := payloadType&payloadAuth != 0
+	pt := payloadType & 0x3F
+	bodyPayload := payload
+	if encrypted {
+		if keys == nil {
+			return nil, fmt.Errorf("ipmi: encrypted payload without keys")
+		}
+		enc, err := encryptPayload(keys.aesKey(), payload)
+		if err != nil {
+			return nil, err
+		}
+		bodyPayload = enc
+	}
+
+	rest := make([]byte, 0, 12+len(bodyPayload)+20)
+	rest = append(rest, authRMCPPlus, payloadType)
+	rest = append(rest, le32(sessionID)...)
+	rest = append(rest, le32(seq)...)
+	ln := make([]byte, 2)
+	binary.LittleEndian.PutUint16(ln, uint16(len(bodyPayload)))
+	rest = append(rest, ln...)
+	rest = append(rest, bodyPayload...)
+
+	if authenticated {
+		if keys == nil {
+			return nil, fmt.Errorf("ipmi: authenticated payload without keys")
+		}
+		// Integrity PAD so AuthType through Next Header is DWORD-aligned.
+		n := len(rest)
+		padLen := (4 - ((n + 2) % 4)) % 4
+		for i := 0; i < padLen; i++ {
+			rest = append(rest, 0xFF)
+		}
+		rest = append(rest, byte(padLen), nextHeaderIPMI)
+		mac := keys.suite.hmacSum(keys.k1, rest)
+		rest = append(rest, mac[:keys.suite.authCodeSize()]...)
+	} else if pt >= payloadOpenReq && pt <= payloadRAKP4 {
+		// Table 13-8 notes [8]/[9]: Open Session and RAKP have no trailer.
+	}
+	return packRMCP(rmcpClassIPMI, rest), nil
+}
+
+type plusPkt struct {
+	payloadType byte // including enc/auth bits
+	sessionID   uint32
+	seq         uint32
+	payload     []byte // decrypted / plain
+}
+
+func parseRMCPPlus(pkt []byte, keys *sessionKeys) (plusPkt, error) {
+	var z plusPkt
+	if len(pkt) < 4+12 {
+		return z, fmt.Errorf("ipmi: short RMCP+ packet")
+	}
+	if pkt[0] != rmcpVersion || pkt[3]&0x0F != rmcpClassIPMI {
+		return z, fmt.Errorf("ipmi: not an IPMI RMCP packet")
+	}
+	rest := pkt[4:]
+	if rest[0] != authRMCPPlus {
+		return z, fmt.Errorf("ipmi: not RMCP+ (auth=0x%02x)", rest[0])
+	}
+	pt := rest[1]
+	z.payloadType = pt
+	z.sessionID = binary.LittleEndian.Uint32(rest[2:6])
+	z.seq = binary.LittleEndian.Uint32(rest[6:10])
+	plen := int(binary.LittleEndian.Uint16(rest[10:12]))
+	if len(rest) < 12+plen {
+		return z, fmt.Errorf("ipmi: truncated RMCP+ payload")
+	}
+	raw := rest[12 : 12+plen]
+	authenticated := pt&payloadAuth != 0
+	encrypted := pt&payloadEnc != 0
+	if authenticated {
+		if keys == nil {
+			return z, fmt.Errorf("ipmi: authenticated packet without keys")
+		}
+		authn := keys.suite.authCodeSize()
+		// trailer after payload: pad, padLen, nextHeader, authcode
+		trail := rest[12+plen:]
+		if len(trail) < 2+authn {
+			return z, fmt.Errorf("ipmi: missing integrity trailer")
+		}
+		padLen := int(trail[len(trail)-2-authn])
+		// covered = AuthType .. Next Header
+		coveredLen := 12 + plen + padLen + 2
+		if len(rest) < coveredLen+authn {
+			return z, fmt.Errorf("ipmi: short integrity covered range")
+		}
+		got := trail[len(trail)-authn:]
+		sum := keys.suite.hmacSum(keys.k1, rest[:coveredLen])
+		if !macEqual(got, sum[:authn]) {
+			return z, fmt.Errorf("ipmi: integrity check failed")
+		}
+	}
+	if encrypted {
+		if keys == nil {
+			return z, fmt.Errorf("ipmi: encrypted packet without keys")
+		}
+		plain, err := decryptPayload(keys.aesKey(), raw)
+		if err != nil {
+			return z, err
+		}
+		z.payload = plain
+	} else {
+		z.payload = raw
+	}
+	return z, nil
+}

--- a/internal/common/redfish/internal/ipmi/sol.go
+++ b/internal/common/redfish/internal/ipmi/sol.go
@@ -1,0 +1,166 @@
+package ipmi
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"sync"
+	"time"
+)
+
+type solConn struct {
+	s        *sess
+	cancel   context.CancelFunc
+	pumpDone chan struct{}
+
+	mu     sync.Mutex
+	cond   *sync.Cond
+	buf    []byte
+	rerr   error
+	closed bool
+}
+
+func newSOL(parent context.Context, s *sess) *solConn {
+	ctx, cancel := context.WithCancel(parent)
+	c := &solConn{s: s, cancel: cancel, pumpDone: make(chan struct{})}
+	c.cond = sync.NewCond(&c.mu)
+	go c.pump(ctx)
+	go c.keepalive(ctx)
+	return c
+}
+
+func (c *solConn) Read(p []byte) (int, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for len(c.buf) == 0 && c.rerr == nil && !c.closed {
+		c.cond.Wait()
+	}
+	if len(c.buf) > 0 {
+		n := copy(p, c.buf)
+		c.buf = c.buf[n:]
+		return n, nil
+	}
+	if c.rerr != nil {
+		return 0, c.rerr
+	}
+	return 0, io.EOF
+}
+
+func (c *solConn) Write(p []byte) (int, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed {
+		return 0, io.ErrClosedPipe
+	}
+	c.s.solSeq++
+	if c.s.solSeq == 0 || c.s.solSeq > 15 {
+		c.s.solSeq = 1
+	}
+	if err := c.s.sendSOL(context.Background(), c.s.solSeq, c.s.lastBMCSeq, c.s.lastAccepted, 0, p); err != nil {
+		return 0, err
+	}
+	return len(p), nil
+}
+
+func (c *solConn) Close() error {
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return nil
+	}
+	c.closed = true
+	c.cond.Broadcast()
+	c.mu.Unlock()
+	c.cancel()
+	_ = c.s.conn.SetReadDeadline(time.Now())
+	select {
+	case <-c.pumpDone:
+	case <-time.After(time.Second):
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	c.s.deactivate(ctx)
+	return c.s.conn.Close()
+}
+
+func (c *solConn) pump(ctx context.Context) {
+	defer close(c.pumpDone)
+	defer c.fail(io.EOF)
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		raw, err := c.s.readUDP(ctx)
+		if err != nil {
+			if ctx.Err() != nil {
+				return
+			}
+			if ne, ok := err.(interface{ Timeout() bool }); ok && ne.Timeout() {
+				continue
+			}
+			c.fail(err)
+			return
+		}
+		plus, err := parseRMCPPlus(raw, &c.s.keys)
+		if err != nil {
+			continue
+		}
+		switch plus.payloadType & 0x3F {
+		case payloadSOL:
+			c.handleSOL(ctx, plus.payload)
+		default:
+			// ignore late IPMI
+		}
+	}
+}
+
+func (c *solConn) handleSOL(ctx context.Context, body []byte) {
+	if len(body) < 4 {
+		return
+	}
+	seq := body[0] & 0x0F
+	op := body[3]
+	if op&0x10 != 0 {
+		c.fail(fmt.Errorf("ipmi: sol deactivating"))
+		return
+	}
+	chars := body[4:]
+	if seq != 0 && len(chars) > 0 {
+		c.mu.Lock()
+		c.buf = append(c.buf, chars...)
+		c.s.lastBMCSeq = seq
+		c.s.lastAccepted = byte(len(chars))
+		c.cond.Signal()
+		c.mu.Unlock()
+		_ = c.s.sendSOL(ctx, 0, seq, byte(len(chars)), 0, nil)
+	}
+}
+
+func (c *solConn) keepalive(ctx context.Context) {
+	t := time.NewTicker(30 * time.Second)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			c.mu.Lock()
+			ack, n := c.s.lastBMCSeq, c.s.lastAccepted
+			closed := c.closed
+			c.mu.Unlock()
+			if closed {
+				return
+			}
+			_ = c.s.sendSOL(ctx, 0, ack, n, 0, nil)
+		}
+	}
+}
+
+func (c *solConn) fail(err error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.rerr == nil {
+		c.rerr = err
+	}
+	c.cond.Broadcast()
+}

--- a/internal/common/redfish/sol.go
+++ b/internal/common/redfish/sol.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -15,6 +16,15 @@ import (
 	gofishredfish "github.com/stmcginnis/gofish/redfish"
 
 	"github.com/coder/websocket"
+
+	"github.com/mattcburns/shoal/internal/common/redfish/internal/ipmi"
+)
+
+// ipmiDial is DialSOL in production; tests inject timeout/port and fakes.
+var (
+	ipmiDial    = ipmi.DialSOL
+	ipmiTimeout = 2 * time.Second
+	ipmiPort    = 623
 )
 
 // OpenSOL opens a serial-over-LAN byte stream for systemID.
@@ -24,7 +34,7 @@ import (
 // Supermicro) but only keep a socket that sniffs as line-oriented SOL text,
 // then SSH when eligible (Redfish SerialConsole.SSH, manager SSH connect type,
 // or Dell NetworkProtocol/OEM serial-redirection even if SerialConsole is
-// empty). IPMI 2.0 SOL last resort is specified, not implemented. Telnet-only
+// empty), then IPMI 2.0 SOL (stdlib client) as last resort. Telnet-only
 // BMCs are unsupported (deferred).
 func (c *client) OpenSOL(ctx context.Context, systemID string) (SOLStream, error) {
 	var dbg []CaptureDebugStep
@@ -97,11 +107,49 @@ func (c *client) OpenSOL(ctx context.Context, systemID string) (SOLStream, error
 		}
 	}
 
+	if stream, ipmiErr := c.tryIPMISOL(ctx, sys, vendor, add); ipmiErr == nil {
+		stream.Debug = dbg
+		return stream, nil
+	} else {
+		add(CaptureDebugStep{Phase: "probe", Vendor: string(vendor), OK: false, Method: "IPMI", Message: sanitizePreview(ipmiErr.Error())})
+	}
+
 	add(CaptureDebugStep{
 		Phase: "probe", Vendor: string(vendor), OK: false,
-		Message: fmt.Sprintf("no supported SOL path (native WS unsupported/failed, SSH ineligible or failed); observed connect types: %v", observed),
+		Message: fmt.Sprintf("no supported SOL path (native WS unsupported/failed, SSH ineligible or failed, IPMI SOL failed); observed connect types: %v", observed),
 	})
 	return SOLStream{}, &SOLUnsupportedError{Vendor: vendor, ConnectTypes: observed, Debug: dbg}
+}
+
+func (c *client) tryIPMISOL(ctx context.Context, sys *gofishredfish.ComputerSystem, vendor VendorID, add func(CaptureDebugStep)) (SOLStream, error) {
+	host, err := sshHost(c.cfg.BaseURL)
+	if err != nil {
+		return SOLStream{}, err
+	}
+	ps := strings.TrimSpace(string(sys.PowerState))
+	if ps == "" || strings.EqualFold(ps, "Off") {
+		add(CaptureDebugStep{
+			Phase: "probe", Vendor: string(vendor), OK: true,
+			Message: fmt.Sprintf("PowerState=%s; SOL attach expected silent until power-on", ps),
+		})
+	}
+	cfg := ipmi.Config{
+		Host:     host,
+		Port:     ipmiPort,
+		Username: c.cfg.Username,
+		Password: c.cfg.Password,
+		Timeout:  ipmiTimeout,
+	}
+	add(CaptureDebugStep{
+		Phase: "request", Vendor: string(vendor), Method: "IPMI", URL: net.JoinHostPort(host, fmt.Sprintf("%d", cfg.Port)),
+		Message: "dial IPMI 2.0 SOL (last resort, suite 3 then 17)",
+	})
+	rc, err := ipmiDial(ctx, cfg)
+	if err != nil {
+		return SOLStream{}, err
+	}
+	add(CaptureDebugStep{Phase: "request", Vendor: string(vendor), Method: "IPMI", OK: true, Message: "ipmi sol session started"})
+	return SOLStream{ReadCloser: rc, Vendor: vendor, Kind: SOLConnectIPMI}, nil
 }
 
 // observedConnectTypes summarizes enabled serial-console protocols from

--- a/internal/common/redfish/sol_test.go
+++ b/internal/common/redfish/sol_test.go
@@ -10,14 +10,30 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"golang.org/x/crypto/ssh"
 
 	"github.com/coder/websocket"
+
+	"github.com/mattcburns/shoal/internal/common/redfish/internal/ipmi"
 )
+
+func TestMain(m *testing.M) {
+	ln, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
+	if err != nil {
+		panic(err)
+	}
+	ipmiPort = ln.LocalAddr().(*net.UDPAddr).Port
+	ipmiTimeout = 50 * time.Millisecond
+	code := m.Run()
+	_ = ln.Close()
+	os.Exit(code)
+}
 
 // --- fake Redfish HTTP server (drives real gofish parsing, not a mock of *client) ---
 
@@ -462,6 +478,46 @@ func TestOpenSOL_IPMIOnly_Unsupported(t *testing.T) {
 	}
 	if !found {
 		t.Fatalf("ConnectTypes = %v, want it to include IPMI", unsupported.ConnectTypes)
+	}
+	trail := err.Error()
+	if !strings.Contains(trail, "udp 623") && !strings.Contains(trail, "ipmi") {
+		t.Fatalf("error = %q, want ipmi/udp timeout in debug trail", trail)
+	}
+	if strings.Contains(trail, "cipher suite 17") {
+		t.Fatal("must not try suite 17 after Get Channel Auth Caps timeout")
+	}
+}
+
+func TestOpenSOL_IPMI_Success(t *testing.T) {
+	bmc, err := ipmi.StartTestBMC(ipmi.TestBMCOptions{Username: "admin", Password: "password", Greet: []byte("ipmi-hello\n")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer bmc.Close()
+	oldPort, oldTO := ipmiPort, ipmiTimeout
+	ipmiPort = bmc.Addr.Port
+	ipmiTimeout = 500 * time.Millisecond
+	t.Cleanup(func() { ipmiPort, ipmiTimeout = oldPort, oldTO })
+
+	srv := newFakeSOLServer(t, fakeSOLServerOpts{
+		systemJSON: systemJSONWithHostSerialConsole(false, false, true, 623, ""),
+	})
+	c := openFakeClient(t, srv.URL)
+	stream, err := c.OpenSOL(context.Background(), "1")
+	if err != nil {
+		t.Fatalf("OpenSOL: %v", err)
+	}
+	defer stream.Close()
+	if stream.Kind != SOLConnectIPMI {
+		t.Fatalf("kind = %q, want ipmi", stream.Kind)
+	}
+	buf := make([]byte, 64)
+	n, rerr := stream.Read(buf)
+	if rerr != nil && n == 0 {
+		t.Fatalf("read: %v", rerr)
+	}
+	if !strings.Contains(string(buf[:n]), "ipmi-hello") {
+		t.Fatalf("stream = %q, want ipmi-hello", buf[:n])
 	}
 }
 

--- a/internal/observe/sol/factory.go
+++ b/internal/observe/sol/factory.go
@@ -20,9 +20,9 @@ type RedfishSOLConfig struct {
 }
 
 // NewCombinedTransportFactory dispatches on session.Transport:
-//   - "redfish_sol": BMC.OpenSOL (line-oriented WS, then SSH attach). IPMI SOL
-//     last-resort is not implemented yet; OpenSOL returns unsupported for
-//     IPMI-only BMCs. Never a watch transport named ipmi_sol.
+//   - "redfish_sol": BMC.OpenSOL (line-oriented WS, then SSH attach, then
+//     IPMI 2.0 SOL last resort inside OpenSOL). Never a watch transport named
+//     ipmi_sol.
 //   - "libvirt", "": existing SSH/local libvirt tailing (delegates to
 //     NewTransportFactory(sshCfg)).
 //   - anything else (including the legacy "ipmi_sol"): a transport whose


### PR DESCRIPTION
PR2 of the real-hardware SOL work (`docs/sol-transports-design.md`).

## What changed

`BMC.OpenSOL` last resort is now a **stdlib-only** IPMI 2.0 SOL client in `internal/common/redfish/internal/ipmi` (`DialSOL` only — no chassis/power/SEL).

- Cipher suite **3**, then **17** if Open Session rejects 3
- UDP timeout on Get Channel Auth Caps does **not** try suite 17
- `WatchSession.Transport=ipmi_sol` remains an error (IPMI is not a transport)
- Golden Rule 6 / runbook / §7.1 flipped to present tense
- `go.mod` unchanged; no `go-ipmi` / `ipmitool`

## Tests

- `TestRAKPVectors_Suite3_SpecConcat` / `_Suite17_SpecConcat` frozen HMAC fixtures (no network)
- Fake UDP BMC: suite 3 echo, suite 3 reject → 17, injected 50ms timeout
- `OpenSOL` IPMI-only + fake → `Kind=ipmi`; timeout path stays `*SOLUnsupportedError` with `udp 623` in the debug trail
- `gofmt` / `go vet` / `staticcheck` / `go test ./...`

No packets to `172.16.21.202` (UDP/623 is filtered from this workstation anyway).

## Out of scope

- HPE `vsp`/`textcons`, ATEN SMASH-CLP
- Cipher suites other than 3 and 17
- ISO reachability for a full provision on the R750